### PR TITLE
Fix non unity build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,43 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: ctest -VV -C ${{ matrix.build_type }}
+
+
+  test_linux_non_unity_no_optional_dependencies:
+    needs: test_indentation
+    strategy: 
+      fail-fast: false
+      matrix: 
+        os: ['ubuntu-latest']
+        build_type: ['Debug']
+      
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS=-Werror -DWB_UNITY_BUILD=OFF
+
+    - name: Build gwb
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Install gwb Linux and macOS
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: sudo cmake --install . --config ${{ matrix.build_type }}
+
+    - name: Test gwb
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: ctest -VV -C ${{ matrix.build_type }}
       
 
   test_windows:

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -26,6 +26,7 @@
 #include <world_builder/world.h>
 #include <world_builder/parameters.h>
 #include <world_builder/point.h>
+#include <world_builder/utilities.h>
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/utilities.h
+++ b/include/world_builder/features/utilities.h
@@ -74,4 +74,5 @@ namespace WorldBuilder
     }
   }
 }
+
 #endif

--- a/source/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/features/fault_models/grains/random_uniform_distribution.cc
@@ -17,6 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
+
 #include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>

--- a/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
+++ b/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
@@ -17,6 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
+
 #include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>

--- a/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -17,6 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
+
 #include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>

--- a/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -17,6 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
+
 #include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>


### PR DESCRIPTION
Found this issue when compiling with aspect. There are still some warnings when compiling with aspect but I can't reproduce them with a standalone build of the world builder yet. Since these are breaking the compilation for non-unity builds, I think it is important to merge then quickly.

This also adds a non-unity build to the tester to prevent this issue in the future.