### PR TITLE
Split and improve the distance from function in preparation for contious slabs and faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Change minimum chame version fom 2.8.12 to 2.8.13. \[Menno Fraters; 2020-11-16; [#215](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/215)]
 - Change minimum xcode version to 11. \[Menno Fraters; 2020-12-10; [#217](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/217)]
 - Change changelog style to markdown based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). \[Menno Fraters; 2021-05-01; [#230](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/230),[#231](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/231)\]
+- Changed the underlying function which determines when you are inside a slab or a fault. This may slightly change the result, but the new result is more realistic I think. \[Menno Fraters; 2021-05-01; [#229](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/229)\]
 
 ### Fixed
 - Fixed namespaces, adding `WorldBuilder::` where needed. \[Timo Heister; 2020-08-10; [#205](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/205)] 

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -2953,6 +2953,22 @@ TEST_CASE("WorldBuilder Features: coordinate interpolation")
     position = {{624e3,200e3,800e3}};
     CHECK(world1.temperature(position, 10, 10) == Approx(1600));
     CHECK(world1.composition(position, 10, 0) == Approx(0.0));
+
+
+    position = {{925e3,625e3,800e3}};
+    CHECK(world1.temperature(position, 10, 10) == Approx(1600));
+    CHECK(world1.composition(position, 10, 0) == Approx(0.0));
+    position = {{925e3,625e3,800e3}};
+    CHECK(world1.temperature(position, 50e3, 10) == Approx(150));
+    CHECK(world1.composition(position, 50e3, 0) == Approx(1.0));
+
+
+    position = {{675e3,150e3,800e3}};
+    CHECK(world1.temperature(position, 10, 10) == Approx(1600));
+    CHECK(world1.composition(position, 10, 0) == Approx(0.0));
+    position = {{675e3,150e3,800e3}};
+    CHECK(world1.temperature(position, 150e3, 10) == Approx(1668.6311660012)); // This used to contain slab material, but not anymore.
+    CHECK(world1.composition(position, 150e3, 0) == Approx(0.0));
   }
 
   {


### PR DESCRIPTION
Split the distance from function in a part which searches for the closed point on the surface and which computes the distance on the plane based on that. This does change the results in some corner cases, but the change is an improvement in my opinion.

For the test case `interpolation_none_cartesian.wb` the difference is the following: 
old:
![old_interpolation_none_cartesian wb](https://user-images.githubusercontent.com/7631629/116760840-5c54dd00-aa16-11eb-8428-d9853d2b12a1.png)
new:
![new_interpolation_none_cartesian wb](https://user-images.githubusercontent.com/7631629/116760839-5bbc4680-aa16-11eb-97a5-b2f78c579a16.png)

The change is not necessarily due to the splitting itself, but due to stricter rules for which line segments is chosen. The old results can be retrieved not selecting only one option in the first part, and compute the distance from the planes for all line segments to which the check point is perpendicular and pick the closest one the the check point. The new scheme limits this early on in the process by only allowing the perpendicular point which is in 2d actually closest to the line to be used. As a side effect, this should also save some computation, since the distance to the plane only has to be computed once.

This is related to #130 