### PR TITLE
Fix subduction plate model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ matrix:
       osx_image: xcode10
       env: 
          - MAKE_FILE_GENERATOR="Unix Makefiles"
-         - MATRIX_EVAL="export PATH=$TRAVIS_ROOT/bin:$PATH && brew install gcc || true  && brew link --overwrite gcc && brew install libomp || brew upgrade libomp || true && export LDFLAGS="-L/usr/local/opt/llvm/lib" && export CPPFLAGS="-I/usr/local/opt/llvm/include" && export CC=/usr/local/opt/llvm/bin/clang && export  CXX=/usr/local/opt/llvm/bin/clang++ && export FC=gfortran" 
+         - MATRIX_EVAL="export PATH=$TRAVIS_ROOT/bin:$PATH && which clang && ls -lh /Applications/Xcode-10.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/ && ls -lh /Applications/Xcode-10.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ && brew install gcc || true  && brew link --overwrite gcc && brew install libomp || brew upgrade libomp || true  && export LDFLAGS="-L/Applications/Xcode-10.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib" && export CPPFLAGS="-I/Applications/Xcode-10.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include" && export CC=/Applications/Xcode-10.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang && export  CXX=/Applications/Xcode-10.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ && export FC=gfortran" 
          - CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=Debug -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include -lomp" -DOpenMP_CXX_LIB_NAMES="omp" -DOpenMP_omp_LIBRARY=/usr/local/opt/libomp/lib/libomp.dylib"
 
     - name: "windows debug"

--- a/cookbooks/2d_cartesian_subduction_rift/2d_cartesian_subduction_rift.wb
+++ b/cookbooks/2d_cartesian_subduction_rift/2d_cartesian_subduction_rift.wb
@@ -24,7 +24,7 @@
     {"model":"subducting plate", "name":"Subducting plate", "coordinates":[[1150e3,-1e3],[1150e3,1e3]], "dip point":[2000e3,0],
      "segments":[{"length":200e3, "thickness":[95e3], "angle":[0,45]}, {"length":200e3, "thickness":[95e3], "angle":[45]}, 
                  {"length":200e3, "thickness":[95e3], "angle":[45,0]}, {"length":100e3, "thickness":[95e3], "angle":[0]}],
-     "temperature models":[{"model":"plate model", "density":3300, "plate velocity":0.01 }],
+     "temperature models":[{"model":"plate model", "density":3300, "plate velocity":0.01, "adiabatic heating":false}],
      "composition models":[{"model":"uniform", "compositions":[0], "max distance slab top":10e3},
                            {"model":"uniform", "compositions":[1], "min distance slab top":10e3, "max distance slab top":95e3 }]}
   ]

--- a/cookbooks/2d_cartesian_subduction_rift_adiabatic/2d_cartesian_subduction_rift_adiabatic.grid
+++ b/cookbooks/2d_cartesian_subduction_rift_adiabatic/2d_cartesian_subduction_rift_adiabatic.grid
@@ -1,0 +1,14 @@
+# ouput variables
+grid_type = cartesian
+dim = 2
+compositions = 6
+
+# domain of the grid
+x_min = 0e3
+x_max = 2000e3 
+z_min = 0 #5711e3
+z_max = 750e3 #6371e3
+
+# grid properties
+n_cell_x = 1600 #400
+n_cell_z = 600 #1500

--- a/cookbooks/2d_cartesian_subduction_rift_adiabatic/2d_cartesian_subduction_rift_adiabatic.wb
+++ b/cookbooks/2d_cartesian_subduction_rift_adiabatic/2d_cartesian_subduction_rift_adiabatic.wb
@@ -1,0 +1,29 @@
+{
+  "version":"0.2",
+  "cross section":[[0,0],[100,0]],
+  "features":
+  [
+    {"model":"oceanic plate", "name":"oceanic plate", "coordinates":[[-1e3,-1e3],[1150e3,-1e3],[1150e3,1e3],[-1e3,1e3]],
+     "temperature models":[{"model":"plate model", "max depth":95e3, "spreading velocity":0.005, "ridge coordinates":[[100e3,-1e3],[100e3,1e3]]}],
+     "composition models":[{"model":"uniform", "compositions":[0], "max depth":10e3},
+                           {"model":"uniform", "compositions":[1], "min depth":10e3, "max depth":95e3}]},
+
+    {"model":"continental plate", "name":"continental plate", "coordinates":[[1150e3,-1e3],[2001e3,-1e3],[2001e3,1e3],[1150e3,1e3]],
+     "temperature models":[{"model":"linear", "max depth":95e3}],
+     "composition models":[{"model":"uniform", "compositions":[2], "max depth":30e3},
+                           {"model":"uniform", "compositions":[3], "min depth":30e3, "max depth":65e3}]},
+
+    {"model":"mantle layer", "name":"upper mantle", "min depth":95e3, "max depth":660e3, "coordinates":[[-1e3,-1e3],[2001e3,-1e3],[2001e3,1e3],[-1e3,1e3]],
+     "composition models":[{"model":"uniform", "compositions":[4]}]},
+
+    {"model":"mantle layer", "name":"lower mantle", "min depth":660e3, "max depth":1160e3, "coordinates":[[-1e3,-1e3],[2001e3,-1e3],[2001e3,1e3],[-1e3,1e3]],
+     "composition models":[{"model":"uniform", "compositions":[5]}]},
+
+    {"model":"subducting plate", "name":"Subducting plate", "coordinates":[[1150e3,-1e3],[1150e3,1e3]], "dip point":[2000e3,0],
+     "segments":[{"length":200e3, "thickness":[95e3], "angle":[0,45]}, {"length":200e3, "thickness":[95e3], "angle":[45]}, 
+                 {"length":200e3, "thickness":[95e3], "angle":[45,0]}, {"length":100e3, "thickness":[95e3], "angle":[0]}],
+     "temperature models":[{"model":"plate model", "density":3300, "plate velocity":0.01}],
+     "composition models":[{"model":"uniform", "compositions":[0], "max distance slab top":10e3},
+                           {"model":"uniform", "compositions":[1], "min distance slab top":10e3, "max distance slab top":95e3 }]}
+  ]
+}

--- a/cookbooks/2d_spherical_subduction_rift/2d_spherical_subduction_rift.wb
+++ b/cookbooks/2d_spherical_subduction_rift/2d_spherical_subduction_rift.wb
@@ -25,7 +25,7 @@
     {"model":"subducting plate", "name":"Subducting plate", "coordinates":[[11.5,-1],[11.5,1]], "dip point":[20,0],
       "segments":[{"length":200e3, "thickness":[95e3], "angle":[0,45]}, {"length":200e3, "thickness":[95e3], "angle":[45]}, 
                   {"length":200e3, "thickness":[95e3], "angle":[45,0]}, {"length":100e3, "thickness":[95e3], "angle":[0]}],
-      "temperature models":[{"model":"plate model", "density":3300, "plate velocity":0.01 }],
+      "temperature models":[{"model":"plate model", "density":3300, "plate velocity":0.01, "adiabatic heating":false}],
       "composition models":[{"model":"uniform", "compositions":[0], "max distance slab top":10e3},
                             {"model":"uniform", "compositions":[1], "min distance slab top":10e3, "max distance slab top":95e3}]}
   ]

--- a/cookbooks/2d_spherical_subduction_rift_adiabatic/2d_spherical_subduction_rift_adiabatic.grid
+++ b/cookbooks/2d_spherical_subduction_rift_adiabatic/2d_spherical_subduction_rift_adiabatic.grid
@@ -1,0 +1,16 @@
+# ouput variables
+grid_type = chunk
+dim = 2
+compositions = 6
+
+# domain of the grid
+x_max = 20
+x_min = 0
+y_max = 0
+y_min = 0
+z_min = 5651000
+z_max = 6371000
+
+# grid properties
+n_cell_x = 1440
+n_cell_z = 320

--- a/cookbooks/2d_spherical_subduction_rift_adiabatic/2d_spherical_subduction_rift_adiabatic.wb
+++ b/cookbooks/2d_spherical_subduction_rift_adiabatic/2d_spherical_subduction_rift_adiabatic.wb
@@ -1,0 +1,30 @@
+{
+  "version":"0.2",
+  "coordinate system":{"model":"spherical", "depth method":"begin segment"},
+  "cross section":[[0,0],[10,0]],
+  "features":
+  [
+    {"model":"oceanic plate", "name":"oceanic plate", "coordinates":[[-1,-1],[11.5,-1],[11.5,1],[-1,1]],
+     "temperature models":[{"model":"plate model", "max depth":95e3, "spreading velocity":0.005, "ridge coordinates":[[1,-1],[1,1]]}],
+     "composition models":[{"model":"uniform", "compositions":[0], "max depth":10e3},
+                           {"model":"uniform", "compositions":[1], "min depth":10e3, "max depth":95e3}]},
+
+    {"model":"continental plate", "name":"continental plate", "coordinates":[[11.5,-1],[21,-1],[21,1],[11.5,1]],
+     "temperature models":[{"model":"linear", "max depth":95e3}],
+     "composition models":[{"model":"uniform", "compositions":[2], "max depth":30e3},
+                           {"model":"uniform", "compositions":[3], "min depth":30e3, "max depth":65e3}]},
+
+    {"model":"mantle layer", "name":"upper mantle", "min depth":95e3, "max depth":660e3, "coordinates":[[-1,-1],[21,-1],[21,1],[-1,1]],
+     "composition models":[{"model":"uniform", "compositions":[4]}]},
+
+    {"model":"mantle layer", "name":"lower mantle", "min depth":660e3, "max depth":1160e3, "coordinates":[[-1,-1],[21,-1],[21,1],[-1,1]],
+     "composition models":[{"model":"uniform", "compositions":[5]}]},
+
+    {"model":"subducting plate", "name":"Subducting plate", "coordinates":[[11.5,-1],[11.5,1]], "dip point":[20,0],
+      "segments":[{"length":200e3, "thickness":[95e3], "angle":[0,45]}, {"length":200e3, "thickness":[95e3], "angle":[45]}, 
+                  {"length":200e3, "thickness":[95e3], "angle":[45,0]}, {"length":100e3, "thickness":[95e3], "angle":[0]}],
+      "temperature models":[{"model":"plate model", "density":3300, "plate velocity":0.01 }],
+      "composition models":[{"model":"uniform", "compositions":[0], "max distance slab top":10e3},
+                            {"model":"uniform", "compositions":[1], "min distance slab top":10e3, "max distance slab top":95e3}]}
+  ]
+}

--- a/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
@@ -82,9 +82,6 @@ namespace WorldBuilder
             // plate model temperature submodule parameters
             double min_depth;
             double max_depth;
-//            double top_temperature;
-//            double bottom_temperature;
-//            double spreading_velocity;
             double density;
             double plate_velocity;
             double thermal_conductivity;
@@ -92,6 +89,7 @@ namespace WorldBuilder
             double specific_heat;
             double potential_mantle_temperature;
             double surface_temperature;
+            bool adiabatic_heating;
             std::string operation;
 
         };

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -42,6 +42,7 @@ namespace WorldBuilder
     class String;
     class Segment;
     class Array;
+    class Bool;
     class UnsignedInt;
   }
 

--- a/source/features/mantle_layer_models/temperature/linear.cc
+++ b/source/features/mantle_layer_models/temperature/linear.cc
@@ -119,7 +119,7 @@ namespace WorldBuilder
 
                 }
 
-              return top_temperature +
+              return top_temperature_local +
                      (depth - min_depth_local) * ((bottom_temperature_local - top_temperature_local) / (max_depth_local - min_depth_local));
 
             }

--- a/source/features/oceanic_plate_models/temperature/linear.cc
+++ b/source/features/oceanic_plate_models/temperature/linear.cc
@@ -118,7 +118,7 @@ namespace WorldBuilder
                                                         this->world->specific_heat) * max_depth_local);
                 }
 
-              return top_temperature +
+              return top_temperature_local +
                      (depth - min_depth_local) * ((bottom_temperature_local - top_temperature_local) / (max_depth_local - min_depth_local));
 
             }

--- a/source/features/oceanic_plate_models/temperature/plate_model.cc
+++ b/source/features/oceanic_plate_models/temperature/plate_model.cc
@@ -106,40 +106,6 @@ namespace WorldBuilder
             {
               ridge_coordinates[i] *= dtr;
             }
-
-          /*
-           prm.load_entry("depth", true, Types::Double(NaN::DSNAN,"The depth in meters to which the temperature rises (or lowers) to."));
-          temperature_submodule_plate_model_depth = prm.get_double("depth");
-
-          prm.load_entry("top temperature", false, Types::Double(293.15,"The temperature in degree Kelvin a the top of this block. If this value is not set, the "));
-          temperature_submodule_plate_model_top_temperature = prm.get_double("top temperature");
-
-
-          prm.load_entry("bottom temperature", false, Types::Double(NaN::DQNAN,"The temperature in degree Kelvin a the bottom of this block."));
-          temperature_submodule_plate_model_bottom_temperature = prm.get_double("bottom temperature");
-
-          prm.load_entry("ridge points", true,
-                         Types::Array(Types::Point<2>(Point<2>({0,0},coordinate_system),
-                                                      "A 2d point on the line where the oceanic ridge is located."),
-                                      "A list of 2d points which define the location of the ridge."));
-          std::vector<Types::Point<2> > temp_ridge_points = prm.get_array<Types::Point<2> >("ridge points");
-
-          const double dtr = prm.coordinate_system->natural_coordinate_system() == spherical ? const_pi / 180.0 : 1.0;
-          WBAssertThrow(temp_ridge_points.size() >= 2,
-                        "Need at least two points to form the ridge of the oceanic plate, "
-                        << temp_ridge_points.size() << " points where given.");
-          temperature_submodule_plate_model_ridge_points.resize(temp_ridge_points.size(),Point<2>(coordinate_system));
-          for (unsigned int i = 0; i < temp_ridge_points.size(); ++i)
-            {
-              temperature_submodule_plate_model_ridge_points[i] = temp_ridge_points[i].value * dtr;
-            }
-
-          prm.load_entry("spreading velocity", true, Types::Double(NaN::DSNAN,
-                                                                   "The spreading velocity of the plate in meter per year. "
-                                                                   "This is the velocity with which one side moves away from the ridge."));
-          // directly convert from meter per year to meter per second.
-          temperature_submodule_plate_model_spreading_velocity = prm.get_double("spreading velocity")/31557600;
-           */
         }
 
 
@@ -161,7 +127,6 @@ namespace WorldBuilder
 
 
               double bottom_temperature_local = bottom_temperature;
-              //const double max_depth = temperature_submodule_plate_model_depth;
 
               if (bottom_temperature_local < 0)
                 {

--- a/source/features/subducting_plate_models/temperature/adiabatic.cc
+++ b/source/features/subducting_plate_models/temperature/adiabatic.cc
@@ -134,10 +134,11 @@ namespace WorldBuilder
                                    double temperature,
                                    const double ,
                                    const double ,
-                                   const std::map<std::string,double> &) const
+                                   const std::map<std::string,double> &distance_from_planes) const
         {
 
-          if (depth <= max_depth && depth >= min_depth)
+          const double distance_from_plane = distance_from_planes.at("distanceFromPlane");
+          if (distance_from_plane <= max_depth && distance_from_plane >= min_depth)
             {
               const double adabatic_temperature = potential_mantle_temperature *
                                                   std::exp(((thermal_expansion_coefficient * gravity_norm) /

--- a/source/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/features/subducting_plate_models/temperature/plate_model.cc
@@ -117,40 +117,6 @@ namespace WorldBuilder
 
           potential_mantle_temperature = this->world->potential_mantle_temperature;
           surface_temperature = this->world->surface_temperature;
-
-          /*
-           prm.load_entry("depth", true, Types::Double(NaN::DSNAN,"The depth in meters to which the temperature rises (or lowers) to."));
-          temperature_submodule_plate_model_depth = prm.get_double("depth");
-
-          prm.load_entry("top temperature", false, Types::Double(293.15,"The temperature in degree Kelvin a the top of this block. If this value is not set, the "));
-          temperature_submodule_plate_model_top_temperature = prm.get_double("top temperature");
-
-
-          prm.load_entry("bottom temperature", false, Types::Double(NaN::DQNAN,"The temperature in degree Kelvin a the bottom of this block."));
-          temperature_submodule_plate_model_bottom_temperature = prm.get_double("bottom temperature");
-
-          prm.load_entry("ridge points", true,
-                         Types::Array(Types::Point<2>(Point<2>({0,0},coordinate_system),
-                                                      "A 2d point on the line where the subducting ridge is located."),
-                                      "A list of 2d points which define the location of the ridge."));
-          std::vector<Types::Point<2> > temp_ridge_points = prm.get_array<Types::Point<2> >("ridge points");
-
-          const double dtr = prm.coordinate_system->natural_coordinate_system() == spherical ? const_pi / 180.0 : 1.0;
-          WBAssertThrow(temp_ridge_points.size() >= 2,
-                        "Need at least two points to form the ridge of the subducting plate, "
-                        << temp_ridge_points.size() << " points where given.");
-          temperature_submodule_plate_model_ridge_points.resize(temp_ridge_points.size(),Point<2>(coordinate_system));
-          for (unsigned int i = 0; i < temp_ridge_points.size(); ++i)
-            {
-              temperature_submodule_plate_model_ridge_points[i] = temp_ridge_points[i].value * dtr;
-            }
-
-          prm.load_entry("spreading velocity", true, Types::Double(NaN::DSNAN,
-                                                                   "The spreading velocity of the plate in meter per year. "
-                                                                   "This is the velocity with which one side moves away from the ridge."));
-          // directly convert from meter per year to meter per second.
-          temperature_submodule_plate_model_spreading_velocity = prm.get_double("spreading velocity")/31557600;
-           */
         }
 
 

--- a/source/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/features/subducting_plate_models/temperature/plate_model.cc
@@ -23,6 +23,7 @@
 #include <world_builder/parameters.h>
 
 #include <world_builder/types/array.h>
+#include <world_builder/types/bool.h>
 #include <world_builder/types/double.h>
 #include <world_builder/types/point.h>
 #include <world_builder/types/string.h>
@@ -44,9 +45,14 @@ namespace WorldBuilder
           :
           min_depth(NaN::DSNAN),
           max_depth(NaN::DSNAN),
-          //top_temperature(NaN::DSNAN),
-          //bottom_temperature(NaN::DSNAN),
-          //spreading_velocity(NaN::DSNAN),
+          density(NaN::DSNAN),
+          plate_velocity(NaN::DSNAN),
+          thermal_conductivity(NaN::DSNAN),
+          thermal_expansion_coefficient(NaN::DSNAN),
+          specific_heat(NaN::DSNAN),
+          potential_mantle_temperature(NaN::DSNAN),
+          surface_temperature(NaN::DSNAN),
+          adiabatic_heating(true),
           operation("")
         {
           this->world = world_;
@@ -79,16 +85,23 @@ namespace WorldBuilder
           prm.declare_entry("thermal conductivity", Types::Double(2.0),
                             "The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.");
 
-          prm.declare_entry("thermal expansion coefficient", Types::Double(3.5e-5),
-                            "The thermal expansivity of the subducting plate material in $K^{-1}$.");
+          prm.declare_entry("thermal expansion coefficient", Types::Double(-1),
+                            "The thermal expansivity of the subducting plate material in $K^{-1}$. If smaller than zero, the global value is used.");
 
-          prm.declare_entry("specific heat", Types::Double(1250),
-                            "The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$.");
+          prm.declare_entry("specific heat", Types::Double(-1),
+                            "The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$. If smaller than zero, the global value is used.");
 
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "add", "substract"}),
                             "Whether the value should replace any value previously defined at this location (replace), "
                             "add the value to the previously define value (add) or substract the value to the previously "
                             "define value (substract).");
+
+          prm.declare_entry("adiabatic heating", Types::Bool(true),
+                            "Wheter adiabatic heating should be used for the slab. Setting the parameter to false leads to equation 26 from McKenzie (1970),"
+                            "which is the result obtained from McKenzie 1969.");
+
+          prm.declare_entry("potential mantle temperature", Types::Double(-1),
+                            "The potential temperature of the mantle at the surface in Kelvin. If smaller than zero, the global value is used.");
         }
 
         void
@@ -112,10 +125,21 @@ namespace WorldBuilder
 
           thermal_expansion_coefficient = prm.get<double>("thermal expansion coefficient");
 
+          if (thermal_expansion_coefficient < 0 )
+            thermal_expansion_coefficient = this->world->thermal_expansion_coefficient;
+
           specific_heat = prm.get<double>("specific heat");
 
+          if (specific_heat < 0)
+            specific_heat = this->world->specific_heat;
 
-          potential_mantle_temperature = this->world->potential_mantle_temperature;
+          adiabatic_heating = prm.get<bool>("adiabatic heating");
+
+          potential_mantle_temperature = this->world->potential_mantle_temperature >= 0
+                                         ?
+                                         this->world->potential_mantle_temperature
+                                         :
+                                         prm.get<double>("potential mantle temperature");
           surface_temperature = this->world->surface_temperature;
         }
 
@@ -129,84 +153,99 @@ namespace WorldBuilder
                                     const double,
                                     const std::map<std::string,double> &distance_from_planes) const
         {
-
           double temperature = temperature_;
-          const double thickness_local = distance_from_planes.at("thicknessLocal");
+          const double thickness_local = std::min(distance_from_planes.at("thicknessLocal"), max_depth);
           const double distance_from_plane = distance_from_planes.at("distanceFromPlane");
           const double distance_along_plane = distance_from_planes.at("distanceAlongPlane");
           const double average_angle = distance_from_planes.at("averageAngle");
 
-          /*
-           * We now use the McKenzie (1970) equation to determine the
-           * temperature inside the slab. The McKenzie equation was
-           * designed for a straight slab, but we have a potentially
-           * curved slab. Because the angle is a required parameter, we
-           * first tried a local angle. This gave weird effects of
-           * apparent cooling when the slabs angle decreases. Now we
-           * use an average angle, which works better.
-           */
-          const double R = (density * specific_heat
-                            * (plate_velocity /(365.25 * 24.0 * 60.0 * 60.0))
-                            * thickness_local) / (2.0 * thermal_conductivity);
-
-          WBAssert(!std::isnan(R), "Internal error: R is not a number: " << R << ".");
-
-          // gravity in original in cm/s^2, here in m/s^2, thickness original in km, here in meter. So 100/1000=0.1
-          const double H = specific_heat
-                           / (thermal_expansion_coefficient * gravity_norm * thickness_local);
-
-          WBAssert(!std::isnan(H), "Internal error: H is not a number: " << H << ".");
-
-          const int n_sum = 500;
-          // distance_from_plane can be zero, so protect division.
-          double z_scaled = 1 - (std::fabs(distance_from_plane) < 2.0 * std::numeric_limits<double>::epsilon() ?
-                                 2.0 * std::numeric_limits<double>::epsilon()
-                                 :
-                                 distance_from_plane
-                                 / thickness_local);
-
-          // distance_along_plane can be zero, so protect division.
-          double x_scaled = (std::fabs(distance_along_plane) < 2.0 * std::numeric_limits<double>::epsilon() ?
-                             2.0 *std::numeric_limits<double>::epsilon()
-                             :
-                             distance_along_plane)
-                            / thickness_local;
-          // the paper uses `(x_scaled * sin(average_angle) - z_scaled * cos(average_angle))` to compute the
-          // depth (execpt that you do not use average angles since they only have on angle). On recomputing
-          // their result it seems to me (Menno) that it should have been `(1-z_scaled)` instead of `z_scaled`.
-          // To avoid this whole problem we just use the depth directly since we have that.
-          // todo: get the local thickniss out of H, that prevents an other division.
-          double temp = exp((distance_from_plane / thickness_local)/ H);
-
-          WBAssert(!std::isnan(z_scaled), "Internal error: z_scaled is not a number: " << z_scaled << ".");
-          WBAssert(!std::isnan(x_scaled), "Internal error: x_scaled is not a number: " << x_scaled << ".");
-          WBAssert(!std::isnan(temp), "Internal error: temp is not a number: " << temp << ". In exponent: "
-                   << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle)) / H
-                   << ", top: " << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle))
-                   << ", x_scaled = " << x_scaled << ", z_scaled = " << z_scaled << ", average_angle = " << average_angle);
-
-          double sum=0;
-          for (int i=1; i<=n_sum; i++)
+          if (distance_from_plane <= max_depth && distance_from_plane >= min_depth)
             {
-              sum += (std::pow((-1.0),i)/(i*const_pi)) *
-                     (exp((R - std::pow(R * R + i * i * const_pi * const_pi, 0.5)) * x_scaled))
-                     * (sin(i * const_pi * z_scaled));
+              /*
+               * We now use the McKenzie (1970) equation to determine the
+               * temperature inside the slab. The McKenzie equation was
+               * designed for a straight slab, but we have a potentially
+               * curved slab. Because the angle is a required parameter, we
+               * first tried a local angle. This gave weird effects of
+               * apparent cooling when the slabs angle decreases. Now we
+               * use an average angle, which works better.
+               */
+              const double R = (density * specific_heat
+                                * (plate_velocity /(365.25 * 24.0 * 60.0 * 60.0))
+                                * thickness_local) / (2.0 * thermal_conductivity);
+
+              WBAssert(!std::isnan(R), "Internal error: R is not a number: " << R << ".");
+
+              const double H = specific_heat
+                               / (thermal_expansion_coefficient * gravity_norm * thickness_local);
+
+              WBAssert(!std::isnan(H), "Internal error: H is not a number: " << H << ".");
+              WBAssert(std::isfinite(1/H), "Internal error: 1/H is not finite: " << 1/H << ".");
+
+              const int n_sum = 500;
+              // distance_from_plane can be zero, so protect division.
+              double z_scaled = 1 - (std::fabs(distance_from_plane) < 2.0 * std::numeric_limits<double>::epsilon() ?
+                                     2.0 * std::numeric_limits<double>::epsilon()
+                                     :
+                                     distance_from_plane
+                                     / thickness_local);
+
+              // distance_along_plane can be zero, so protect division.
+              double x_scaled = (std::fabs(distance_along_plane) < 2.0 * std::numeric_limits<double>::epsilon() ?
+                                 2.0 *std::numeric_limits<double>::epsilon()
+                                 :
+                                 distance_along_plane)
+                                / thickness_local;
+              // the paper uses `(x_scaled * sin(average_angle) - z_scaled * cos(average_angle))` to compute the
+              // depth (execpt that you do not use average angles since they only have on angle). On recomputing
+              // their result it seems to me (Menno) that it should have been `(1-z_scaled)` instead of `z_scaled`.
+              // To avoid this whole problem we just use the depth directly since we have that.
+              // todo: get the local thickniss out of H, that prevents an other division.
+              // If we want to specifiy the bottom temperature, because we have defined a linear temperture increase in the
+              // mantle and/or oceanic plate, we have to switch off adiabatic heating for now.
+              // Todo: there may be a better way to deal with this.
+              double temp = adiabatic_heating ? exp((distance_from_plane / thickness_local)/ H) : 1;
+
+              WBAssert(!std::isnan(z_scaled), "Internal error: z_scaled is not a number: " << z_scaled << ".");
+              WBAssert(!std::isnan(x_scaled), "Internal error: x_scaled is not a number: " << x_scaled << ".");
+              WBAssert(!std::isnan(temp), "Internal error: temp is not a number: " << temp << ". In exponent: "
+                       << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle)) / H
+                       << ", top: " << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle))
+                       << ", x_scaled = " << x_scaled << ", z_scaled = " << z_scaled << ", average_angle = " << average_angle);
+
+
+              WBAssert(std::isfinite(z_scaled), "Internal error: z_scaled is not finite: " << z_scaled << ".");
+              WBAssert(std::isfinite(x_scaled), "Internal error: x_scaled is not finite: " << x_scaled << ".");
+              WBAssert(std::isfinite(temp), "Internal error: temp is not finite: " << temp << ". In exponent: "
+                       << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle)) / H
+                       << ", top: " << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle))
+                       << ", x_scaled = " << x_scaled << ", z_scaled = " << z_scaled << ", average_angle = " << average_angle
+                       << ", average_angle = " << average_angle << ", sin(average_angle) = " << sin(average_angle)
+                       << ", cos(average_angle) = " << cos(average_angle) << ", H = " << H << ", max_depth = " << max_depth);
+
+              double sum=0;
+              for (int i=1; i<=n_sum; i++)
+                {
+                  sum += (std::pow((-1.0),i)/(i*const_pi)) *
+                         (exp((R - std::pow(R * R + i * i * const_pi * const_pi, 0.5)) * x_scaled))
+                         * (sin(i * const_pi * z_scaled));
+                }
+              // todo: investiage wheter this 273.15 should just be the surface temperature.
+              temperature = temp * (potential_mantle_temperature
+                                    + 2.0 * (potential_mantle_temperature - 273.15) * sum);
+
+              WBAssert(!std::isnan(temperature), "Internal error: temperature is not a number: " << temperature << ".");
+              WBAssert(std::isfinite(temperature), "Internal error: temperature is not finite: " << temperature << ".");
+
+
+
+              if (operation == "replace")
+                return temperature;
+              else if ("add")
+                return temperature_ + temperature;
+              else if ("substract")
+                return temperature_ - temperature;
             }
-          // todo: investiage wheter this 273.15 should just be the surface temperature.
-          temperature = temp * (potential_mantle_temperature
-                                + 2.0 * (potential_mantle_temperature - 273.15) * sum);
-
-          WBAssert(!std::isnan(temperature), "Internal error: temperature is not a number: " << temperature << ".");
-
-
-
-          if (operation == "replace")
-            return temperature;
-          else if ("add")
-            return temperature_ + temperature;
-          else if ("substract")
-            return temperature_ - temperature;
-
 
           return temperature_;
         }

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -1516,18 +1516,18 @@ TEST_CASE("WorldBuilder Features: Subducting Plate")
 
   position = {{250e3,500e3,800e3}};
   // results strongly dependent on the summation number of the McKenzie temperature.
-  CHECK(world1.temperature(position, 0, 10) == Approx(1616.7957367454));
-  CHECK(world1.temperature(position, 1, 10) == Approx(1607.4818890612)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 5, 10) == Approx(1571.2135069216)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 10, 10) == Approx(1528.0459485492)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 100, 10) == Approx(1068.1100810682)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 500, 10) == Approx(894.9450953737)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 1000, 10) == Approx(847.7577529978)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 5000, 10) == Approx(638.1862559148)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 10e3, 10) == Approx(542.3510458781));
-  CHECK(world1.temperature(position, 25e3, 10) == Approx(551.5599843184));
-  CHECK(world1.temperature(position, 50e3, 10) == Approx(756.7177819132));
-  CHECK(world1.temperature(position, 75e3, 10) == Approx(986.4816608584));
+  CHECK(world1.temperature(position, 0, 10) == Approx(1599.9999999994));
+  CHECK(world1.temperature(position, 1, 10) == Approx(1590.6681048292)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 5, 10) == Approx(1554.3294579725)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 10, 10) == Approx(1511.0782994151)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 100, 10) == Approx(1050.2588653774)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 500, 10) == Approx(876.8637089978)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 1000, 10) == Approx(829.7197877204)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 5000, 10) == Approx(620.6827823798)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 10e3, 10) == Approx(525.727843761));
+  CHECK(world1.temperature(position, 25e3, 10) == Approx(538.4605698191));
+  CHECK(world1.temperature(position, 50e3, 10) == Approx(751.6318639633));
+  CHECK(world1.temperature(position, 75e3, 10) == Approx(991.5852995579));
   CHECK(world1.temperature(position, 150e3, 10) == Approx(1668.6311660012));
   //CHECK(world1.temperature(position, std::sqrt(2) * 100e3 - 1, 10) == Approx(150.0));
   //CHECK(world1.temperature(position, std::sqrt(2) * 100e3 + 1, 10) == Approx(1664.6283561404));
@@ -1704,23 +1704,23 @@ TEST_CASE("WorldBuilder Features: Subducting Plate")
   WorldBuilder::World world2(file_name2);
 
   position = {{250e3,500e3,800e3}};
-  CHECK(world2.temperature(position, 0, 10) == Approx(1615.4703444765));
+  CHECK(world2.temperature(position, 0, 10) == Approx(1599.9999999994));
   CHECK(world2.composition(position, 0, 0) == 1.0);
-  CHECK(world2.temperature(position, 1, 10) == Approx(1602.2389716513));
+  CHECK(world2.temperature(position, 1, 10) == Approx(1586.7321267113));
   CHECK(world2.composition(position, 1, 0) == 1.0);
-  CHECK(world2.temperature(position, 1e3, 10) == Approx(252.1645713879));
+  CHECK(world2.temperature(position, 1e3, 10) == Approx(233.1298084984));
   CHECK(world2.composition(position, 1e3, 0) == 1.0);
-  CHECK(world2.temperature(position, 10e3, 10) == Approx(428.0876423223));
+  CHECK(world2.temperature(position, 10e3, 10) == Approx(412.3206666645));
   CHECK(world2.composition(position, 10e3, 0) == 1.0);
-  CHECK(world2.temperature(position, 20e3, 10) == Approx(555.8731102111));
+  CHECK(world2.temperature(position, 20e3, 10) == Approx(544.1584323159));
   CHECK(world2.composition(position, 20e3, 0) == 1.0);
-  CHECK(world2.temperature(position, 40e3, 10) == Approx(815.6811256009));
+  CHECK(world2.temperature(position, 40e3, 10) == Approx(814.1198929245));
   CHECK(world2.composition(position, 40e3, 0) == 1.0);
-  CHECK(world2.temperature(position, 60e3, 10) == Approx(1076.6671650689));
+  CHECK(world2.temperature(position, 60e3, 10) == Approx(1087.9994157551));
   CHECK(world2.composition(position, 60e3, 0) == 1.0);
-  CHECK(world2.temperature(position, 80e3, 10) == Approx(1338.1548821219));
+  CHECK(world2.temperature(position, 80e3, 10) == Approx(1365.1437340828));
   CHECK(world2.composition(position, 80e3, 0) == 1.0);
-  CHECK(world2.temperature(position, 100e3, 10) == Approx(1600.0));
+  CHECK(world2.temperature(position, 100e3, 10) == Approx(1645.4330950743));
   CHECK(world2.composition(position, 100e3, 0) == 1.0);
 
 


### PR DESCRIPTION
For the rebuttal of the paper looked again at the McKenzie 1970 paper which is used to implement the subducting plate plate model and found a bug in my implementation and what is likely an error in the paper itself. This pull request fixes the bug, cleans up the code and circumvents the possible error in the paper by using the depth we have directly instead of computing it with angles. This is also fundamentally better for this code because we do no have a single straight slab like in the paper, but potentially a segmented curved slab.