### PR TITLE
Make fortran compiler optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
 script:
   - gcc --version
   - gcov --version
-  - gfortran --version
   - mkdir build
   - mkdir install
   - cmake . -G "${MAKE_FILE_GENERATOR}" ${CMAKE_EXTRA_ARGS} ${MAC_COMPILER_EXTRA}
@@ -55,7 +54,7 @@ matrix:
          - MAKE_FILE_GENERATOR="Unix Makefiles"
          - CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=Coverage"
          - RUN_COVERALLS="TRUE"
-         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && FC=gfortran && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6 --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-6 --slave /usr/bin/gcov gcov /usr/bin/gcov-6 && sudo update-alternatives --config gcc && gcc --version && gcov --version && mkdir astyle && cd astyle && wget 'https://sourceforge.net/projects/astyle/files/astyle/astyle 2.04/astyle_2.04_linux.tar.gz' && tar -zxvf astyle_2.04_linux.tar.gz && cd astyle/build/gcc && make && sudo make install && cd ../../../../ && pip install --user cpp-coveralls"
+         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && FC=gfortran && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6 --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-6 --slave /usr/bin/gcov gcov /usr/bin/gcov-6 && sudo update-alternatives --config gcc && gcc --version && gcov --version && gfortran --version && mkdir astyle && cd astyle && wget 'https://sourceforge.net/projects/astyle/files/astyle/astyle 2.04/astyle_2.04_linux.tar.gz' && tar -zxvf astyle_2.04_linux.tar.gz && cd astyle/build/gcc && make && sudo make install && cd ../../../../ && pip install --user cpp-coveralls"
       addons:
         apt:
           sources:
@@ -72,7 +71,7 @@ matrix:
       env:
          - MAKE_FILE_GENERATOR="Unix Makefiles"
          - CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=Release"
-         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && FC=gfortran"
+         - MATRIX_EVAL="gfortran --version && CC=gcc-6 && CXX=g++-6 && FC=gfortran"
       addons:
         apt:
           sources:
@@ -89,7 +88,7 @@ matrix:
       env:
          - MAKE_FILE_GENERATOR="Unix Makefiles"
          - CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=Debug"
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9 && FC=gfortran"
+         - MATRIX_EVAL="gfortran --version && CC=gcc-4.9 && CXX=g++-4.9 && FC=gfortran"
       addons:
         apt:
           sources:
@@ -100,6 +99,23 @@ matrix:
             - cmake
        
 
+    - name: "linux gcc 4.9 debug no fortan"
+      sudo: false
+      compiler:
+        - g++-4.9
+      env:
+         - MAKE_FILE_GENERATOR="Unix Makefiles"
+         - CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=Debug"
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" 
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+            - cmake
+       
+
     - name: "linux clang"
       sudo: false
       os: linux
@@ -107,7 +123,7 @@ matrix:
         - clang-3.6
       env: 
          - MAKE_FILE_GENERATOR="Unix Makefiles"
-         - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6 && GC=gfortran" 
+         - MATRIX_EVAL="gfortran --version && CC=clang-3.6 && CXX=clang++-3.6 && GC=gfortran" 
          - CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=Debug"
       addons:
         apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-
+include(CheckLanguage)
 cmake_minimum_required (VERSION 2.6)
-project(WorldBuilder C CXX Fortran)
+project(WorldBuilder C CXX)
 
 # load in version info and export it
 SET(WORLD_BUILDER_SOURCE_DIR ${CMAKE_SOURCE_DIR})
@@ -15,12 +15,28 @@ set (WORLD_BUILDER_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 # generate version.cc
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/source/config.cc.in" "${CMAKE_BINARY_DIR}/source/config.cc" @ONLY)
 
+# finding support for different languages
+# finding a fortran compiler
+check_language(Fortran)
+if(CMAKE_Fortran_COMPILER)
+  enable_language(Fortran)
+  message(STATUS "Found Fortran support. Enabling Fortran wrapper and tests.")
+else()
+  message(STATUS "Did not find Fortran support. Disabling Fortran wrapper and tests.")
+endif()
 
 # Add include directory
 include_directories("include/" "tests/") 
 
 # Add source directory
-file(GLOB_RECURSE SOURCES "source/*.cc" "source/*.f90" "${CMAKE_BINARY_DIR}/source/*.cc")
+file(GLOB_RECURSE SOURCES_CXX "source/*.cc" "${CMAKE_BINARY_DIR}/source/*.cc")
+
+if(CMAKE_Fortran_COMPILER)
+  file(GLOB_RECURSE SOURCES_FORTAN "source/*.f90")
+endif()
+
+set(SOURCES ${SOURCES_CXX} ${SOURCES_FORTAN})
+
 
 # Provide "indent" target for indenting all headers and source files
 ADD_CUSTOM_TARGET(indent

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,13 @@
 # Unit test testing
 #find all the unit test files
-file(GLOB_RECURSE UNIT_TEST_SOURCES "unit_tests/*.cc" "unit_tests/*.f90")
+file(GLOB_RECURSE UNIT_TEST_SOURCES_CXX "unit_tests/*.cc")
+
+if(CMAKE_Fortran_COMPILER)
+  file(GLOB_RECURSE UNIT_TEST_SOURCES_FORTAN "unit_tests/*.f90")
+endif()
+
+set(UNIT_TEST_SOURCES ${UNIT_TEST_SOURCES_CXX} ${UNIT_TEST_SOURCES_FORTAN})
+
 
 #set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin/)
 
@@ -109,22 +116,20 @@ foreach(test_source ${VISU_TEST_SOURCES})
                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/visualization/)
 endforeach(test_source)
 
-#test fortran compilation
-#if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-#set(CMAKE_FORTRAN_CLANG_LIB_FLAG "-undefined dynamic_lookup")
-	#endif()
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran)
-if(NOT APPLE)
-  add_test(NAME compile_simple_fortran_test
-	COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/test.f90 -L../../lib/ -Wl,--whole-archive -lWorldBuilder -Wl,--no-whole-archive -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o test${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
-	 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
-else()
-  add_test(NAME compile_simple_fortran_test
-	COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/test.f90 -L../../lib/ -Wl,-force_load,../../lib/libWorldBuilder.a -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o test${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
-	 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
-endif()
-add_test(run_simple_fortran_test
-	 ${CMAKE_COMMAND}
+#test fortran compilation if compiler found
+if(CMAKE_Fortran_COMPILER)
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran)
+  if(NOT APPLE)
+    add_test(NAME compile_simple_fortran_test
+             COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/test.f90 -L../../lib/ -Wl,--whole-archive -lWorldBuilder -Wl,--no-whole-archive -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o test${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
+	     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
+  else()
+    add_test(NAME compile_simple_fortran_test
+	    COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/test.f90 -L../../lib/ -Wl,-force_load,../../lib/libWorldBuilder.a -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o test${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
+	    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
+  endif()
+  add_test(run_simple_fortran_test
+           ${CMAKE_COMMAND}
                  -D TEST_NAME=run_simple_fortran_test
                  -D TEST_PROGRAM=${CMAKE_BINARY_DIR}/tests/fortran/test${CMAKE_EXECUTABLE_SUFFIX}
                  -D TEST_ARGS=${CMAKE_CURRENT_SOURCE_DIR}/data/continental_plate.wb
@@ -132,19 +137,19 @@ add_test(run_simple_fortran_test
 		 -D TEST_REFERENCE=${CMAKE_CURRENT_SOURCE_DIR}/fortran/run_simple_fortran_test.log
                  -P ${CMAKE_SOURCE_DIR}/tests/fortran/run_fortran_tests.cmake
                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/) 
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran)
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran)
 
-if(NOT APPLE)
-  add_test(NAME compile_simple_fortran_example 
-	COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/example.f90 -L../../lib/ -Wl,--whole-archive -lWorldBuilder -Wl,--no-whole-archive -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o example${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
-	 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
-else()
-  add_test(NAME compile_simple_fortran_example 
-	COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/example.f90 -L../../lib/ -Wl,-force_load,../../lib/libWorldBuilder.a -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o example${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
-	 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
-endif()
-add_test(run_simple_fortran_example
-	 ${CMAKE_COMMAND}
+  if(NOT APPLE)
+    add_test(NAME compile_simple_fortran_example 
+	     COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/example.f90 -L../../lib/ -Wl,--whole-archive -lWorldBuilder -Wl,--no-whole-archive -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o example${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
+	     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
+  else()
+    add_test(NAME compile_simple_fortran_example 
+	     COMMAND ${CMAKE_Fortran_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/fortran/example.f90 -L../../lib/ -Wl,-force_load,../../lib/libWorldBuilder.a -I../../mod/ ${CMAKE_Fortran_FLAGS_COVERAGE} -o example${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_EXE_LINKER_FLAGS} 
+	     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/)
+  endif()
+  add_test(run_simple_fortran_example
+	   ${CMAKE_COMMAND}
                  -D TEST_NAME=run_simple_fortran_example
                  -D TEST_PROGRAM=${CMAKE_BINARY_DIR}/tests/fortran/example${CMAKE_EXECUTABLE_SUFFIX}
                  -D TEST_ARGS=${CMAKE_CURRENT_SOURCE_DIR}/data/continental_plate.wb
@@ -152,3 +157,4 @@ add_test(run_simple_fortran_example
 		 -D TEST_REFERENCE=${CMAKE_CURRENT_SOURCE_DIR}/fortran/run_simple_fortran_example.log
                  -P ${CMAKE_SOURCE_DIR}/tests/fortran/run_fortran_tests.cmake
                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/fortran/) 
+ endif()


### PR DESCRIPTION
A fortran compiler is not needed for the compiling the core of the world builder, since it is only used to make and test the fortran wrapper. This pull request let cmake look for a fortran compiler and displays a message whether the compiler is found and switches the compilation of the fortran wrapper and tests off if it isn't found. Resolves issue #133, and is a step towards issue #131.