### PR TITLE
replace travis badge with github actions badge in readme.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Github CI
+name: tests
 
 on: [push, pull_request]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a047af8dae6e498b8900d0ccdd2b726b)](https://www.codacy.com/app/MFraters/WorldBuilder?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=GeodynamicWorldBuilder/WorldBuilder&amp;utm_campaign=Badge_Grade)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/8amaw31qwwlo33vs?svg=true)](https://ci.appveyor.com/project/MFraters/worldbuilder)
-[![Travis CI Build Status](https://travis-ci.org/GeodynamicWorldBuilder/WorldBuilder.svg?branch=master)](https://travis-ci.org/GeodynamicWorldBuilder/WorldBuilder)
+[![actions](https://github.com/GeodynamicWorldBuilder/WorldBuilder/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/GeodynamicWorldBuilder/WorldBuilder/actions?query=branch%3Amaster)
 [![Documentation](https://codedocs.xyz/GeodynamicWorldBuilder/WorldBuilder.svg)](https://codedocs.xyz/GeodynamicWorldBuilder/WorldBuilder/index.html)
 [![Coverage Status](https://coveralls.io/repos/github/GeodynamicWorldBuilder/WorldBuilder/badge.svg?branch=master)](https://coveralls.io/github/GeodynamicWorldBuilder/WorldBuilder?branch=master)
 [![codecov](https://codecov.io/gh/GeodynamicWorldBuilder/WorldBuilder/branch/master/graph/badge.svg)](https://codecov.io/gh/GeodynamicWorldBuilder/WorldBuilder)


### PR DESCRIPTION
Since Travis is not use anymore, lets remove the badge and replace it with a github actions badge of the master branch. Also shorten the name of the github actions test for the badge. 