### PR TITLE
Clarify namespace interpolationtype.

### DIFF
--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -148,7 +148,7 @@ namespace WorldBuilder
         /**
          * The type of interpolation used to get the line position between the points.
          */
-        Utilities::InterpolationType interpolation_type;
+        WorldBuilder::Utilities::InterpolationType interpolation_type;
 
         /**
          * number of original coordinates, before adding


### PR DESCRIPTION
Found issue in #255. Fixing failing build when `MAKE_UNITY_BUILD_BATCH_SIZE` is set to 10.