### PR TITLE
Change fault linear entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Changed the underlying function which determines when you are inside a slab or a fault. This may slightly change the result, but the new result is more realistic I think. \[Menno Fraters; 2021-05-01; [#229](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/229)\]
 - The Vizualizer now uses compressed output by default. This decreases the file size and increases perforamnce. \[Menno Fraters; 2021-05-22; [#239](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/239)\]
 - The Vizualizer buffers output before it writes it to a file. This increases performance. \[Menno Fraters; 2021-05-22; [#239](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/239)\]
+- In the fault temperature model linear, the entiry top temperature is changed to center temperature and the entry bottom temperature is changed to side temperature, since this represents the actual sides more accurately. \[Menno Fraters; 2021-07-09; [#260](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/260)\]
 
 ### Fixed
 - Fixed namespaces, adding `WorldBuilder::` where needed. \[Timo Heister; 2020-08-10; [#205](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/205)\] 

--- a/source/features/fault_models/temperature/linear.cc
+++ b/source/features/fault_models/temperature/linear.cc
@@ -65,12 +65,12 @@ namespace WorldBuilder
           prm.declare_entry("max distance fault center", Types::Double(std::numeric_limits<double>::max()),
                             "The minimum distance to the center of the fault. This determines where the linear temperature end.");
 
-          prm.declare_entry("top temperature", Types::Double(293.15),
-                            "The temperature at the top in degree Kelvin of this feature."
+          prm.declare_entry("center temperature", Types::Double(293.15),
+                            "The temperature at the center of this feature in degree Kelvin."
                             "If the value is below zero, the an adiabatic temperature is used.");
 
-          prm.declare_entry("bottom temperature", Types::Double(-1),
-                            "The temperature at the top in degree Kelvin of this feature. "
+          prm.declare_entry("side temperature", Types::Double(-1),
+                            "The temperature at the sides of this feature in degree Kelvin. "
                             "If the value is below zero, an adiabatic temperature is used.");
 
         }
@@ -82,8 +82,8 @@ namespace WorldBuilder
           max_depth = prm.get<double>("max distance fault center");
           WBAssert(max_depth >= min_depth, "max depth needs to be larger or equal to min depth.");
           operation = Utilities::string_operations_to_enum(prm.get<std::string>("operation"));
-          top_temperature = prm.get<double>("top temperature");
-          bottom_temperature = prm.get<double>("bottom temperature");
+          top_temperature = prm.get<double>("center temperature");
+          bottom_temperature = prm.get<double>("side temperature");
         }
 
 

--- a/tests/data/fault_constant_angles_cartesian_2.wb
+++ b/tests/data/fault_constant_angles_cartesian_2.wb
@@ -6,7 +6,7 @@
 [
      {"model":"fault", "name":"First subducting plate", "coordinates":[[0e3,500e3],[500e3,500e3],[501e3,500e3],[1000e3,750e3]], "dip point":[2200e3,2200e3],
          "segments":[{"length":200e3, "thickness":[100e3,100e3], "angle":[45,45], 
-                      "temperature models":[{"model":"linear", "max distance fault center":100e3, "top temperature":1, "bottom temperature":7}],
+                      "temperature models":[{"model":"linear", "max distance fault center":100e3, "center temperature":1, "side temperature":7}],
                       "composition models":[{"model":"uniform", "compositions":[3]}]}, 
                      {"length":200e3, "thickness":[100e3,100e3], "angle":[60,60], "temperature models":[{"model":"uniform", "temperature":2}]}, 
                      {"length":150e3, "thickness":[100e3,100e3], "angle":[90,90], "temperature models":[{"model":"uniform", "temperature":3}]}],

--- a/tests/visualization/fault.wb
+++ b/tests/visualization/fault.wb
@@ -27,7 +27,7 @@
               {"length":200e3, "thickness":[100e3, 50e3], "angle":[0,45]},
               {"length":200e3, "thickness":[50e3], "angle":[45], "temperature models":[{"model":"uniform", "temperature":650}]}
             ],
-            "temperature models":[{"model":"linear", "max distance fault center":100e3, "top temperature":650, "bottom temperature":550}]
+            "temperature models":[{"model":"linear", "max distance fault center":100e3, "center temperature":650, "side temperature":550}]
          }
        ],
        "temperature models":[{"model":"uniform", "temperature":600}],


### PR DESCRIPTION
The linear temperature model in the fault feature has the entries `top temperature` and `bottom temperature`. These should be named `center temperature` and `side temperature` since the fault feature uses the distance from the center to the sides.