### PR TITLE
fix spherical_slab_interpolation_simple_CMS to slabs instead of faults.

### DIFF
--- a/tests/app/spherical_slab_interpolation_simple_CMS.wb
+++ b/tests/app/spherical_slab_interpolation_simple_CMS.wb
@@ -15,7 +15,7 @@
        "temperature models":[{"model":"uniform", "temperature":600}]
     },
     {
-       "model":"fault", "name":"Big out model slab", "dip point":[-10,10],
+       "model":"subducting plate", "name":"Out model slab", "dip point":[-10,10],
        "coordinates":[[120,120],[130,130],[145,135],[165,165]], 
        "segments":
        [
@@ -25,7 +25,7 @@
        "temperature models":[{"model":"uniform", "temperature":600}]
     },
     {
-       "model":"fault", "name":"Big out model slab", "dip point":[10,-10],
+       "model":"subducting plate", "name":"Out model slab", "dip point":[10,-10],
        "coordinates":[[120,120],[130,130],[145,135],[165,165]], 
        "segments":
        [


### PR DESCRIPTION
Fixing a mistake made in #266. Currently using faults in a slab benchmark, which are already benchmarked in the fault benchmark. So this fixes that.