### PR TITLE
fix warning in a specific version of gcc 5.4.0.

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -649,7 +649,7 @@ namespace internal
             hasDependencies_ = true;
             for (ConstMemberIterator itr = dependencies->MemberBegin(); itr != dependencies->MemberEnd(); ++itr)
               {
-                SizeType sourceIndex;
+                SizeType sourceIndex = 0;
                 if (FindPropertyIndex(itr->name, &sourceIndex))
                   {
                     if (itr->value.IsArray())
@@ -658,7 +658,7 @@ namespace internal
                         std::memset(properties_[sourceIndex].dependencies, 0, sizeof(bool)* propertyCount_);
                         for (ConstValueIterator targetItr = itr->value.Begin(); targetItr != itr->value.End(); ++targetItr)
                           {
-                            SizeType targetIndex;
+                            SizeType targetIndex = 0;
                             if (FindPropertyIndex(*targetItr, &targetIndex))
                               properties_[sourceIndex].dependencies[targetIndex] = true;
                           }


### PR DESCRIPTION
we are not sure why, but when putting version 0.4.0 in aspect (see https://github.com/geodynamics/aspect/pull/3546) one of the two gcc 5.4.0 compilers generated a warning for line 652 of include/rapidjason/schema.h, hitting the flag Werror=maybe-uninitialized. The warning is a false positive, and I have not been able to reproduce it with any of the other compilers in the wb test suite. But since the fix is trivial, I implement it here.