### PR TITLE
test whole library linker solution.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,12 @@ add_executable(WorldBuilderVisualization "${CMAKE_CURRENT_SOURCE_DIR}/visualizat
 
 # Make sure that the whole library is loaded, so the registration is done correctly.
 SET(GWB_LIBRARY_WHOLE -Wl,--whole-archive WorldBuilder -Wl,--no-whole-archive)
+SET(GWB_LIBRARY_WHOLE_APPLE -Wl,--all_load WorldBuilder -Wl,--noall_load)
 target_link_libraries (WorldBuilderApp ${GWB_LIBRARY_WHOLE}) 
 if(NOT APPLE)
   target_link_libraries (WorldBuilderVisualization ${GWB_LIBRARY_WHOLE}) 
 else()
-  target_link_libraries (WorldBuilderVisualization ${GWB_LIBRARY_WHOLE} omp) 
+  target_link_libraries (WorldBuilderVisualization ${GWB_LIBRARY_WHOLE_APPLE} omp) 
 endif()
 
 # binary:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,14 @@ set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 add_library(WorldBuilder ${SOURCES})
 add_executable(WorldBuilderApp "${CMAKE_CURRENT_SOURCE_DIR}/app/main.cc")
 add_executable(WorldBuilderVisualization "${CMAKE_CURRENT_SOURCE_DIR}/visualization/main.cc")
-target_link_libraries (WorldBuilderApp WorldBuilder) 
+
+# Make sure that the whole library is loaded, so the registration is done correctly.
+SET(GWB_LIBRARY_WHOLE -Wl,--whole-archive WorldBuilder -Wl,--no-whole-archive)
+target_link_libraries (WorldBuilderApp ${GWB_LIBRARY_WHOLE}) 
 if(NOT APPLE)
-  target_link_libraries (WorldBuilderVisualization WorldBuilder) 
+  target_link_libraries (WorldBuilderVisualization ${GWB_LIBRARY_WHOLE}) 
 else()
-  target_link_libraries (WorldBuilderVisualization WorldBuilder omp) 
+  target_link_libraries (WorldBuilderVisualization ${GWB_LIBRARY_WHOLE} omp) 
 endif()
 
 # binary:

--- a/include/world_builder/coordinate_systems/cartesian.h
+++ b/include/world_builder/coordinate_systems/cartesian.h
@@ -31,7 +31,7 @@ namespace WorldBuilder
     /**
      * Register header file
      */
-    WB_REGISTER_COORDINATE_SYSTEM_HEADER(Cartesian)
+    //WB_REGISTER_COORDINATE_SYSTEM_HEADER(Cartesian)
 
 
     /**

--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -157,7 +157,6 @@ namespace WorldBuilder
      * to ensure that the static variable is actually initialized.
      */
 #define WB_REGISTER_COORDINATE_SYSTEM(klass,name) \
-  int make_sure_compilation_unit_referenced##klass() { return 0; } \
   class klass##Factory : public ObjectFactory { \
     public: \
       klass##Factory() \
@@ -175,10 +174,10 @@ namespace WorldBuilder
      * register it. Because this is a library, we need some extra measures
      * to ensure that the static variable is actually initialized.
      */
-#define WB_REGISTER_COORDINATE_SYSTEM_HEADER(klass) \
+/*#define WB_REGISTER_COORDINATE_SYSTEM_HEADER(klass) \
   extern int make_sure_compilation_unit_referenced##klass(); \
   static int never_actually_used##klass = make_sure_compilation_unit_referenced##klass();
-
+*/
   }
 }
 

--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -174,10 +174,10 @@ namespace WorldBuilder
      * register it. Because this is a library, we need some extra measures
      * to ensure that the static variable is actually initialized.
      */
-/*#define WB_REGISTER_COORDINATE_SYSTEM_HEADER(klass) \
-  extern int make_sure_compilation_unit_referenced##klass(); \
-  static int never_actually_used##klass = make_sure_compilation_unit_referenced##klass();
-*/
+    /*#define WB_REGISTER_COORDINATE_SYSTEM_HEADER(klass) \
+      extern int make_sure_compilation_unit_referenced##klass(); \
+      static int never_actually_used##klass = make_sure_compilation_unit_referenced##klass();
+    */
   }
 }
 

--- a/include/world_builder/coordinate_systems/spherical.h
+++ b/include/world_builder/coordinate_systems/spherical.h
@@ -31,7 +31,7 @@ namespace WorldBuilder
     /**
      * Register header file
      */
-    WB_REGISTER_COORDINATE_SYSTEM_HEADER(Spherical)
+    //WB_REGISTER_COORDINATE_SYSTEM_HEADER(Spherical)
 
     /**
      * This implements a Spherical geometry model.The Cartesian geometry model

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,12 @@ foreach(test_source ${UNIT_TEST_SOURCES})
 
     # Make sure that the whole library is loaded, so the registration is done correctly.
     SET(GWB_LIBRARY_WHOLE -Wl,--whole-archive WorldBuilder -Wl,--no-whole-archive)
-    target_link_libraries(${test_name} ${Boost_LIBRARIES} ${GWB_LIBRARY_WHOLE})
+    SET(GWB_LIBRARY_WHOLE_APPLE -Wl,--all_load WorldBuilder -Wl,--noall_load) 
+	if(NOT APPLE)
+      target_link_libraries(${test_name} ${Boost_LIBRARIES} ${GWB_LIBRARY_WHOLE})
+    else()
+      target_link_libraries(${test_name} ${Boost_LIBRARIES} ${GWB_LIBRARY_WHOLE_APPLE})
+    endif()
 
 	# Move testing binaries into a testBin directory
         set_target_properties(${test_name} PROPERTIES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,9 @@ foreach(test_source ${UNIT_TEST_SOURCES})
         # Add compile target
         add_executable(${test_name} ${test_source})
 
-    target_link_libraries(${test_name} ${Boost_LIBRARIES} WorldBuilder)
+    # Make sure that the whole library is loaded, so the registration is done correctly.
+    SET(GWB_LIBRARY_WHOLE -Wl,--whole-archive WorldBuilder -Wl,--no-whole-archive)
+    target_link_libraries(${test_name} ${Boost_LIBRARIES} ${GWB_LIBRARY_WHOLE})
 
 	# Move testing binaries into a testBin directory
         set_target_properties(${test_name} PROPERTIES
@@ -106,8 +108,8 @@ endforeach(test_source)
 #set(CMAKE_FORTRAN_CLANG_LIB_FLAG "-undefined dynamic_lookup")
 	#endif()
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran)
-add_test(NAME compile_simple_fortran_test 
-	COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/test.f90 -L../../lib/ -lWorldBuilder -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o test${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
+add_test(NAME compile_simple_fortran_test
+	COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/test.f90 -L../../lib/ -Wl,--whole-archive -lWorldBuilder -Wl,--no-whole-archive -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o test${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
 	 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
 
 add_test(run_simple_fortran_test
@@ -121,7 +123,7 @@ add_test(run_simple_fortran_test
                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/) 
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran)
 add_test(NAME compile_simple_fortran_example 
-	COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/example.f90 -L../../lib/ -lWorldBuilder -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o example${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
+	COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/example.f90 -L../../lib/ -Wl,--whole-archive -lWorldBuilder -Wl,--no-whole-archive -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o example${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
 	 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
 
 add_test(run_simple_fortran_example


### PR DESCRIPTION
The solution for having a plugin system has been reported to cause problems with gcc 5 (#118 and see https://github.com/geodynamics/aspect/issues/2613). Doing some more research on a different solution, I am now testing whether a linker flag (-Wl,--whole-archive) might also solve the problem of non-referenced compiler units causing the plugin system to fail. This solution might even better, because it will fully automatize the plugin system.