### PR TITLE
Stabelize github linux mpi tester

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,6 +200,7 @@ jobs:
     - name:  Install optional dependencies
       run:   |
          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt update;
             sudo apt install gfortran swig python3-setuptools openmpi-bin
          elif [ "$RUNNER_OS" == "macOS" ]; then
             sudo brew install open-mpi || true    


### PR DESCRIPTION
Stabelize github linux mpi tester by using apt update. Same solution as for #262, but it didn't seem needed at this location. Turns out it is needed.