### PR TITLE
update naming convetions to lower case.

### DIFF
--- a/source/features/continental_plate.cc
+++ b/source/features/continental_plate.cc
@@ -57,7 +57,7 @@ namespace WorldBuilder
       prm.load_entry("name", true, Types::String("","The name which the user has given to the feature."));
       name = prm.get_string("name");
       bool set = prm.load_entry("coordinates", true, Types::Array(
-                                  Types::Point<2>(Point<2>(0,0, coordinate_system),"desciption point cross section"),
+                                  Types::Point<2>(Point<2>(0,0, coordinate_system),"Description point cross section"),
                                   "An array of Points representing an array of coordinates where the feature is located."));
 
       WBAssertThrow(set == true, "A list of coordinates is required for every feature.");
@@ -178,7 +178,7 @@ namespace WorldBuilder
               if (std::isnan(temperature_submodule_linear_bottom_temperature))
                 {
                   bottom_temperature =  this->world->parameters.get_double("potential mantle temperature") +
-                                        (((this->world->parameters.get_double("potential mantle temperature") * this->world->parameters.get_double("Thermal expansion coefficient alpha") * gravity_norm) /
+                                        (((this->world->parameters.get_double("potential mantle temperature") * this->world->parameters.get_double("thermal expansion coefficient alpha") * gravity_norm) /
                                           this->world->parameters.get_double("specific heat Cp")) * 1000.0) * ((depth) / 1000.0);
                 }
 

--- a/source/features/oceanic_plate.cc
+++ b/source/features/oceanic_plate.cc
@@ -210,7 +210,7 @@ namespace WorldBuilder
               if (std::isnan(temperature_submodule_linear_bottom_temperature))
                 {
                   bottom_temperature =  this->world->parameters.get_double("potential mantle temperature") +
-                                        (((this->world->parameters.get_double("potential mantle temperature") * this->world->parameters.get_double("Thermal expansion coefficient alpha") * gravity_norm) /
+                                        (((this->world->parameters.get_double("potential mantle temperature") * this->world->parameters.get_double("thermal expansion coefficient alpha") * gravity_norm) /
                                           this->world->parameters.get_double("specific heat Cp")) * 1000.0) * ((depth) / 1000.0);
                 }
 
@@ -231,7 +231,7 @@ namespace WorldBuilder
               if (std::isnan(bottom_temperature))
                 {
                   bottom_temperature =  this->world->parameters.get_double("potential mantle temperature") +
-                                        (((this->world->parameters.get_double("potential mantle temperature") * this->world->parameters.get_double("Thermal expansion coefficient alpha") * gravity_norm) /
+                                        (((this->world->parameters.get_double("potential mantle temperature") * this->world->parameters.get_double("thermal expansion coefficient alpha") * gravity_norm) /
                                           this->world->parameters.get_double("specific heat Cp")) * 1000.0) * ((max_depth) / 1000.0);
                 }
 

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -174,8 +174,8 @@ namespace WorldBuilder
             prm.load_entry("thermal conductivity", false, Types::Double(2.0,"The thermal conductivity of the subducting plate material in ... units."));
             temperature_submodule_plate_model_thermal_conductivity = prm.get_double("thermal conductivity");
 
-            prm.load_entry("Thermal expansion coefficient", false, Types::Double(3.5e-5,"The thermal expansivity of the subducting plate material in ... units"));
-            temperature_submodule_plate_model_Thermal_expansion_coefficient = prm.get_double("Thermal expansion coefficient");
+            prm.load_entry("thermal expansion coefficient", false, Types::Double(3.5e-5,"The thermal expansivity of the subducting plate material in ... units"));
+            temperature_submodule_plate_model_Thermal_expansion_coefficient = prm.get_double("thermal expansion coefficient");
 
             prm.load_entry("specific heat", false, Types::Double(1250,"The specific heat of the subducting plate material in ... units"));
             temperature_submodule_plate_model_specific_heat = prm.get_double("specific heat");

--- a/source/world.cc
+++ b/source/world.cc
@@ -52,7 +52,7 @@ namespace WorldBuilder
     /**
      * First load the coordinate system parameters.
      */
-    prm.load_entry("Coordinate system", false, Types::CoordinateSystem("cartesian","This determines the coordinate system"));
+    prm.load_entry("coordinate system", false, Types::CoordinateSystem("cartesian","This determines the coordinate system"));
 
     const CoordinateSystem coordinate_system = prm.coordinate_system->natural_coordinate_system();
 
@@ -63,7 +63,7 @@ namespace WorldBuilder
                    Types::Double(1600,"The potential temperature of the mantle at the surface in Kelvin"));
     prm.load_entry("surface temperature", false,
                    Types::Double(293,"The temperature at the surface in Kelvin"));
-    prm.load_entry("Thermal expansion coefficient alpha", false,
+    prm.load_entry("thermal expansion coefficient alpha", false,
                    Types::Double(3.5e-5,"The thermal expansion coefficient alpha. TODO: expand add units"));
     prm.load_entry("specific heat Cp", false, Types::Double(1250,"The specific heat Cp.  TODO: expand and add units"));
     prm.load_entry("thermal diffusivity", false, Types::Double(0.804e-6,"Set the thermal diffusivity. TODO: expand and add units "));
@@ -71,14 +71,14 @@ namespace WorldBuilder
     /**
      * Model rotation parameters.
      */
-    prm.load_entry("Surface rotation angle", false,
-                   Types::Double(0,"The angle with which the model should be rotated around the Surface rotation point."));
-    prm.load_entry("Surface rotation point", false,
+    prm.load_entry("surface rotation angle", false,
+                   Types::Double(0,"The angle with which the model should be rotated around the surface rotation point."));
+    prm.load_entry("surface rotation point", false,
                    Types::Point<2>(Point<2>(0,0, coordinate_system), "The point where should be rotated around."));
 
 
 
-    bool set = prm.load_entry("Cross section", false,
+    bool set = prm.load_entry("cross section", false,
                               Types::Array(
                                 Types::Point<2>(Point<2>(0,0, coordinate_system),"A point in the cross section."),
                                 "This is an array of two points along where the cross section is taken"));
@@ -86,7 +86,7 @@ namespace WorldBuilder
     if (set)
       {
         dim = 2;
-        std::vector<const Types::Point<2>* > cross_section = prm.get_array<const Types::Point<2> >("Cross section");
+        std::vector<const Types::Point<2>* > cross_section = prm.get_array<const Types::Point<2> >("cross section");
 
         WBAssertThrow(cross_section.size() == 2, "The cross section should contain two points, but it contains "
                       << cross_section.size() << " points.");
@@ -96,7 +96,7 @@ namespace WorldBuilder
          */
         Point<2> surface_coord_conversions = (*cross_section[0]-*cross_section[1]) * (coordinate_system == spherical ? M_PI / 180.0 : 1.0);
         surface_coord_conversions *= -1/(surface_coord_conversions.norm());
-        prm.set_entry("Surface coordinate conversions",
+        prm.set_entry("surface coordinate conversions",
                       Types::Point<2>(surface_coord_conversions, surface_coord_conversions, "An internal value which is precomputed."));
       }
     else
@@ -104,7 +104,7 @@ namespace WorldBuilder
         dim = 3;
       }
 
-    prm.load_entry("Surface objects", true, Types::List(
+    prm.load_entry("surface objects", true, Types::List(
                      Types::Feature("These are the features"), "A list of features."));
 
   }
@@ -120,7 +120,7 @@ namespace WorldBuilder
                   << dim << ".");
 
     // Todo: merge this into one line
-    const Types::Array &cross_section_natural = parameters.get_array("Cross section");
+    const Types::Array &cross_section_natural = parameters.get_array("cross section");
 
     WBAssert(cross_section_natural.inner_type_index.size() == 2,
              "Internal error: Cross section natural should contain two points, but it contains "
@@ -134,7 +134,7 @@ namespace WorldBuilder
              "Internal error: Cross section should contain two points, but it contains "
              << cross_section.size() <<  " points.");
 
-    const WorldBuilder::Point<2> &surface_coord_conversions = this->parameters.get_point<2>("Surface coordinate conversions");
+    const WorldBuilder::Point<2> &surface_coord_conversions = this->parameters.get_point<2>("surface coordinate conversions");
 
     Point<3> coord_3d(cross_section[0][0] + point[0] * surface_coord_conversions[0],
                       cross_section[0][1] + point[0] * surface_coord_conversions[1],
@@ -153,7 +153,7 @@ namespace WorldBuilder
     Point<3> point(point_,cartesian);
 
     double temperature = this->parameters.get_double("potential mantle temperature") +
-                         (((this->parameters.get_double("potential mantle temperature") * this->parameters.get_double("Thermal expansion coefficient alpha") * gravity_norm) /
+                         (((this->parameters.get_double("potential mantle temperature") * this->parameters.get_double("thermal expansion coefficient alpha") * gravity_norm) /
                            this->parameters.get_double("specific heat Cp")) * 1000.0) * ((depth) / 1000.0);
 
 
@@ -176,7 +176,7 @@ namespace WorldBuilder
                   << dim << ".");
 
     // Todo: merge this into one line
-    const Types::Array &cross_section_natural = this->parameters.get_array("Cross section");
+    const Types::Array &cross_section_natural = this->parameters.get_array("cross section");
     std::vector<Types::Point<2> > cross_section;
     for (unsigned int i = 0; i < cross_section_natural.inner_type_index.size(); ++i)
       cross_section.push_back(this->parameters.vector_point_2d[cross_section_natural.inner_type_index[i]]);
@@ -184,7 +184,7 @@ namespace WorldBuilder
     WBAssert(cross_section.size() == 2, "Internal error: Cross section should contain two points, but it contains "
              << cross_section.size() <<  " points.");
 
-    const WorldBuilder::Point<2> &surface_coord_conversions = this->parameters.get_point<2>("Surface coordinate conversions");
+    const WorldBuilder::Point<2> &surface_coord_conversions = this->parameters.get_point<2>("surface coordinate conversions");
 
     Point<3> coord_3d(cross_section[0][0] + point[0] * surface_coord_conversions[0],
                       cross_section[0][1] + point[0] * surface_coord_conversions[1],

--- a/tests/app/app_spherical.wb
+++ b/tests/app/app_spherical.wb
@@ -1,32 +1,32 @@
-"Cross section": [[100e3,100e3],[400e3,500e3]],
-"Coordinate system":{"spherical":{"depth method":"starting point"}},
-"Surface rotation point": ["0","0"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"cross section": [[100e3,100e3],[400e3,500e3]],
+"coordinate system":{"spherical":{"depth method":"starting point"}},
+"surface rotation point": ["0","0"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Continental plate":{"name":"Carribean","coordinates":[[-125,50],[-60,50],[-60,25],[-125,25]],
+     "continental plate":{"name":"Carribean","coordinates":[[-125,50],[-60,50],[-60,25],[-125,25]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":10},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":1}},
 
-     "Continental Plate":{"name":"Rest", "coordinates":[[-10,60],[125,60],[125,10],[-10,10]],
+     "continental Plate":{"name":"Rest", "coordinates":[[-10,60],[125,60],[125,10],[-10,10]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Continental plate":{"name":"Carribean2","coordinates":[[10,-10],[10,-40],[125,-40],[125,-10]],
+     "continental plate":{"name":"Carribean2","coordinates":[[10,-10],[10,-40],[125,-40],[125,-10]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":30},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}},
 
-     "Continental plate":{"name":"Carribean3","coordinates":[[-10,-10],[-10,-40],[-125,-40],[-125,-10]],
+     "continental plate":{"name":"Carribean3","coordinates":[[-10,-10],[-10,-40],[-125,-40],[-125,-10]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":40},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":4}},
 
-     "Continental plate":{"name":"South Pole","coordinates":[[-90,-90],[-90,-70],[360,-70],[360,-90]],
+     "continental plate":{"name":"South Pole","coordinates":[[-90,-90],[-90,-70],[360,-70],[360,-90]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":50},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":5}},
 
-     "Continental plate":{"name":"Equator","coordinates":[[-90,-7.5],[-90,7.5],[360,7.5],[360,-7.5]],
+     "continental plate":{"name":"Equator","coordinates":[[-90,-7.5],[-90,7.5],[360,7.5],[360,-7.5]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":60},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":6}}
 }

--- a/tests/app/app_wb1.wb
+++ b/tests/app/app_wb1.wb
@@ -1,20 +1,20 @@
-"Cross section": [[100e3,100e3],[400e3,500e3]],
-"Coordinate system":{"Cartesian":{}},
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"cross section": [[100e3,100e3],[400e3,500e3]],
+"coordinate system":{"Cartesian":{}},
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
      
-     "Continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+     "continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Continental plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
 }

--- a/tests/app/app_wb2.wb
+++ b/tests/app/app_wb2.wb
@@ -1,18 +1,18 @@
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
      
-     "Continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+     "continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Continental Plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental Plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
 }

--- a/tests/app/app_wb3.wb
+++ b/tests/app/app_wb3.wb
@@ -1,18 +1,18 @@
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"sinimum parts per distance unit": 5,
+"sinimum distance points": 1e-5,
+"surface objects":
 {
-     "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
      
-     "Continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+     "continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Continental Plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental Plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
 }

--- a/tests/data/continental_plate.wb
+++ b/tests/data/continental_plate.wb
@@ -1,32 +1,32 @@
-"Cross section": [[100e3,100e3],[400e3,500e3]],
-"Coordinate system":{"cartesian":{}},
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"cross section": [[100e3,100e3],[400e3,500e3]],
+"coordinate system":{"cartesian":{}},
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-  "Continental plate":{"name":"First continental plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+  "continental plate":{"name":"First continental plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
     "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
     "composition submodule":{"name":"none"}},
      
-  "Continental Plate":{"name":"Second continental plate", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+  "continental Plate":{"name":"Second continental plate", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
     "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
     "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-  "Continental plate":{"name":"Third continental plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+  "continental plate":{"name":"Third continental plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
     "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
     "composition submodule":{"name":"constant", "depth":250e3, "composition":3}},
 
-  "Continental plate":{"name":"Fourth continental plate","coordinates":[[-1e3,1500e3],[500e3,1500e3],[500e3,2000e3],[-1e3,2000e3]],
+  "continental plate":{"name":"Fourth continental plate","coordinates":[[-1e3,1500e3],[500e3,1500e3],[500e3,2000e3],[-1e3,2000e3]],
     "temperature submodule":{"name":"linear", "depth":250e3},
     "composition submodule":{"name":"constant", "depth":250e3, "composition":4}},
 
-   "Continental plate":{"name":"Fifth continental plate","coordinates":[[500e3,-1e3],[500e3,500e3],[1000e3,500e3],[1000e3,-1e3]],
+   "continental plate":{"name":"Fifth continental plate","coordinates":[[500e3,-1e3],[500e3,500e3],[1000e3,500e3],[1000e3,-1e3]],
     "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
     "composition submodule":{"name":"constant", "depth":250e3, "composition":5}},
 
-   "Continental plate":{"name":"Sixth continental plate","coordinates":[[1250e3,-1e3],[1250e3,500e3],[1750e3,500e3],[1750e3,-1e3]],
+   "continental plate":{"name":"Sixth continental plate","coordinates":[[1250e3,-1e3],[1250e3,500e3],[1750e3,500e3],[1750e3,-1e3]],
      "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
      "composition submodule":{"name":"constant layers", "depth":250e3, "layers":[{"composition":6, "thickness":75e3},{"composition":7, "thickness":75e3},{"composition":8, "thickness":75e3}]}}
      

--- a/tests/data/oceanic_plate_cartesian.wb
+++ b/tests/data/oceanic_plate_cartesian.wb
@@ -1,36 +1,36 @@
-"Cross section": [[100e3,100e3],[400e3,500e3]],
-"Coordinate system":{"cartesian":{}},
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"cross section": [[100e3,100e3],[400e3,500e3]],
+"coordinate system":{"cartesian":{}},
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-  "Oceanic plate":{"name":"First oceanic plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+  "oceanic plate":{"name":"First oceanic plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
      "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
      "composition submodule":{"name":"none"}},
      
-  "Oceanic Plate":{"name":"Second oceanic plate", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+  "oceanic Plate":{"name":"Second oceanic plate", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
      "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
      "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-  "Oceanic plate":{"name":"Third oceanic plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+  "oceanic plate":{"name":"Third oceanic plate","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
      "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
      "composition submodule":{"name":"constant", "depth":250e3, "composition":3}},
 
-  "Oceanic plate":{"name":"Fourth oceanic plate","coordinates":[[-1e3,1500e3],[500e3,1500e3],[500e3,2000e3],[-1e3,2000e3]],
+  "oceanic plate":{"name":"Fourth oceanic plate","coordinates":[[-1e3,1500e3],[500e3,1500e3],[500e3,2000e3],[-1e3,2000e3]],
      "temperature submodule":{"name":"linear", "depth":250e3},
      "composition submodule":{"name":"constant", "depth":250e3, "composition":4}},
 
-  "Oceanic plate":{"name":"Fifth oceanic plate","coordinates":[[500e3,-1e3],[500e3,500e3],[1000e3,500e3],[1000e3,-1e3]],
+  "oceanic plate":{"name":"Fifth oceanic plate","coordinates":[[500e3,-1e3],[500e3,500e3],[1000e3,500e3],[1000e3,-1e3]],
      "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
      "composition submodule":{"name":"constant", "depth":250e3, "composition":5}},
      
-  "Oceanic plate":{"name":"Sixth oceanic plate","coordinates":[[1100e3,-1e3],[1100e3,750e3],[2500e3,750e3],[2500e3,-1e3]],
+  "oceanic plate":{"name":"Sixth oceanic plate","coordinates":[[1100e3,-1e3],[1100e3,750e3],[2500e3,750e3],[2500e3,-1e3]],
      "temperature submodule":{"name":"plate model", "depth":250e3, "spreading velocity":0.01, "ridge points":[[1500e3,-1e3],[1500e3,750e3]]},
      "composition submodule":{"name":"none"}},
      
-  "Oceanic plate":{"name":"Seventh oceanic plate","coordinates":[[50e3,-1e3],[400e3,-1e3],[400e3,400e3],[50e3,400e3]],
+  "oceanic plate":{"name":"Seventh oceanic plate","coordinates":[[50e3,-1e3],[400e3,-1e3],[400e3,400e3],[50e3,400e3]],
      "temperature submodule":{"name":"plate model", "depth":250e3, "spreading velocity":0.01, "ridge points":[[1500e3,-1e3],[1500e3,750e3]]},
      "composition submodule":{"name":"constant layers", "depth":250e3, "layers":[{"composition":6, "thickness":75e3},{"composition":7, "thickness":75e3},{"composition":8, "thickness":75e3}]}}     
     }

--- a/tests/data/oceanic_plate_spherical.wb
+++ b/tests/data/oceanic_plate_spherical.wb
@@ -1,32 +1,32 @@
-"Cross section": [[100e3,100e3],[400e3,500e3]],
-"Coordinate system":{"spherical":{"depth method":"starting point"}},
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"cross section": [[100e3,100e3],[400e3,500e3]],
+"coordinate system":{"spherical":{"depth method":"starting point"}},
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Oceanic plate":{"name":"First oceanic plate","coordinates":[[-10,-10],[-1,-10],[-1,-1],[-10,-1]],
+     "oceanic plate":{"name":"First oceanic plate","coordinates":[[-10,-10],[-1,-10],[-1,-1],[-10,-1]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
      
-     "Oceanic Plate":{"name":"Second oceanic plate", "coordinates":[[10,-10],[1,-10],[1,-1],[10,-1]],
+     "oceanic Plate":{"name":"Second oceanic plate", "coordinates":[[10,-10],[1,-10],[1,-1],[10,-1]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Oceanic plate":{"name":"Third oceanic plate","coordinates":[[-10,10],[-1,10],[-1,1],[-10,1]],
+     "oceanic plate":{"name":"Third oceanic plate","coordinates":[[-10,10],[-1,10],[-1,1],[-10,1]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}},
 
-     "Oceanic plate":{"name":"Fourth oceanic plate","coordinates":[[10,10],[1,10],[1,1],[10,1]],
+     "oceanic plate":{"name":"Fourth oceanic plate","coordinates":[[10,10],[1,10],[1,1],[10,1]],
          "temperature submodule":{"name":"linear", "depth":250e3},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":4}},
 
-     "Oceanic plate":{"name":"Fifth oceanic plate","coordinates":[[-20,-20],[-11,-20],[-11,-11],[-20,-11]],
+     "oceanic plate":{"name":"Fifth oceanic plate","coordinates":[[-20,-20],[-11,-20],[-11,-11],[-20,-11]],
          "temperature submodule":{"name":"linear", "depth":250e3, "top temperature":10, "bottom temperature":50},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":5}},
      
-     "Oceanic plate":{"name":"First oceanic plate","coordinates":[[20,-20],[-10,-20],[-10,-11],[20,-11]],
+     "oceanic plate":{"name":"First oceanic plate","coordinates":[[20,-20],[-10,-20],[-10,-11],[20,-11]],
          "temperature submodule":{"name":"plate model", "depth":250e3, "spreading velocity":0.01, "ridge points":[[15,-20],[15,-15],[10,-10]]},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":6}}
      

--- a/tests/data/simple_wb1.json
+++ b/tests/data/simple_wb1.json
@@ -1,20 +1,20 @@
-"Cross section": [[100e3,100e3],[400e3,500e3]],
-"Coordinate system":{"cartesian":{}},
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"cross section": [[100e3,100e3],[400e3,500e3]],
+"coordinate system":{"cartesian":{}},
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
      
-     "Continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+     "continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Continental plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
      

--- a/tests/data/simple_wb2.json
+++ b/tests/data/simple_wb2.json
@@ -1,18 +1,18 @@
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
      
-     "Continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+     "continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Continental Plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental Plate":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
      

--- a/tests/data/simple_wb3.json
+++ b/tests/data/simple_wb3.json
@@ -1,18 +1,18 @@
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "continental plate":{"name":"Carribean","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"none"}},
      
-     "Continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
+     "continental Plate":{"name":"Rest", "coordinates":[[2000e3,2000e3],[1000e3,2000e3],[1000e3,1000e3],[2000e3,1000e3]],
          "temperature submodule":{"name":"constant", "depth":250e3, "temperature":20},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":2}},
 
-     "Nonexistend submodule":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+     "nonexistend submodule":{"name":"Carribean2","coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
          "temperature submodule":{"name":"none", "depth":250e3, "temperature":150},
          "composition submodule":{"name":"constant", "depth":250e3, "composition":3}}
      

--- a/tests/data/subducting_plate_constant_angles_cartesian.wb
+++ b/tests/data/subducting_plate_constant_angles_cartesian.wb
@@ -1,12 +1,12 @@
-"Cross section": [[100e3,100e3],[400e3,500e3]],
-"Coordinate system":{"cartesian":{}},
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"cross section": [[100e3,100e3],[400e3,500e3]],
+"coordinate system":{"cartesian":{}},
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Subducting plate":{"name":"First subducting plate", "coordinates":[[0e3,500e3],[500e3,500e3],[1000e3,750e3]], "reference point":[1200e3,1200e3],
+     "subducting plate":{"name":"First subducting plate", "coordinates":[[0e3,500e3],[500e3,500e3],[1000e3,750e3]], "reference point":[1200e3,1200e3],
          "starting depth":0, "max depth":1e10,
          "segments":
          {
@@ -16,7 +16,7 @@
          },
          "temperature submodule":{"name":"constant", "temperature":150},
          "composition submodule":{"name":"constant", "composition":3}},
-     "Subducting plate":{"name":"Second subducting plate", "coordinates":[[0e3,250e3],[500e3,250e3],[1000e3,500e3]], "reference point":[0,-1],
+     "subducting plate":{"name":"Second subducting plate", "coordinates":[[0e3,250e3],[500e3,250e3],[1000e3,500e3]], "reference point":[0,-1],
          "starting depth":0, "max depth":1e10,
          "segments":
          {

--- a/tests/data/subducting_plate_different_angles_cartesian.wb
+++ b/tests/data/subducting_plate_different_angles_cartesian.wb
@@ -1,12 +1,12 @@
-"Cross section": [[100e3,100e3],[400e3,500e3]],
-"Coordinate system":{"cartesian":{}},
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"cross section": [[100e3,100e3],[400e3,500e3]],
+"coordinate system":{"cartesian":{}},
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Subducting plate":{"name":"First subducting plate", "coordinates":[[0e3,500e3],[500e3,500e3],[1000e3,750e3]], "reference point":[1200e3,1200e3],
+     "subducting plate":{"name":"First subducting plate", "coordinates":[[0e3,500e3],[500e3,500e3],[1000e3,750e3]], "reference point":[1200e3,1200e3],
          "starting depth":0, "max depth":1e10,
          "segments":
          {

--- a/tests/data/subducting_plate_different_angles_spherical.wb
+++ b/tests/data/subducting_plate_different_angles_spherical.wb
@@ -1,12 +1,12 @@
-"Cross section": [[100e3,100e3],[400e3,500e3]],
-"Coordinate system":{"spherical":{"depth method":"starting point"}},
-"Surface rotation point": ["165e3","166e3"],
-"Surface rotation angle": "0",
-"Minimum parts per distance unit": 5,
-"Minimum distance points": 1e-5,
-"Surface objects":
+"cross section": [[100e3,100e3],[400e3,500e3]],
+"coordinate system":{"spherical":{"depth method":"starting point"}},
+"surface rotation point": ["165e3","166e3"],
+"surface rotation angle": "0",
+"minimum parts per distance unit": 5,
+"minimum distance points": 1e-5,
+"surface objects":
 {
-     "Subducting plate":{"name":"First subducting plate", "coordinates":[[-11,0],[0,0],[11,6]], "reference point":[-30,-30],
+     "subducting plate":{"name":"First subducting plate", "coordinates":[[-11,0],[0,0],[11,6]], "reference point":[-30,-30],
          "starting depth":0, "max depth":1e10,
          "segments":
          {

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -556,7 +556,7 @@ TEST_CASE("WorldBuilder Coordinate Systems: Spherical")
   WorldBuilder::World world(file_name);
   CoordinateSystems::Spherical *spherical = new CoordinateSystems::Spherical(&world);
 
-  world.parameters.enter_subsection("Coordinate system");
+  world.parameters.enter_subsection("coordinate system");
   {
     world.parameters.enter_subsection("spherical");
     {
@@ -1573,7 +1573,7 @@ TEST_CASE("WorldBuilder Types: print_tree")
   std::stringstream output;
   output <<
          "{\n" <<
-         "  \"Cross section\": \n" <<
+         "  \"cross section\": \n" <<
          "  {\n" <<
          "    \"\": \n" <<
          "    {\n" <<
@@ -1586,21 +1586,21 @@ TEST_CASE("WorldBuilder Types: print_tree")
          "      \"\": \"500e3\"\n" <<
          "     }\n" <<
          "   },\n" <<
-         "  \"Coordinate system\": \n" <<
+         "  \"coordinate system\": \n" <<
          "  {\n" <<
          "    \"cartesian\": \"\"\n" <<
          "   },\n" <<
-         "  \"Surface rotation point\": \n" <<
+         "  \"surface rotation point\": \n" <<
          "  {\n" <<
          "    \"\": \"165e3\",\n" <<
          "    \"\": \"166e3\"\n" <<
          "   },\n" <<
-         "  \"Surface rotation angle\": \"0\",\n" <<
-         "  \"Minimum parts per distance unit\": \"5\",\n" <<
-         "  \"Minimum distance points\": \"1e-5\",\n" <<
-         "  \"Surface objects\": \n" <<
+         "  \"surface rotation angle\": \"0\",\n" <<
+         "  \"minimum parts per distance unit\": \"5\",\n" <<
+         "  \"minimum distance points\": \"1e-5\",\n" <<
+         "  \"surface objects\": \n" <<
          "  {\n" <<
-         "    \"Continental plate\": \n" <<
+         "    \"continental plate\": \n" <<
          "    {\n" <<
          "      \"name\": \"Carribean\",\n" <<
          "      \"coordinates\": \n" <<
@@ -1637,7 +1637,7 @@ TEST_CASE("WorldBuilder Types: print_tree")
          "        \"name\": \"none\"\n" <<
          "       }\n" <<
          "     },\n" <<
-         "    \"Continental Plate\": \n" <<
+         "    \"continental Plate\": \n" <<
          "    {\n" <<
          "      \"name\": \"Rest\",\n" <<
          "      \"coordinates\": \n" <<
@@ -1676,7 +1676,7 @@ TEST_CASE("WorldBuilder Types: print_tree")
          "        \"composition\": \"2\"\n" <<
          "       }\n" <<
          "     },\n" <<
-         "    \"Continental plate\": \n" <<
+         "    \"continental plate\": \n" <<
          "    {\n" <<
          "      \"name\": \"Carribean2\",\n" <<
          "      \"coordinates\": \n" <<


### PR DESCRIPTION
While writing the manual, noticed some inconsitities in naming conversions for the world builder input file parameters. Now they are all lower case.