### PR TITLE
fix cmake old limit from version 2.8.12 to 2.8.13.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,9 +245,9 @@ endif()
 if (NOT MSVC AND NOT APPLE)
    #TODO: if other compiles need to be threaded, see https://computing.llnl.gov/tutorials/pthreads/#Compiling to add the correct cases.
    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER MATCHES "[Cc]lang")
-      # Preventing issues with older cmake compilers (<2.8.11) which do not support VERSION_GREATER_EQUAL
-      # cmake vesrion 3.12.0 introduces COMPILE_LANGUAGE:FORTAN, otherwise this would be >=2.8.11
-      if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12") 
+      # Preventing issues with older cmake compilers (<2.8.12) which do not support VERSION_GREATER_EQUAL
+      # cmake vesrion 3.12.0 introduces COMPILE_LANGUAGE:FORTAN, otherwise this would be >=2.8.12
+      if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.13")
         SET(WB_COMPILER_OPTIONS_PRIVATE -pedantic -fPIC -Wall -Wextra  
         $<$<COMPILE_LANGUAGE:CXX>:-std=c++11 -Wmost -Wconversion -Wunreachable-code -Wuninitialized -Wold-style-cast -Wshadow -Wfloat-equal -Wpointer-arith -Wwrite-strings 
         -Wsynth -Wsign-compare -Woverloaded-virtual -Wliteral-range -Wparentheses -Wunused-local-typedefs -Wcast-qual -fstrict-aliasing -Werror=uninitialized -Wundef 
@@ -260,16 +260,16 @@ if (NOT MSVC AND NOT APPLE)
    else()
       # gcc linux
 
-      # Preventing issues with older cmake compilers (<2.8.11) which do not support VERSION_GREATER_EQUAL
-      # cmake vesrion 3.12.0 introduces COMPILE_LANGUAGE:FORTAN, otherwise this would be >=2.8.11
-      if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12") 
+      # Preventing issues with older cmake compilers (<2.8.12) which do not support VERSION_GREATER_EQUAL
+      # cmake vesrion 3.12.0 introduces COMPILE_LANGUAGE:FORTAN, otherwise this would be >=2.8.12
+      if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.13")
         SET(WB_COMPILER_OPTIONS_PRIVATE -pedantic -fPIC -Wall -Wextra  $<$<COMPILE_LANGUAGE:CXX>:-std=c++11 -Wpointer-arith -Wwrite-strings -Wsynth -Wsign-compare -Woverloaded-virtual -Wno-placement-new -Wno-literal-suffix -Wno-parentheses -Wno-unused-local-typedefs -Wcast-qual -fstrict-aliasing -Wmaybe-uninitialized -Werror=maybe-uninitialized -Wparentheses -Wfloat-equal -Wundef -Wcast-align -Wlogical-op -Wmissing-declarations -Wredundant-decls -Wdiv-by-zero -Wdisabled-optimization -Wswitch-default -Wno-unused>)
       else()
         SET(WB_COMPILER_OPTIONS_PRIVATE "-std=c++11 -pedantic -fPIC -Wall -Wextra -Wpointer-arith -Wwrite-strings -Wsynth -Wsign-compare -Woverloaded-virtual -Wno-placement-new -Wno-literal-suffix -Wno-parentheses -Wno-unused-local-typedefs -Wcast-qual -fstrict-aliasing -Wmaybe-uninitialized -Werror=maybe-uninitialized -Wparentheses -Wfloat-equal -Wundef -Wcast-align -Wlogical-op -Wmissing-declarations -Wredundant-decls -Wdiv-by-zero -Wdisabled-optimization -Wswitch-default -Wno-unused>")
       endif()
 
       # adding flags is a hassle before cmake 3.12.0, and these flags are mostly useful for development, so just ignore those flags.
-      if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12") # Preventing issues with older cmake compilers which do not support VERSION_GREATER_EQUAL
+      if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.13") # Preventing issues with older cmake compilers which do not support VERSION_GREATER_EQUAL
         include(CheckCXXCompilerFlag)
 
         check_cxx_compiler_flag(-Wsuggest-override SUGGEST_OVERWRITE_CXX_COMPILE_FLAG)
@@ -311,7 +311,7 @@ endif()
 
 
 
-if(${CMAKE_VERSION} VERSION_LESS "2.8.12") 
+if(${CMAKE_VERSION} VERSION_LESS "2.8.13")
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WB_COMPILER_OPTIONS_INTERFACE} ${WB_COMPILER_OPTIONS_PRIVATE} ${WB_COMPILER_OPTIONS_PRIVATE_COVERAGE_OLD}")
 else()
   target_compile_options(WorldBuilder INTERFACE ${WB_COMPILER_OPTIONS_INTERFACE} PRIVATE ${WB_COMPILER_OPTIONS_PRIVATE} ${WB_COMPILER_OPTIONS_PRIVATE_COVERAGE_NEW})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ foreach(test_source ${UNIT_TEST_SOURCES})
   # Add compile target
   add_executable(${test_name} ${test_source})
 
-  if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.12") # Preventing issues with older cmake compilers which do not support VERSION_GREATER_EQUAL
+  if(NOT ${CMAKE_VERSION} VERSION_LESS "2.8.13") # Preventing issues with older cmake compilers which do not support VERSION_GREATER_EQUAL
     target_compile_options(${test_name} INTERFACE ${WB_COMPILER_OPTIONS_INTERFACE} PRIVATE ${WB_COMPILER_OPTIONS_PRIVATE})
   endif()
 


### PR DESCRIPTION
While testing pull request #214, I found that the limit for which cmake version supports the required cmake language features is in practice on subversion higher than I thought. This fixes the problem by using the old style up to cmake version 2.8.13. 