### PR TITLE
Add mastodon follow link to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Documentation](https://codedocs.xyz/GeodynamicWorldBuilder/WorldBuilder.svg)](https://codedocs.xyz/GeodynamicWorldBuilder/WorldBuilder/index.html)
 [![Coverage Status](https://coveralls.io/repos/github/GeodynamicWorldBuilder/WorldBuilder/badge.svg?branch=master)](https://coveralls.io/github/GeodynamicWorldBuilder/WorldBuilder?branch=master)
 [![codecov](https://codecov.io/gh/GeodynamicWorldBuilder/WorldBuilder/branch/master/graph/badge.svg)](https://codecov.io/gh/GeodynamicWorldBuilder/WorldBuilder)
+[![Mastodon Follow](https://img.shields.io/mastodon/follow/106136314313793382?domain=https%3A%2F%2Fsocial.mfraters.net&style=social)](https://social.mfraters.net/@world_builder)
 
 # The Geodynamic World Builder (GWB)
 ## What is the Geodynamic World Builder?

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ And cite the specific version of the software used. Version 0.3.0 can be cited a
 
 Menno Fraters and others. 2019, October 23. The Geodynamic World Builder v0.3.0. Zenodo. [https://doi.org/10.5281/zenodo.3900603](https://doi.org/10.5281/zenodo.3900603).
 
+## How can I follow the progress of this project
+There are multiple ways in which you can follow this project:
+ 1. Watch the repository on github. This will give you an update of what happening in the repository. This happens automatically and you can set it up to notify you for different kind of events. 
+ 2. Follow the [world builder Mastodon account](https://social.mfraters.net/@world_builder). This is a manually updated feed which updates when there are new release or major new features merged in the main branch. More general new related to the project may also be posted.
+ 3. Subscribe the the Mastodon RSS feed: https://social.mfraters.net/@world_builder.rss. This will show exactly the same information as the mastodon account, but you can use any RSS reader.
+ 4. Visit the [world builder website](https://geodynamicworldbuilder.github.io/). Besides all kind of useful information and links, it also contains a RSS feed viewer the world builder Mastodon account.


### PR DESCRIPTION
This pull request adds a link to the mastodon account for the world builder. 

I do not expect many people interested in the project having a mastodon (or any ActivityPub based account), but the main use case will be to keep the site a bit more up to date than before. I did that through including a feed from the world builder mastodon account into the website. I am planning to do posts for both releases and when major new features are merged into master. 

Besides that use case, I also like the fact that if people want to follow the project in a way which doesn't spam their email boxes which happens when you use follow the repository on github, there is now an easy way to do. You just need to get a [Mastodon account](https://joinmastodon.org/) or use the [rss feed](https://social.mfraters.net/@world_builder.rss) generated by mastodon. 