### PR TITLE
Clean brackets around function name and a few more virtual and final specifier changes

### DIFF
--- a/include/world_builder/coordinate_systems/cartesian.h
+++ b/include/world_builder/coordinate_systems/cartesian.h
@@ -61,13 +61,12 @@ namespace WorldBuilder
         /**
          * declare and read in the world builder file into the parameters class
          */
-        virtual
         void parse_entries(Parameters &prm) override final;
+
 
         /**
          * Returns what the natural coordinate system for this Coordinate System is.
          */
-        virtual
         CoordinateSystem natural_coordinate_system() const override final;
 
         /**
@@ -75,7 +74,6 @@ namespace WorldBuilder
          * the domain.
          * \sa DepthMethod
          */
-        virtual
         DepthMethod depth_method() const override final;
 
         /**
@@ -85,7 +83,6 @@ namespace WorldBuilder
          * model it  will be (radius, longitude) in 2d and (radius, longitude,
          * latitude) in 3d.
          */
-        virtual
         std::array<double,3> cartesian_to_natural_coordinates(const std::array<double,3> &position) const override final;
 
         /**
@@ -93,7 +90,6 @@ namespace WorldBuilder
          * coordinate system which is most 'natural' to the geometry model into
          * Cartesian coordinates.
          */
-        virtual
         std::array<double,3> natural_to_cartesian_coordinates(const std::array<double,3> &position) const override final;
 
 
@@ -101,7 +97,6 @@ namespace WorldBuilder
          * Computes the distance between two points which are on the same depth.
          * The input is two 3d points at that depth. It is implemented as the
          */
-        virtual
         double distance_between_points_at_same_depth(const Point<3> &point_1, const Point<3> &point_2) const override final;
 
 

--- a/include/world_builder/coordinate_systems/spherical.h
+++ b/include/world_builder/coordinate_systems/spherical.h
@@ -60,13 +60,12 @@ namespace WorldBuilder
         /**
          * declare and read in the world builder file into the parameters class
          */
-        virtual
         void parse_entries(Parameters &prm) override final;
+
 
         /**
          * Returns what the natural coordinate system for this Coordinate System is.
          */
-        virtual
         CoordinateSystem natural_coordinate_system() const override final;
 
         /**
@@ -74,7 +73,6 @@ namespace WorldBuilder
          * the domain.
          * \sa DepthMethod
          */
-        virtual
         DepthMethod depth_method() const override final;
 
         /**
@@ -84,7 +82,6 @@ namespace WorldBuilder
          * model it  will be (radius, longitude) in 2d and (radius, longitude,
          * latitude) in 3d.
          */
-        virtual
         std::array<double,3> cartesian_to_natural_coordinates(const std::array<double,3> &position) const override final;
 
         /**
@@ -92,7 +89,6 @@ namespace WorldBuilder
          * coordinate system which is most 'natural' to the geometry model into
          * Cartesian coordinates.
          */
-        virtual
         std::array<double,3> natural_to_cartesian_coordinates(const std::array<double,3> &position) const override final;
 
 
@@ -106,7 +102,6 @@ namespace WorldBuilder
          * special case of the Vincenty formula for an ellipsoid with equal
          * major and minor axes (https://doi.org/10.1179/sre.1975.23.176.88).
          */
-        virtual
         double distance_between_points_at_same_depth(const Point<3> &point_1, const Point<3> &point_3) const override final;
 
         /**

--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -61,19 +61,17 @@ namespace WorldBuilder
         /**
          * declare and read in the world builder file into the parameters class
          */
-        virtual
-        void parse_entries(Parameters &prm) override;
+        void parse_entries(Parameters &prm) override final;
 
 
         /**
          * Returns a temperature based on the given position, depth in the model,
          * gravity and current temperature.
          */
-        virtual
         double temperature(const Point<3> &position,
                            const double depth,
                            const double gravity,
-                           double temperature) const override;
+                           double temperature) const override final;
 
         /**
          * Returns a value for the requests composition (0 is not present,
@@ -81,11 +79,10 @@ namespace WorldBuilder
          * the composition which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
         double composition(const Point<3> &position,
                            const double depth,
                            const unsigned int composition_number,
-                           double value) const override;
+                           double value) const override final;
 
 
 

--- a/include/world_builder/features/continental_plate_models/composition/uniform.h
+++ b/include/world_builder/features/continental_plate_models/composition/uniform.h
@@ -60,7 +60,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -68,7 +67,6 @@ namespace WorldBuilder
              * Returns a composition based on the given position, depth in the model,
              * gravity and current composition.
              */
-            virtual
             double get_composition(const Point<3> &position,
                                    const double depth,
                                    const unsigned int composition_number,

--- a/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/continental_plate_models/temperature/linear.h
+++ b/include/world_builder/features/continental_plate_models/temperature/linear.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/continental_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/continental_plate_models/temperature/uniform.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -70,10 +70,10 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         virtual
-        double (temperature)(const Point<3> &position,
-                             const double depth,
-                             const double gravity,
-                             double temperature) const override final;
+        double temperature(const Point<3> &position,
+                           const double depth,
+                           const double gravity,
+                           double temperature) const override final;
 
         /**
          * Returns a value for the requests composition (0 is not present,
@@ -82,10 +82,10 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         virtual
-        double (composition)(const Point<3> &position,
-                             const double depth,
-                             const unsigned int composition_number,
-                             double composition_value) const override final;
+        double composition(const Point<3> &position,
+                           const double depth,
+                           const unsigned int composition_number,
+                           double composition_value) const override final;
 
 
 

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -62,14 +62,12 @@ namespace WorldBuilder
         /**
          * declare and read in the world builder file into the parameters class
          */
-        virtual
         void parse_entries(Parameters &prm) override final;
 
         /**
          * Returns a temperature based on the given position, depth in the model,
          * gravity and current temperature.
          */
-        virtual
         double temperature(const Point<3> &position,
                            const double depth,
                            const double gravity,
@@ -81,7 +79,6 @@ namespace WorldBuilder
          * the composition which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
         double composition(const Point<3> &position,
                            const double depth,
                            const unsigned int composition_number,

--- a/include/world_builder/features/fault_models/composition/uniform.h
+++ b/include/world_builder/features/fault_models/composition/uniform.h
@@ -60,7 +60,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -68,7 +67,6 @@ namespace WorldBuilder
              * Returns a composition based on the given position, depth in the model,
              * gravity and current composition.
              */
-            virtual
             double get_composition(const Point<3> &position,
                                    const double depth,
                                    const unsigned int composition_number,

--- a/include/world_builder/features/fault_models/temperature/adiabatic.h
+++ b/include/world_builder/features/fault_models/temperature/adiabatic.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/fault_models/temperature/linear.h
+++ b/include/world_builder/features/fault_models/temperature/linear.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/fault_models/temperature/uniform.h
+++ b/include/world_builder/features/fault_models/temperature/uniform.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -61,19 +61,19 @@ namespace WorldBuilder
         /**
          * declare and read in the world builder file into the parameters class
          */
-        virtual
         void parse_entries(Parameters &prm) override final;
+
 
 
         /**
          * Returns a temperature based on the given position, depth in the model,
          * gravity and current temperature.
          */
-        virtual
         double temperature(const Point<3> &position,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
+
 
         /**
          * Returns a value for the requests composition (0 is not present,
@@ -81,11 +81,11 @@ namespace WorldBuilder
          * the composition which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
         double composition(const Point<3> &position,
                            const double depth,
                            const unsigned int composition_number,
                            double value) const override final;
+
 
 
 

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -82,10 +82,10 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         virtual
-        double (composition)(const Point<3> &position,
-                             const double depth,
-                             const unsigned int composition_number,
-                             double value) const override final;
+        double composition(const Point<3> &position,
+                           const double depth,
+                           const unsigned int composition_number,
+                           double value) const override final;
 
 
 

--- a/include/world_builder/features/mantle_layer_models/composition/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/composition/uniform.h
@@ -60,7 +60,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -68,7 +67,6 @@ namespace WorldBuilder
              * Returns a composition based on the given position, depth in the model,
              * gravity and current composition.
              */
-            virtual
             double get_composition(const Point<3> &position,
                                    const double depth,
                                    const unsigned int composition_number,

--- a/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/mantle_layer_models/temperature/linear.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/linear.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/mantle_layer_models/temperature/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/uniform.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -60,19 +60,19 @@ namespace WorldBuilder
         /**
          * declare and read in the world builder file into the parameters class
          */
-        virtual
         void parse_entries(Parameters &prm) override final;
+
 
 
         /**
          * Returns a temperature based on the given position, depth in the model,
          * gravity and current temperature.
          */
-        virtual
         double temperature(const Point<3> &position,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
+
 
         /**
          * Returns a value for the requests composition (0 is not present,
@@ -80,11 +80,11 @@ namespace WorldBuilder
          * the composition which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
         double composition(const Point<3> &position,
                            const double depth,
                            const unsigned int composition_number,
                            double value) const override final;
+
 
 
 

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -69,10 +69,10 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         virtual
-        double (temperature)(const Point<3> &position,
-                             const double depth,
-                             const double gravity,
-                             double temperature) const override final;
+        double temperature(const Point<3> &position,
+                           const double depth,
+                           const double gravity,
+                           double temperature) const override final;
 
         /**
          * Returns a value for the requests composition (0 is not present,
@@ -81,10 +81,10 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         virtual
-        double (composition)(const Point<3> &position,
-                             const double depth,
-                             const unsigned int composition_number,
-                             double value) const override final;
+        double composition(const Point<3> &position,
+                           const double depth,
+                           const unsigned int composition_number,
+                           double value) const override final;
 
 
 

--- a/include/world_builder/features/oceanic_plate_models/composition/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/uniform.h
@@ -60,7 +60,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -68,7 +67,6 @@ namespace WorldBuilder
              * Returns a composition based on the given position, depth in the model,
              * gravity and current composition.
              */
-            virtual
             double get_composition(const Point<3> &position,
                                    const double depth,
                                    const unsigned int composition_number,

--- a/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/oceanic_plate_models/temperature/linear.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/linear.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -71,10 +71,10 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         virtual
-        double (temperature)(const Point<3> &position,
-                             const double depth,
-                             const double gravity,
-                             double temperature) const override final;
+        double temperature(const Point<3> &position,
+                           const double depth,
+                           const double gravity,
+                           double temperature) const override final;
 
         /**
          * Returns a value for the requests composition (0 is not present,
@@ -83,10 +83,10 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         virtual
-        double (composition)(const Point<3> &position,
-                             const double depth,
-                             const unsigned int composition_number,
-                             double composition_value) const override final;
+        double composition(const Point<3> &position,
+                           const double depth,
+                           const unsigned int composition_number,
+                           double composition_value) const override final;
 
 
 

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -62,19 +62,19 @@ namespace WorldBuilder
         /**
          * declare and read in the world builder file into the parameters class
          */
-        virtual
         void parse_entries(Parameters &prm) override final;
+
 
 
         /**
          * Returns a temperature based on the given position, depth in the model,
          * gravity and current temperature.
          */
-        virtual
         double temperature(const Point<3> &position,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
+
 
         /**
          * Returns a value for the requests composition (0 is not present,
@@ -82,7 +82,6 @@ namespace WorldBuilder
          * the composition which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
         double composition(const Point<3> &position,
                            const double depth,
                            const unsigned int composition_number,

--- a/include/world_builder/features/subducting_plate_models/composition/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/composition/uniform.h
@@ -60,7 +60,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -68,7 +67,6 @@ namespace WorldBuilder
              * Returns a composition based on the given position, depth in the model,
              * gravity and current composition.
              */
-            virtual
             double get_composition(const Point<3> &position,
                                    const double depth,
                                    const unsigned int composition_number,

--- a/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/subducting_plate_models/temperature/linear.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/linear.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/features/subducting_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/uniform.h
@@ -61,7 +61,6 @@ namespace WorldBuilder
             /**
              * declare and read in the world builder file into the parameters class
              */
-            virtual
             void parse_entries(Parameters &prm) override final;
 
 
@@ -69,7 +68,6 @@ namespace WorldBuilder
              * Returns a temperature based on the given position, depth in the model,
              * gravity and current temperature.
              */
-            virtual
             double get_temperature(const Point<3> &position,
                                    const double depth,
                                    const double gravity,

--- a/include/world_builder/types/array.h
+++ b/include/world_builder/types/array.h
@@ -62,7 +62,6 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
                           const std::string &documentation) const override final;

--- a/include/world_builder/types/bool.h
+++ b/include/world_builder/types/bool.h
@@ -53,7 +53,6 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
                           const std::string &documentation) const override final;

--- a/include/world_builder/types/double.h
+++ b/include/world_builder/types/double.h
@@ -52,7 +52,6 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
                           const std::string &documentation) const override final;

--- a/include/world_builder/types/object.h
+++ b/include/world_builder/types/object.h
@@ -59,10 +59,9 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
-                          const std::string &documentation) const  override final;
+                          const std::string &documentation) const override final;
 
 
         /**

--- a/include/world_builder/types/plugin_system.h
+++ b/include/world_builder/types/plugin_system.h
@@ -58,7 +58,6 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
                           const std::string &documentation) const override final;

--- a/include/world_builder/types/point.h
+++ b/include/world_builder/types/point.h
@@ -68,7 +68,6 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
                           const std::string &documentation) const override final;

--- a/include/world_builder/types/segment.h
+++ b/include/world_builder/types/segment.h
@@ -68,7 +68,6 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
                           const std::string &documentation) const override final;
@@ -85,7 +84,7 @@ namespace WorldBuilder
         std::unique_ptr<Types::Interface> composition_plugin_system;
 
       protected:
-        Segment *clone_impl() const  override final
+        Segment *clone_impl() const override final
         {
           return new Segment(*this);
         };
@@ -128,7 +127,6 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
                           const std::string &documentation) const override final;

--- a/include/world_builder/types/string.h
+++ b/include/world_builder/types/string.h
@@ -76,7 +76,6 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
                           const std::string &documentation) const override final;
@@ -89,7 +88,7 @@ namespace WorldBuilder
 
 
       protected:
-        String *clone_impl() const  override final
+        String *clone_impl() const override final
         {
           return new String(*this);
         };

--- a/include/world_builder/types/unsigned_int.h
+++ b/include/world_builder/types/unsigned_int.h
@@ -53,7 +53,6 @@ namespace WorldBuilder
         /**
          * Todo
          */
-        virtual
         void write_schema(Parameters &prm,
                           const std::string &name,
                           const std::string &documentation) const override final;


### PR DESCRIPTION
the find and replace left some brackets around function names. Also remove virtual specifier where there is a final specifier, add a few more final specifiers and remove some extra spaces.

So, `virtual` is only used in the base class, and should never be used in combination with override or final. Derived classes use either `override` if they are not final or `override final` if they are final. The `override final` is not just `final` mostly to avoid some compiler warnings, although there also seem some discussion whether it is better or not.

Some further reading:
https://en.cppreference.com/w/cpp/language/virtual
https://stackoverflow.com/questions/39932391/virtual-override-or-both-c
