### PR TITLE
Add new policy needed for cmake 3.18.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ if(POLICY CMP0086)
   cmake_policy(SET CMP0086 NEW)
 endif()
 
+if(POLICY CMP0058)
+  cmake_policy(SET CMP0058 NEW)
+endif()
+
 # load in version info and export it
 SET(WORLD_BUILDER_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 INCLUDE("${CMAKE_SOURCE_DIR}/cmake/version.cmake")


### PR DESCRIPTION
Found this while working on making the world builder a separate automatically compiled cmake project inaspect.