### PR TITLE
remove using namespace from include file

### DIFF
--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -27,8 +27,6 @@
 #include <world_builder/parameters.h>
 #include <world_builder/point.h>
 
-using namespace std;
-
 namespace WorldBuilder
 {
   class World;
@@ -150,7 +148,7 @@ namespace WorldBuilder
          * number of original coordinates, before adding
          * more automatically.
          */
-        size_t original_number_of_coordinates;
+        std::size_t original_number_of_coordinates;
 
         /**
          * The coordinates at the surface of the feature

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -36,6 +36,7 @@
 
 #include "glm/glm.h"
 
+using namespace std;
 
 namespace WorldBuilder
 {

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -39,7 +39,7 @@
 
 #include "glm/glm.h"
 
-
+using namespace std;
 
 namespace WorldBuilder
 {

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -137,7 +137,7 @@ namespace WorldBuilder
                                                                              ? 0
                                                                              :
                                                                              static_cast<unsigned>(parameters.GetErrorOffset())-5,
-                                                                             (static_cast<unsigned>(parameters.GetErrorOffset()) + 10 > json_input_stream_error.seekg(0,ios::end).tellg()
+                                                                             (static_cast<unsigned>(parameters.GetErrorOffset()) + 10 > json_input_stream_error.seekg(0,std::ios::end).tellg()
                                                                               ?
                                                                               static_cast<unsigned>(json_input_stream.tellg())-static_cast<unsigned>(parameters.GetErrorOffset())
                                                                               :

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -541,7 +541,7 @@ TEST_CASE("WorldBuilder Utilities: Point in polygon")
 TEST_CASE("WorldBuilder Utilities: Natural Coordinate")
 {
   // Cartesian
-  unique_ptr<CoordinateSystems::Interface> cartesian(CoordinateSystems::Interface::create("cartesian",NULL));
+  std::unique_ptr<CoordinateSystems::Interface> cartesian(CoordinateSystems::Interface::create("cartesian",NULL));
 
   // Test the natural coordinate system
   Utilities::NaturalCoordinate nca1(std::array<double,3> {{1,2,3}},*cartesian);
@@ -555,7 +555,7 @@ TEST_CASE("WorldBuilder Utilities: Natural Coordinate")
   CHECK(ncp1.get_depth_coordinate() == Approx(3.0));
 
 
-  unique_ptr<CoordinateSystems::Interface> spherical(CoordinateSystems::Interface::create("spherical",NULL));
+  std::unique_ptr<CoordinateSystems::Interface> spherical(CoordinateSystems::Interface::create("spherical",NULL));
 
   // Test the natural coordinate system
   Utilities::NaturalCoordinate nsa1(std::array<double,3> {{1,2,3}},*spherical);
@@ -826,7 +826,7 @@ TEST_CASE("WorldBuilder Coordinate Systems: Interface")
                     Contains("Internal error: Plugin with name '!not_implemented_coordinate_system!' is not found. "
                              "The size of factories is "));
 
-  unique_ptr<CoordinateSystems::Interface> interface(CoordinateSystems::Interface::create("cartesian",&world));
+  std::unique_ptr<CoordinateSystems::Interface> interface(CoordinateSystems::Interface::create("cartesian",&world));
 
   interface->declare_entries(world.parameters, "", {});
 
@@ -839,7 +839,7 @@ TEST_CASE("WorldBuilder Coordinate Systems: Interface")
 
 TEST_CASE("WorldBuilder Coordinate Systems: Cartesian")
 {
-  unique_ptr<CoordinateSystems::Interface> cartesian(CoordinateSystems::Interface::create("cartesian",NULL));
+  std::unique_ptr<CoordinateSystems::Interface> cartesian(CoordinateSystems::Interface::create("cartesian",NULL));
 
   //todo:fix
   //cartesian->declare_entries();
@@ -868,7 +868,7 @@ TEST_CASE("WorldBuilder Coordinate Systems: Spherical")
 
   WorldBuilder::World world(file_name);
 
-  unique_ptr<CoordinateSystems::Interface> spherical(CoordinateSystems::Interface::create("spherical", &world));
+  std::unique_ptr<CoordinateSystems::Interface> spherical(CoordinateSystems::Interface::create("spherical", &world));
 
   world.parameters.enter_subsection("coordinate system");
   {


### PR DESCRIPTION
Remove "using namespace std" from features/interface.h as this puts many
symbols into the global namespace.