### PR TITLE
reorganize readme to include FAQ section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ The Geodynamic World Builder(GWB) is an open source code library intended to set
 
 For more information see the the [GWB site](https://geodynamicworldbuilder.github.io/), see the automatically generated extensive [online User Manual](https://gwb.mfraters.net/manual/manual.pdf) or the automatically generated [code documentation](https://codedocs.xyz/GeodynamicWorldBuilder/WorldBuilder/index.html).
 
-## What do I do when I have a question or want to request a feature?
+## Frequently Asked Questions (FAQ)
+### What do I do when I have a question or want to request a feature?
 If you have a question about the code and you can not find the answer easily in the documentation or the question is already raised as an [issue](https://github.com/GeodynamicWorldBuilder/WorldBuilder/issues), please let us know by opening an [issue on github](https://github.com/GeodynamicWorldBuilder/WorldBuilder/issues/new). This is also the preferred method for asking for new features for GWB.
 
-## I found a mistake in the documentation or code, what should I do?
+### I found a mistake in the documentation or code, what should I do?
 Please do not keep it to yourself and let us know. Others will also profit from mistakes being found and fixed. Even if it is just a typo in the documentation feel free to raise an issue or, even better, make a pull request to fix the issue.
 
-## Is there a way to ask a quick question or chat with the developers or other users?
+### Is there a way to ask a quick question or chat with the developers or other users?
 We are now also experimenting with matrix chat (#gwb:matrix.org). [Matrix](matrix.org) is an open source distributed chat system. Since the main developer is already present on matrix, a special space has been created for the world builder allowing the option for multiple rooms. The space can be found [here](https://matrix.to/#/!vhukRUGUINnZOIutoQ:matrix.org). The matrix system is not limited to one client, but using the [Element](https://element.io) client is generally recommended. Element can be used as a dektop, mobile or web application. Feel free to join!
 
-## How to cite?
+### How to cite?
 The developers of the Geodynamic World Builder request that you cite the following publication:
 
 Fraters, M., Thieulot, C., van den Berg, A., and Spakman, W.: The Geodynamic World Builder: a solution for complex initial conditions in numerical modelling, Solid Earth, [https://doi.org/10.5194/se-10-1785-2019](https://doi.org/10.5194/se-10-1785-2019), 2019.
@@ -32,7 +33,7 @@ And cite the specific version of the software used. Version 0.4.0 can be cited a
 
 Menno Fraters and others. 2021, June 22. The Geodynamic World Builder v0.4.0. Zenodo. [https://doi.org/10.5281/zenodo.5014808](https://doi.org/10.5281/zenodo.5014808).
 
-## How can I follow the progress of this project
+### How can I follow the progress of this project?
 There are multiple ways in which you can follow this project:
  1. Watch the repository on github. This will give you an update of what happening in the repository. This happens automatically and you can set it up to notify you for different kind of events. 
  2. Follow the [world builder Mastodon account](https://social.mfraters.net/@world_builder). This is a manually updated feed which updates when there are new release or major new features merged in the main branch. More general new related to the project may also be posted.


### PR DESCRIPTION
I think this new organization with just two main sections is much clearer. Calling the questions a FAQ may be a bit of a stretch and a projection, but I think it is the best way of communicating the information.