### PR TITLE
Fix bug in subducting slab plate model

### DIFF
--- a/source/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/features/subducting_plate_models/temperature/plate_model.cc
@@ -141,7 +141,7 @@ namespace WorldBuilder
 
         double
         PlateModel::get_temperature(const Point<3> &,
-                                    const double,
+                                    const double depth,
                                     const double gravity_norm,
                                     double temperature_,
                                     const double,
@@ -151,7 +151,6 @@ namespace WorldBuilder
           const double thickness_local = std::min(distance_from_planes.at("thicknessLocal"), max_depth);
           const double distance_from_plane = distance_from_planes.at("distanceFromPlane");
           const double distance_along_plane = distance_from_planes.at("distanceAlongPlane");
-          const double average_angle = distance_from_planes.at("averageAngle");
 
           if (distance_from_plane <= max_depth && distance_from_plane >= min_depth)
             {
@@ -159,10 +158,8 @@ namespace WorldBuilder
                * We now use the McKenzie (1970) equation to determine the
                * temperature inside the slab. The McKenzie equation was
                * designed for a straight slab, but we have a potentially
-               * curved slab. Because the angle is a required parameter, we
-               * first tried a local angle. This gave weird effects of
-               * apparent cooling when the slabs angle decreases. Now we
-               * use an average angle, which works better.
+               * curved slab. Since the angle is used to compute the depth
+               * of the point, we directly use the depth.
                */
               const double R = (density * specific_heat
                                 * (plate_velocity /(365.25 * 24.0 * 60.0 * 60.0))
@@ -170,26 +167,19 @@ namespace WorldBuilder
 
               WBAssert(!std::isnan(R), "Internal error: R is not a number: " << R << ".");
 
-              const double H = specific_heat
-                               / (thermal_expansion_coefficient * gravity_norm * thickness_local);
-
-              WBAssert(!std::isnan(H), "Internal error: H is not a number: " << H << ".");
-              WBAssert(std::isfinite(1/H), "Internal error: 1/H is not finite: " << 1/H << ".");
-
               const int n_sum = 500;
               // distance_from_plane can be zero, so protect division.
               double z_scaled = 1 - (std::fabs(distance_from_plane) < 2.0 * std::numeric_limits<double>::epsilon() ?
                                      2.0 * std::numeric_limits<double>::epsilon()
                                      :
-                                     distance_from_plane
-                                     / thickness_local);
+                                     distance_from_plane/thickness_local);
 
               // distance_along_plane can be zero, so protect division.
               double x_scaled = (std::fabs(distance_along_plane) < 2.0 * std::numeric_limits<double>::epsilon() ?
                                  2.0 *std::numeric_limits<double>::epsilon()
                                  :
-                                 distance_along_plane)
-                                / thickness_local;
+                                 distance_along_plane/thickness_local);
+
               // the paper uses `(x_scaled * sin(average_angle) - z_scaled * cos(average_angle))` to compute the
               // depth (execpt that you do not use average angles since they only have on angle). On recomputing
               // their result it seems to me (Menno) that it should have been `(1-z_scaled)` instead of `z_scaled`.
@@ -198,24 +188,13 @@ namespace WorldBuilder
               // If we want to specifiy the bottom temperature, because we have defined a linear temperture increase in the
               // mantle and/or oceanic plate, we have to switch off adiabatic heating for now.
               // Todo: there may be a better way to deal with this.
-              double temp = adiabatic_heating ? exp((distance_from_plane / thickness_local)/ H) : 1;
+              ;
+              double temp = adiabatic_heating ? std::exp(((thermal_expansion_coefficient * gravity_norm * depth) / specific_heat)) : 1;
 
-              WBAssert(!std::isnan(z_scaled), "Internal error: z_scaled is not a number: " << z_scaled << ".");
-              WBAssert(!std::isnan(x_scaled), "Internal error: x_scaled is not a number: " << x_scaled << ".");
               WBAssert(!std::isnan(temp), "Internal error: temp is not a number: " << temp << ". In exponent: "
-                       << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle)) / H
-                       << ", top: " << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle))
-                       << ", x_scaled = " << x_scaled << ", z_scaled = " << z_scaled << ", average_angle = " << average_angle);
-
-
-              WBAssert(std::isfinite(z_scaled), "Internal error: z_scaled is not finite: " << z_scaled << ".");
-              WBAssert(std::isfinite(x_scaled), "Internal error: x_scaled is not finite: " << x_scaled << ".");
-              WBAssert(std::isfinite(temp), "Internal error: temp is not finite: " << temp << ". In exponent: "
-                       << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle)) / H
-                       << ", top: " << (x_scaled * sin(average_angle) - z_scaled * cos(average_angle))
-                       << ", x_scaled = " << x_scaled << ", z_scaled = " << z_scaled << ", average_angle = " << average_angle
-                       << ", average_angle = " << average_angle << ", sin(average_angle) = " << sin(average_angle)
-                       << ", cos(average_angle) = " << cos(average_angle) << ", H = " << H << ", max_depth = " << max_depth);
+                       << std::exp(((thermal_expansion_coefficient * gravity_norm) / specific_heat) * depth)
+                       << ", thermal_expansion_coefficient = " << thermal_expansion_coefficient << ", gravity_norm = " << gravity_norm
+                       << ", specific_heat = "<< specific_heat << ", depth = " << depth );
 
               double sum=0;
               for (int i=1; i<=n_sum; i++)

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -1874,13 +1874,13 @@ TEST_CASE("WorldBuilder Features: Subducting Plate")
   CHECK(world1.temperature(position, 5, 10) == Approx(1554.3294579725)); // we are in the plate for sure (colder than anywhere in the mantle)
   CHECK(world1.temperature(position, 10, 10) == Approx(1511.0782994151)); // we are in the plate for sure (colder than anywhere in the mantle)
   CHECK(world1.temperature(position, 100, 10) == Approx(1050.2588653774)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 500, 10) == Approx(876.8637089978)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 1000, 10) == Approx(829.7197877204)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 5000, 10) == Approx(620.6827823798)); // we are in the plate for sure (colder than anywhere in the mantle)
-  CHECK(world1.temperature(position, 10e3, 10) == Approx(525.727843761));
-  CHECK(world1.temperature(position, 25e3, 10) == Approx(538.4605698191));
-  CHECK(world1.temperature(position, 50e3, 10) == Approx(751.6318639633));
-  CHECK(world1.temperature(position, 75e3, 10) == Approx(991.5852995579));
+  CHECK(world1.temperature(position, 500, 10) == Approx(876.8996655758)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 1000, 10) == Approx(829.7878359145)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 5000, 10) == Approx(620.9373458573)); // we are in the plate for sure (colder than anywhere in the mantle)
+  CHECK(world1.temperature(position, 10e3, 10) == Approx(526.1591705397));
+  CHECK(world1.temperature(position, 25e3, 10) == Approx(539.5656824584));
+  CHECK(world1.temperature(position, 50e3, 10) == Approx(754.7202618956));
+  CHECK(world1.temperature(position, 75e3, 10) == Approx(997.7030956234));
   CHECK(world1.temperature(position, 150e3, 10) == Approx(1668.6311660012));
   //CHECK(world1.temperature(position, std::sqrt(2) * 100e3 - 1, 10) == Approx(150.0));
   //CHECK(world1.temperature(position, std::sqrt(2) * 100e3 + 1, 10) == Approx(1664.6283561404));


### PR DESCRIPTION
This fixes a bug which was introduced in #125. The ideas and comments in that pull request are I think still correct about using the depth, but for some reason the depth was never actually used. This pull request makes sure that the depth is actually used. Since the changes where made for version 0.3.0, that is the only version affected by this bug.