### PR TITLE
set min xcode version from 10 to 11 since brew in complaining.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -218,7 +218,7 @@ matrix:
       os: osx
       compiler: 
         - clang
-      osx_image: xcode10
+      osx_image: xcode11
       env: 
          - MAKE_FILE_GENERATOR="Unix Makefiles"
          - MATRIX_EVAL="export PATH=$TRAVIS_ROOT/bin:$PATH && which clang && ls -lh /Applications/Xcode-10.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/ && ls -lh /Applications/Xcode-10.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ && brew install gcc || true  && brew link --overwrite gcc && brew install swig || true && export FC=gfortran" # && export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR/build/lib"
@@ -229,7 +229,7 @@ matrix:
       os: osx
       compiler: 
         - clang
-      osx_image: xcode10
+      osx_image: xcode11
       env: 
          - MAKE_FILE_GENERATOR="Unix Makefiles"
          - MATRIX_EVAL="export PATH=$TRAVIS_ROOT/bin:$PATH && which clang && brew install swig || true" 


### PR DESCRIPTION
Brew in the old osx versions has started to complain about xcode being too old. The problem could probably be solved by some fine tuning of the tester (and it should still be possible to install the world builder with xcode 10), but since osx doesn't seem to support old versions very well anyway, we will update the osx tester to xcode version 11. 