### PR TITLE
link manual GWB version to the global repository version.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -109,7 +109,7 @@
 \begin{tikzpicture}[remember picture,overlay]
 \node[inner sep=0pt] (background) at (current page.center) {\includegraphics[width=\paperwidth]{world_builder_logo_v4.png}};
 \draw (current page.center) node [fill opacity=0.0,text opacity=1,inner sep=1cm]{\Huge\centering\bfseries\sffamily\parbox[c][][t]{\paperwidth}{\centering  Manual of \\  the Geodynamic \\ World Builder \\ [10pt] 
-{\Large geodynamicworldbuilder.github.io} \\ [0pt] {\Large Generated \today{}} \\ [10pt] {\huge version 0.2.0-pre}}}; 
+	{\Large geodynamicworldbuilder.github.io} \\ [0pt] {\Large Generated \today{}} \\ [10pt] {\huge version \input{../../VERSION}}}}; 
 \draw (current page.south) node [fill opacity=0.0,text opacity=1,inner sep=1cm]{\Large\centering\bfseries\sffamily\parbox[t][][t]{\paperwidth}{\centering  Written by Menno Fraters \\[10pt]\large With contributions from Arie van den Berg, Wim Spakman and Cedric Thieulot \\ [100pt]}}; 
 \end{tikzpicture}
 \vfill


### PR DESCRIPTION
This makes sure that the version as shown in the manual is always consistent with the actual version of the code as represented in the VERSION file in the root of the repository. This does create a relative link, which means that the manual should always be build from a certain location. This therefore creates a restriction, but I am not sure if it will be a problem in practice.