### PR TITLE
Remove unnessesary top level curly braces in the world builder file.

### DIFF
--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -17,6 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <fstream>
+#include <sstream>
 #include <vector>
 #include <tuple>
 
@@ -46,7 +47,13 @@ namespace WorldBuilder
     // Now read in the world builder file into a file stream and
     // put it into a boost property tree.
     std::ifstream json_input_stream(filename.c_str());
-    boost::property_tree::json_parser::read_json (json_input_stream, tree);
+    std::stringstream json_fixed_input_stream;
+
+    WBAssert(json_input_stream, "Could not read the world builder file.");
+    json_fixed_input_stream << "{" <<  json_input_stream.rdbuf() << "}";
+    json_input_stream.close();
+
+    boost::property_tree::json_parser::read_json (json_fixed_input_stream, tree);
     local_tree = &tree;
   }
 

--- a/tests/app/app_spherical.wb
+++ b/tests/app/app_spherical.wb
@@ -1,12 +1,11 @@
+"Cross section": [[100e3,100e3],[400e3,500e3]],
+"Coordinate system":{"spherical":{"depth method":"starting point"}},
+"Surface rotation point": ["0","0"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Cross section": [[100e3,100e3],[400e3,500e3]],
-    "Coordinate system":{"spherical":{"depth method":"starting point"}},
-    "Surface rotation point": ["0","0"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Continental plate":{"name":"Carribean","coordinates":[[-125,50],[-60,50],[-60,25],[-125,25]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":10},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":1}},
@@ -30,5 +29,4 @@
      "Continental plate":{"name":"Equator","coordinates":[[-90,-7.5],[-90,7.5],[360,7.5],[360,-7.5]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":60},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":6}}
-    }
 }

--- a/tests/app/app_wb1.wb
+++ b/tests/app/app_wb1.wb
@@ -1,12 +1,11 @@
+"Cross section": [[100e3,100e3],[400e3,500e3]],
+"Coordinate system":{"Cartesian":{}},
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Cross section": [[100e3,100e3],[400e3,500e3]],
-    "Coordinate system":{"Cartesian":{}},
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
@@ -18,6 +17,4 @@
      "Continental plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
-     
-    }
 }

--- a/tests/app/app_wb2.wb
+++ b/tests/app/app_wb2.wb
@@ -1,10 +1,9 @@
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
@@ -16,6 +15,4 @@
      "Continental Plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
-     
-    }
 }

--- a/tests/app/app_wb3.wb
+++ b/tests/app/app_wb3.wb
@@ -1,10 +1,9 @@
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
@@ -16,6 +15,4 @@
      "Continental Plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
-     
-    }
 }

--- a/tests/data/continental_plate.wb
+++ b/tests/data/continental_plate.wb
@@ -1,35 +1,33 @@
+"Cross section": [[100e3,100e3],[400e3,500e3]],
+"Coordinate system":{"cartesian":{}},
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Cross section": [[100e3,100e3],[400e3,500e3]],
-    "Coordinate system":{"cartesian":{}},
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
-     "Continental plate":{"name":"First continental plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
-         "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
-         "composition submodule":{"name":"none"}},
+  "Continental plate":{"name":"First continental plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+    "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
+    "composition submodule":{"name":"none"}},
      
-     "Continental Plate":{"name":"Second continental plate", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
-         "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
-         "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
+  "Continental Plate":{"name":"Second continental plate", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+    "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
+    "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Continental plate":{"name":"Third continental plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
-         "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
-         "composition submodule":{"name":"constant", "depth":250e3, "composition":3}},
+  "Continental plate":{"name":"Third continental plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+    "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
+    "composition submodule":{"name":"constant", "depth":250e3, "composition":3}},
 
-     "Continental plate":{"name":"Fourth continental plate","coordinates":[[-1e3,1500e3],[500e3,1500e3],[500e3,2000e3],[-1e3,2000e3]],
-         "temperature submodule":{"name":"linear", "depth":250e3},
-         "composition submodule":{"name":"constant", "depth":250e3, "composition":4}},
+  "Continental plate":{"name":"Fourth continental plate","coordinates":[[-1e3,1500e3],[500e3,1500e3],[500e3,2000e3],[-1e3,2000e3]],
+    "temperature submodule":{"name":"linear", "depth":250e3},
+    "composition submodule":{"name":"constant", "depth":250e3, "composition":4}},
 
-     "Continental plate":{"name":"Fifth continental plate","coordinates":[[500e3,-1e3],[500e3,500e3],[1000e3,500e3],[1000e3,-1e3]],
-         "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
-         "composition submodule":{"name":"constant", "depth":250e3, "composition":5}},
+   "Continental plate":{"name":"Fifth continental plate","coordinates":[[500e3,-1e3],[500e3,500e3],[1000e3,500e3],[1000e3,-1e3]],
+    "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
+    "composition submodule":{"name":"constant", "depth":250e3, "composition":5}},
 
-     "Continental plate":{"name":"Sixth continental plate","coordinates":[[1250e3,-1e3],[1250e3,500e3],[1750e3,500e3],[1750e3,-1e3]],
-         "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
-         "composition submodule":{"name":"constant layers", "depth":250e3, "layers":[{"composition":6, "thickness":75e3},{"composition":7, "thickness":75e3},{"composition":8, "thickness":75e3}]}}
+   "Continental plate":{"name":"Sixth continental plate","coordinates":[[1250e3,-1e3],[1250e3,500e3],[1750e3,500e3],[1750e3,-1e3]],
+     "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
+     "composition submodule":{"name":"constant layers", "depth":250e3, "layers":[{"composition":6, "thickness":75e3},{"composition":7, "thickness":75e3},{"composition":8, "thickness":75e3}]}}
      
     }
-}

--- a/tests/data/oceanic_plate_cartesian.wb
+++ b/tests/data/oceanic_plate_cartesian.wb
@@ -1,39 +1,36 @@
+"Cross section": [[100e3,100e3],[400e3,500e3]],
+"Coordinate system":{"cartesian":{}},
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Cross section": [[100e3,100e3],[400e3,500e3]],
-    "Coordinate system":{"cartesian":{}},
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
-     "Oceanic plate":{"name":"First oceanic plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
-         "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
-         "composition submodule":{"name":"none"}},
+  "Oceanic plate":{"name":"First oceanic plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
+     "composition submodule":{"name":"none"}},
      
-     "Oceanic Plate":{"name":"Second oceanic plate", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
-         "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
-         "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
+  "Oceanic Plate":{"name":"Second oceanic plate", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+     "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
+     "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Oceanic plate":{"name":"Third oceanic plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
-         "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
-         "composition submodule":{"name":"constant", "depth":250e3, "composition":3}},
+  "Oceanic plate":{"name":"Third oceanic plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
+     "composition submodule":{"name":"constant", "depth":250e3, "composition":3}},
 
-     "Oceanic plate":{"name":"Fourth oceanic plate","coordinates":[[-1e3,1500e3],[500e3,1500e3],[500e3,2000e3],[-1e3,2000e3]],
-         "temperature submodule":{"name":"linear", "depth":250e3},
-         "composition submodule":{"name":"constant", "depth":250e3, "composition":4}},
+  "Oceanic plate":{"name":"Fourth oceanic plate","coordinates":[[-1e3,1500e3],[500e3,1500e3],[500e3,2000e3],[-1e3,2000e3]],
+     "temperature submodule":{"name":"linear", "depth":250e3},
+     "composition submodule":{"name":"constant", "depth":250e3, "composition":4}},
 
-     "Oceanic plate":{"name":"Fifth oceanic plate","coordinates":[[500e3,-1e3],[500e3,500e3],[1000e3,500e3],[1000e3,-1e3]],
-         "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
-         "composition submodule":{"name":"constant", "depth":250e3, "composition":5}},
+  "Oceanic plate":{"name":"Fifth oceanic plate","coordinates":[[500e3,-1e3],[500e3,500e3],[1000e3,500e3],[1000e3,-1e3]],
+     "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
+     "composition submodule":{"name":"constant", "depth":250e3, "composition":5}},
      
-     "Oceanic plate":{"name":"Sixth oceanic plate","coordinates":[[1100e3,-1e3],[1100e3,750e3],[2500e3,750e3],[2500e3,-1e3]],
-         "temperature submodule":{"name":"plate model", "depth":250e3, "spreading velocity":0.01, "ridge points":[[1500e3,-1e3],[1500e3,750e3]]},
-         "composition submodule":{"name":"none"}},
+  "Oceanic plate":{"name":"Sixth oceanic plate","coordinates":[[1100e3,-1e3],[1100e3,750e3],[2500e3,750e3],[2500e3,-1e3]],
+     "temperature submodule":{"name":"plate model", "depth":250e3, "spreading velocity":0.01, "ridge points":[[1500e3,-1e3],[1500e3,750e3]]},
+     "composition submodule":{"name":"none"}},
      
-     "Oceanic plate":{"name":"Seventh oceanic plate","coordinates":[[50e3,-1e3],[400e3,-1e3],[400e3,400e3],[50e3,400e3]],
-         "temperature submodule":{"name":"plate model", "depth":250e3, "spreading velocity":0.01, "ridge points":[[1500e3,-1e3],[1500e3,750e3]]},
-         "composition submodule":{"name":"constant layers", "depth":250e3, "layers":[{"composition":6, "thickness":75e3},{"composition":7, "thickness":75e3},{"composition":8, "thickness":75e3}]}}
-     
+  "Oceanic plate":{"name":"Seventh oceanic plate","coordinates":[[50e3,-1e3],[400e3,-1e3],[400e3,400e3],[50e3,400e3]],
+     "temperature submodule":{"name":"plate model", "depth":250e3, "spreading velocity":0.01, "ridge points":[[1500e3,-1e3],[1500e3,750e3]]},
+     "composition submodule":{"name":"constant layers", "depth":250e3, "layers":[{"composition":6, "thickness":75e3},{"composition":7, "thickness":75e3},{"composition":8, "thickness":75e3}]}}     
     }
-}

--- a/tests/data/oceanic_plate_spherical.wb
+++ b/tests/data/oceanic_plate_spherical.wb
@@ -1,12 +1,11 @@
+"Cross section": [[100e3,100e3],[400e3,500e3]],
+"Coordinate system":{"spherical":{"depth method":"starting point"}},
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Cross section": [[100e3,100e3],[400e3,500e3]],
-    "Coordinate system":{"spherical":{"depth method":"starting point"}},
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Oceanic plate":{"name":"First oceanic plate","coordinates":[[-10,-10],[-1,-10],[-1,-1],[-10,-1]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
@@ -31,5 +30,4 @@
          "temperature submodule":{"name":"plate model", "depth":250e3, "spreading velocity":0.01, "ridge points":[[15,-20],[15,-15],[10,-10]]},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":6}}
      
-    }
 }

--- a/tests/data/simple_wb1.json
+++ b/tests/data/simple_wb1.json
@@ -1,12 +1,11 @@
+"Cross section": [[100e3,100e3],[400e3,500e3]],
+"Coordinate system":{"cartesian":{}},
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Cross section": [[100e3,100e3],[400e3,500e3]],
-    "Coordinate system":{"cartesian":{}},
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
@@ -19,5 +18,4 @@
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
      
-    }
 }

--- a/tests/data/simple_wb2.json
+++ b/tests/data/simple_wb2.json
@@ -1,10 +1,9 @@
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
@@ -17,5 +16,4 @@
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
      
-    }
 }

--- a/tests/data/simple_wb3.json
+++ b/tests/data/simple_wb3.json
@@ -1,10 +1,9 @@
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
@@ -17,5 +16,4 @@
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
      
-    }
 }

--- a/tests/data/subducting_plate_constant_angles_cartesian.wb
+++ b/tests/data/subducting_plate_constant_angles_cartesian.wb
@@ -1,12 +1,11 @@
+"Cross section": [[100e3,100e3],[400e3,500e3]],
+"Coordinate system":{"cartesian":{}},
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Cross section": [[100e3,100e3],[400e3,500e3]],
-    "Coordinate system":{"cartesian":{}},
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Subducting plate":{"name":"First subducting plate", "coordinates":[[0e3,500e3],[500e3,500e3],[1000e3,750e3]], "reference point":[1200e3,1200e3],
          "starting depth":0, "max depth":1e10,
          "segments":
@@ -27,5 +26,4 @@
          },
          "temperature submodule":{"name":"plate model", "density":3300, "plate velocity":0.01 },
          "composition submodule":{"name":"constant layers", "layers":[{"composition":0, "thickness":33e3},{"composition":1, "thickness":33e3},{"composition":2, "thickness":33e3}]}}
-    }
 }

--- a/tests/data/subducting_plate_different_angles_cartesian.wb
+++ b/tests/data/subducting_plate_different_angles_cartesian.wb
@@ -1,12 +1,11 @@
+"Cross section": [[100e3,100e3],[400e3,500e3]],
+"Coordinate system":{"cartesian":{}},
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Cross section": [[100e3,100e3],[400e3,500e3]],
-    "Coordinate system":{"cartesian":{}},
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Subducting plate":{"name":"First subducting plate", "coordinates":[[0e3,500e3],[500e3,500e3],[1000e3,750e3]], "reference point":[1200e3,1200e3],
          "starting depth":0, "max depth":1e10,
          "segments":
@@ -17,5 +16,4 @@
          },
          "temperature submodule":{"name":"plate model", "density":3300, "plate velocity":0.01 },
          "composition submodule":{"name":"none"}}
-    }
 }

--- a/tests/data/subducting_plate_different_angles_spherical.wb
+++ b/tests/data/subducting_plate_different_angles_spherical.wb
@@ -1,12 +1,11 @@
+"Cross section": [[100e3,100e3],[400e3,500e3]],
+"Coordinate system":{"spherical":{"depth method":"starting point"}},
+"Surface rotation point": ["165e3","166e3"],
+"Surface rotation angle": "0",
+"Minimum parts per distance unit": 5,
+"Minimum distance points": 1e-5,
+"Surface objects":
 {
-    "Cross section": [[100e3,100e3],[400e3,500e3]],
-    "Coordinate system":{"spherical":{"depth method":"starting point"}},
-    "Surface rotation point": ["165e3","166e3"],
-    "Surface rotation angle": "0",
-    "Minimum parts per distance unit": 5,
-    "Minimum distance points": 1e-5,
-    "Surface objects":
-    {
      "Subducting plate":{"name":"First subducting plate", "coordinates":[[-11,0],[0,0],[11,6]], "reference point":[-30,-30],
          "starting depth":0, "max depth":1e10,
          "segments":
@@ -17,5 +16,4 @@
          },
          "temperature submodule":{"name":"plate model", "density":3300, "plate velocity":0.01 },
          "composition submodule":{"name":"constant", "composition":1, "depth":50e3}}
-    }
 }

--- a/tests/data/type_data.json
+++ b/tests/data/type_data.json
@@ -1,32 +1,30 @@
+"unsigned int":4,
+"double":"1.23456e2",
+"string":"mystring 0",
+"2d point": ["10", "11"],
+"3d point": ["12", "13", "14"],
+"double array" :[25,26,27],
+"point<2> array": [[10,11], [12,13], [14,15]],
+"point<3> array": [[20,21,22], [23,24,25], [26,27,28]],
+"subsection 1":
 {
-    "unsigned int":4,
-    "double":"1.23456e2",
-    "string":"mystring 0",
-    "2d point": ["10", "11"],
-    "3d point": ["12", "13", "14"],
-    "double array" :[25,26,27],
-    "point<2> array": [[10,11], [12,13], [14,15]],
-    "point<3> array": [[20,21,22], [23,24,25], [26,27,28]],
-    "subsection 1":
+    "unsigned int":5,
+    "double":"2.23456e2",
+    "string":"mystring 1",
+    "2d point": ["15", "16"],
+    "3d point": ["17", "18", "19"],
+    "double array":[35,36,37],
+    "point<2> array": [[20,21], [22,23], [24,25]],
+    "point<3> array": [[30,31,32], [33,34,35], [36,37,38]],
+    "subsection 2": 
     {
-        "unsigned int":5,
-        "double":"2.23456e2",
-        "string":"mystring 1",
-        "2d point": ["15", "16"],
-        "3d point": ["17", "18", "19"],
-        "double array":[35,36,37],
-        "point<2> array": [[20,21], [22,23], [24,25]],
-        "point<3> array": [[30,31,32], [33,34,35], [36,37,38]],
-	"subsection 2": 
-	{
-	    "unsigned int":6,
-            "double":"3.23456e2",
-            "string":"mystring 2",
-            "2d point": ["20", "21"],
-            "3d point": ["22", "23", "24"],
-            "double array":[45,46,47],
-            "point<2> array": [[40,41], [42,43], [44,45]],
-            "point<3> array": [[40,41,42], [43,44,45], [46,47,48]]
-	}
-    }
+        "unsigned int":6,
+        "double":"3.23456e2",
+        "string":"mystring 2",
+        "2d point": ["20", "21"],
+        "3d point": ["22", "23", "24"],
+        "double array":[45,46,47],
+        "point<2> array": [[40,41], [42,43], [44,45]],
+        "point<3> array": [[40,41,42], [43,44,45], [46,47,48]]
+     }
 }

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -1564,7 +1564,12 @@ TEST_CASE("WorldBuilder Types: print_tree")
   std::string file_name = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/simple_wb1.json";
   boost::property_tree::ptree tree;
   std::ifstream json_input_stream(file_name.c_str());
-  boost::property_tree::json_parser::read_json (json_input_stream, tree);
+
+  std::stringstream json_fixed_input_stream;
+  json_fixed_input_stream << "{" <<  json_input_stream.rdbuf() << "}";
+  json_input_stream.close();
+
+  boost::property_tree::json_parser::read_json (json_fixed_input_stream, tree);
   std::stringstream output;
   output <<
          "{\n" <<


### PR DESCRIPTION
I noticed that there is no reason to have the top level curly braces in the world builder input file. They make the file less readable. Although they are required by the boost json reader, we can place them manually just before the file is passed to the json reader. 

This change invalidates all current world builder files, and requires them to be changed. Since there hasn't been a release yet, that is fine.