### PR TITLE
remove gfortran as requirement in manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -178,7 +178,7 @@ Data visualization is carried out with ParaView software \url{https://paraview.o
 
 \chapter{Installation}
 \label{chapter:installation}
-The world builder is currently official supports Linux, OSX and Windows operating systems. Each change to the library is tested against these platforms. The only requirement are a c++ compiler (tested both with gcc and clang) with at minimum c++11 is installed together with \cmake{} (\url{https://cmake.org/}) and gfortran. 
+The world builder is currently official supports Linux, OSX and Windows operating systems. Each change to the library is tested against these platforms. The only requirement are a c++ compiler (tested both with gcc and clang) with at minimum c++11 is installed together with \cmake{} (\url{https://cmake.org/}). 
 
 Section \ref{section:in_package} will go in depth about what is in the \GWB{} package when it is downloaded and installed completely. If you want to skip this explanation, go directly to section \ref{section:installation_for_different_cases}.
 


### PR DESCRIPTION
There was still a reference to gfortran as a requirement left in the manual. Removed this.