### PR TITLE
Avoid map containers for parameter transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - The World Builder Visualizer will now use zlib compression for vtu files by default. If zlib is not available binary output will be used. \[Menno Fraters; 2021-06-26; [#282](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/282)\]
+- The return argument type of the distance_point_from_curved_planes function has been converted from a map to a struct, requiring a change in the plugin interfaces for 'fault_models' and 'subducting_plate_models', but significantly increasing the speed of the function and all functions that access its returned values. \[Rene Gassmoeller; 2021-06-27; [#289](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/289)\]
 
 ## [0.4.0]
 ### Added

--- a/include/world_builder/features/fault_models/composition/interface.h
+++ b/include/world_builder/features/fault_models/composition/interface.h
@@ -84,7 +84,7 @@ namespace WorldBuilder
                                    double composition,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const = 0;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/fault_models/composition/interface.h
+++ b/include/world_builder/features/fault_models/composition/interface.h
@@ -26,6 +26,7 @@
 #include <world_builder/world.h>
 #include <world_builder/parameters.h>
 #include <world_builder/point.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -84,7 +85,7 @@ namespace WorldBuilder
                                    double composition,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/fault_models/composition/uniform.h
+++ b/include/world_builder/features/fault_models/composition/uniform.h
@@ -73,7 +73,7 @@ namespace WorldBuilder
                                    double composition,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/fault_models/composition/uniform.h
+++ b/include/world_builder/features/fault_models/composition/uniform.h
@@ -73,7 +73,7 @@ namespace WorldBuilder
                                    double composition,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/fault_models/grains/interface.h
+++ b/include/world_builder/features/fault_models/grains/interface.h
@@ -85,7 +85,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const std::map<std::string,double> &distance_from_planes) const = 0;
+                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/fault_models/grains/interface.h
+++ b/include/world_builder/features/fault_models/grains/interface.h
@@ -26,6 +26,7 @@
 #include <world_builder/world.h>
 #include <world_builder/parameters.h>
 #include <world_builder/point.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -85,7 +86,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
+                       const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
@@ -90,7 +90,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const std::map<std::string,double> &distance_from_planes) const override final;
+                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
           private:
             // uniform grains submodule parameters

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
@@ -90,7 +90,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                       const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
           private:
             // uniform grains submodule parameters

--- a/include/world_builder/features/fault_models/grains/uniform.h
+++ b/include/world_builder/features/fault_models/grains/uniform.h
@@ -90,7 +90,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const std::map<std::string,double> &distance_from_planes) const override final;
+                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
           private:
             // uniform grains submodule parameters

--- a/include/world_builder/features/fault_models/grains/uniform.h
+++ b/include/world_builder/features/fault_models/grains/uniform.h
@@ -90,7 +90,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                       const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
           private:
             // uniform grains submodule parameters

--- a/include/world_builder/features/fault_models/temperature/adiabatic.h
+++ b/include/world_builder/features/fault_models/temperature/adiabatic.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/fault_models/temperature/adiabatic.h
+++ b/include/world_builder/features/fault_models/temperature/adiabatic.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/fault_models/temperature/interface.h
+++ b/include/world_builder/features/fault_models/temperature/interface.h
@@ -26,6 +26,7 @@
 #include <world_builder/world.h>
 #include <world_builder/parameters.h>
 #include <world_builder/point.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -84,7 +85,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/fault_models/temperature/interface.h
+++ b/include/world_builder/features/fault_models/temperature/interface.h
@@ -84,7 +84,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const = 0;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/fault_models/temperature/linear.h
+++ b/include/world_builder/features/fault_models/temperature/linear.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/fault_models/temperature/linear.h
+++ b/include/world_builder/features/fault_models/temperature/linear.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/fault_models/temperature/uniform.h
+++ b/include/world_builder/features/fault_models/temperature/uniform.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/fault_models/temperature/uniform.h
+++ b/include/world_builder/features/fault_models/temperature/uniform.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/composition/interface.h
+++ b/include/world_builder/features/subducting_plate_models/composition/interface.h
@@ -84,7 +84,7 @@ namespace WorldBuilder
                                    double composition,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const = 0;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/subducting_plate_models/composition/interface.h
+++ b/include/world_builder/features/subducting_plate_models/composition/interface.h
@@ -26,6 +26,7 @@
 #include <world_builder/world.h>
 #include <world_builder/parameters.h>
 #include <world_builder/point.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -84,7 +85,7 @@ namespace WorldBuilder
                                    double composition,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/subducting_plate_models/composition/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/composition/uniform.h
@@ -73,7 +73,7 @@ namespace WorldBuilder
                                    double composition,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/composition/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/composition/uniform.h
@@ -73,7 +73,7 @@ namespace WorldBuilder
                                    double composition,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/grains/interface.h
+++ b/include/world_builder/features/subducting_plate_models/grains/interface.h
@@ -85,7 +85,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const std::map<std::string,double> &distance_from_planes) const = 0;
+                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/subducting_plate_models/grains/interface.h
+++ b/include/world_builder/features/subducting_plate_models/grains/interface.h
@@ -26,6 +26,7 @@
 #include <world_builder/world.h>
 #include <world_builder/parameters.h>
 #include <world_builder/point.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -85,7 +86,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
+                       const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
@@ -90,7 +90,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const std::map<std::string,double> &distance_from_planes) const override final;
+                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
           private:
             // uniform grains submodule parameters

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
@@ -90,7 +90,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                       const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
           private:
             // uniform grains submodule parameters

--- a/include/world_builder/features/subducting_plate_models/grains/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/grains/uniform.h
@@ -90,7 +90,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const std::map<std::string,double> &distance_from_planes) const override final;
+                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
           private:
             // uniform grains submodule parameters

--- a/include/world_builder/features/subducting_plate_models/grains/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/grains/uniform.h
@@ -90,7 +90,7 @@ namespace WorldBuilder
                        WorldBuilder::grains grains,
                        const double feature_min_depth,
                        const double feature_max_depth,
-                       const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                       const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
           private:
             // uniform grains submodule parameters

--- a/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/temperature/interface.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/interface.h
@@ -26,6 +26,7 @@
 #include <world_builder/world.h>
 #include <world_builder/parameters.h>
 #include <world_builder/point.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -84,7 +85,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/subducting_plate_models/temperature/interface.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/interface.h
@@ -84,7 +84,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const = 0;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const = 0;
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/subducting_plate_models/temperature/linear.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/linear.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/temperature/linear.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/linear.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/uniform.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/features/subducting_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/uniform.h
@@ -74,7 +74,7 @@ namespace WorldBuilder
                                    double temperature,
                                    const double feature_min_depth,
                                    const double feature_max_depth,
-                                   const std::map<std::string,double> &distance_from_planes) const override final;
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const override final;
 
 
           private:

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -262,8 +262,8 @@ namespace WorldBuilder
       double distance_from_plane;
 
       /**
-       * The distance between edge of the plane and
-       * the point if the point is projected onto the curved plane.
+       * The distance between the the start of the first segment (usually at
+       * the surface) to the provided point following the (curved) plane.
        */
       double distance_along_plane;
 

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -249,6 +249,21 @@ namespace WorldBuilder
         std::vector<double> m_a, m_b, m_c, m_y;
     };
 
+    struct PointPlaneDistance
+    {
+      double distance_from_plane;
+      double distance_along_plane;
+      double fraction_of_section;
+      double fraction_of_segment;
+      size_t section;
+      size_t segment;
+      double average_angle;
+
+      // This is unrelated and should not be stored in here, but some
+      // plugins rely on this structure as temporary storage space.
+      double local_thickness;
+    };
+
     /**
      * Computes the distance of a point to a curved plane.
      * TODO: add more info on how this works/is implemented.
@@ -289,7 +304,7 @@ namespace WorldBuilder
      * the original number. Note that no whole numbers may be skiped. So for a list of 4 points,
      * {0,0.5,1,2} is allowed, but {0,2,3,4} is not.
      */
-    std::map<std::string,double> distance_point_from_curved_planes(const Point<3> &point,
+    PointPlaneDistance distance_point_from_curved_planes(const Point<3> &point,
                                                                    const Point<2> &reference_point,
                                                                    const std::vector<Point<2> > &point_list,
                                                                    const std::vector<std::vector<double> > &plane_segment_lengths,

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -339,7 +339,7 @@ namespace WorldBuilder
      * extra coordinates automatically, and still reference the user provided coordinates by
      * the original number. Note that no whole numbers may be skiped. So for a list of 4 points,
      * {0,0.5,1,2} is allowed, but {0,2,3,4} is not.
-     * 
+     *
      * The function returns a struct that contains which segment and section of the curved
      * planes the point is closest to, what fraction of those segment and section lies before
      * the point (looking from the start of segment/section), the distance
@@ -347,17 +347,17 @@ namespace WorldBuilder
      * and the average angle of the closest segment/section.
      */
     PointDistanceFromCurvedPlanes distance_point_from_curved_planes(const Point<3> &point,
-                                                                   const Point<2> &reference_point,
-                                                                   const std::vector<Point<2> > &point_list,
-                                                                   const std::vector<std::vector<double> > &plane_segment_lengths,
-                                                                   const std::vector<std::vector<Point<2> > > &plane_segment_angles,
-                                                                   const double start_radius,
-                                                                   const std::unique_ptr<CoordinateSystems::Interface> &coordinate_system,
-                                                                   const bool only_positive,
-                                                                   const InterpolationType interpolation_type,
-                                                                   const interpolation &x_spline,
-                                                                   const interpolation &y_spline,
-                                                                   std::vector<double> global_x_list = {});
+                                                                    const Point<2> &reference_point,
+                                                                    const std::vector<Point<2> > &point_list,
+                                                                    const std::vector<std::vector<double> > &plane_segment_lengths,
+                                                                    const std::vector<std::vector<Point<2> > > &plane_segment_angles,
+                                                                    const double start_radius,
+                                                                    const std::unique_ptr<CoordinateSystems::Interface> &coordinate_system,
+                                                                    const bool only_positive,
+                                                                    const InterpolationType interpolation_type,
+                                                                    const interpolation &x_spline,
+                                                                    const interpolation &y_spline,
+                                                                    std::vector<double> global_x_list = {});
 
 
 

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -249,14 +249,50 @@ namespace WorldBuilder
         std::vector<double> m_a, m_b, m_c, m_y;
     };
 
-    struct PointPlaneDistance
+    /**
+     * A struct that is used to hold the return values of the function
+     * distance_point_from_curved_planes(). See there for a documentation
+     * of the meaning of the member variables.
+     */
+    struct PointDistanceFromCurvedPlanes
     {
+      /**
+       * The shortest distance between point and plane.
+       */
       double distance_from_plane;
+
+      /**
+       * The distance between edge of the plane and
+       * the point if the point is projected onto the curved plane.
+       */
       double distance_along_plane;
+
+      /**
+       * The fraction of the section that lies before the projected point
+       * on the plane (when looking from the start point of the section).
+       */
       double fraction_of_section;
+
+      /**
+       * The fraction of the segment that lies before the projected point
+       * on the plane (when looking from the start point of the segment).
+       */
       double fraction_of_segment;
+
+      /**
+       * The number of the section that is closest to the point
+       */
       size_t section;
+
+      /**
+       * The number of the segment that is closest to the point.
+       */
       size_t segment;
+
+      /**
+       * The average dip angle of the plane at the location where the
+       * point is projected onto the plane.
+       */
       double average_angle;
 
       // This is unrelated and should not be stored in here, but some
@@ -303,8 +339,14 @@ namespace WorldBuilder
      * extra coordinates automatically, and still reference the user provided coordinates by
      * the original number. Note that no whole numbers may be skiped. So for a list of 4 points,
      * {0,0.5,1,2} is allowed, but {0,2,3,4} is not.
+     * 
+     * The function returns a struct that contains which segment and section of the curved
+     * planes the point is closest to, what fraction of those segment and section lies before
+     * the point (looking from the start of segment/section), the distance
+     * of the point from the plane and the distance of the point along the plane,
+     * and the average angle of the closest segment/section.
      */
-    PointPlaneDistance distance_point_from_curved_planes(const Point<3> &point,
+    PointDistanceFromCurvedPlanes distance_point_from_curved_planes(const Point<3> &point,
                                                                    const Point<2> &reference_point,
                                                                    const std::vector<Point<2> > &point_list,
                                                                    const std::vector<std::vector<double> > &plane_segment_lengths,

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -24,6 +24,7 @@
 
 #include <world_builder/parameters.h>
 #include <world_builder/grains.h>
+#include <world_builder/utilities.h>
 
 
 

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -24,7 +24,6 @@
 
 #include <world_builder/parameters.h>
 #include <world_builder/grains.h>
-#include <world_builder/utilities.h>
 
 
 

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -513,7 +513,7 @@ namespace WorldBuilder
           const double section_fraction = distance_from_planes.fraction_of_section;
           const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
           const size_t next_section = current_section + 1;
-          const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
+          const size_t current_segment = distance_from_planes.segment;
           //const size_t next_segment = current_segment + 1;
           const double segment_fraction = distance_from_planes.fraction_of_segment;
 
@@ -647,7 +647,7 @@ namespace WorldBuilder
           const double section_fraction = distance_from_planes.fraction_of_section;
           const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
           const size_t next_section = current_section + 1;
-          const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
+          const size_t current_segment = distance_from_planes.segment;
           //const size_t next_segment = current_segment + 1;
           const double segment_fraction = distance_from_planes.fraction_of_segment;
 

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -363,7 +363,7 @@ namespace WorldBuilder
           // todo: explain
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
-          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
+          WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -494,7 +494,7 @@ namespace WorldBuilder
           // todo: explain
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
-          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
+          WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -628,7 +628,7 @@ namespace WorldBuilder
           // todo: explain
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
-          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
+          WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -363,7 +363,7 @@ namespace WorldBuilder
           // todo: explain
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
-          std::map<std::string,double> distance_from_planes =
+          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -377,14 +377,14 @@ namespace WorldBuilder
                                                                        this->y_spline,
                                                                        one_dimensional_coordinates);
 
-          const double distance_from_plane = distance_from_planes["distanceFromPlane"];
-          const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
-          const double section_fraction = distance_from_planes["sectionFraction"];
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[static_cast<size_t>(distance_from_planes["section"])]));
+          const double distance_from_plane = distance_from_planes.distance_from_plane;
+          const double distance_along_plane = distance_from_planes.distance_along_plane;
+          const double section_fraction = distance_from_planes.fraction_of_section;
+          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
           const size_t next_section = current_section + 1;
-          const size_t current_segment = static_cast<size_t>(distance_from_planes["segment"]); // the original value was a unsigned in, converting it back.
+          const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
-          const double segment_fraction = distance_from_planes["segmentFraction"];
+          const double segment_fraction = distance_from_planes.fraction_of_segment;
 
           if (abs(distance_from_plane) < INFINITY || (distance_along_plane) < INFINITY)
             {
@@ -494,7 +494,7 @@ namespace WorldBuilder
           // todo: explain
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
-          std::map<std::string,double> distance_from_planes =
+          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -508,14 +508,14 @@ namespace WorldBuilder
                                                                        this->y_spline,
                                                                        one_dimensional_coordinates);
 
-          const double distance_from_plane = distance_from_planes["distanceFromPlane"];
-          const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
-          const double section_fraction = distance_from_planes["sectionFraction"];
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[static_cast<size_t>(distance_from_planes["section"])]));
+          const double distance_from_plane = distance_from_planes.distance_from_plane;
+          const double distance_along_plane = distance_from_planes.distance_along_plane;
+          const double section_fraction = distance_from_planes.fraction_of_section;
+          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
           const size_t next_section = current_section + 1;
-          const size_t current_segment = static_cast<size_t>(distance_from_planes["segment"]); // the original value was a unsigned int, turning it back.
+          const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
-          const double segment_fraction = distance_from_planes["segmentFraction"];
+          const double segment_fraction = distance_from_planes.fraction_of_segment;
 
           if (abs(distance_from_plane) < INFINITY || (distance_along_plane) < INFINITY)
             {
@@ -628,7 +628,7 @@ namespace WorldBuilder
           // todo: explain
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
-          std::map<std::string,double> distance_from_planes =
+          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -642,14 +642,14 @@ namespace WorldBuilder
                                                                        this->y_spline,
                                                                        one_dimensional_coordinates);
 
-          const double distance_from_plane = distance_from_planes["distanceFromPlane"];
-          const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
-          const double section_fraction = distance_from_planes["sectionFraction"];
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[static_cast<size_t>(distance_from_planes["section"])]));
+          const double distance_from_plane = distance_from_planes.distance_from_plane;
+          const double distance_along_plane = distance_from_planes.distance_along_plane;
+          const double section_fraction = distance_from_planes.fraction_of_section;
+          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
           const size_t next_section = current_section + 1;
-          const size_t current_segment = static_cast<size_t>(distance_from_planes["segment"]); // the original value was a unsigned int, turning it back.
+          const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
-          const double segment_fraction = distance_from_planes["segmentFraction"];
+          const double segment_fraction = distance_from_planes.fraction_of_segment;
 
           if (abs(distance_from_plane) < INFINITY || (distance_along_plane) < INFINITY)
             {

--- a/source/features/fault_models/composition/uniform.cc
+++ b/source/features/fault_models/composition/uniform.cc
@@ -95,10 +95,10 @@ namespace WorldBuilder
                                  double composition_,
                                  const double  /*feature_min_depth*/,
                                  const double  /*feature_max_depth*/,
-                                 const std::map<std::string,double> &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
         {
           double composition = composition_;
-          if (std::fabs(distance_from_plane.at("distanceFromPlane")) <= max_depth && std::fabs(distance_from_plane.at("distanceFromPlane")) >= min_depth)
+          if (std::fabs(distance_from_plane.distance_from_plane) <= max_depth && std::fabs(distance_from_plane.distance_from_plane) >= min_depth)
             {
               for (unsigned int i =0; i < compositions.size(); ++i)
                 {

--- a/source/features/fault_models/composition/uniform.cc
+++ b/source/features/fault_models/composition/uniform.cc
@@ -95,7 +95,7 @@ namespace WorldBuilder
                                  double composition_,
                                  const double  /*feature_min_depth*/,
                                  const double  /*feature_max_depth*/,
-                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_plane) const
         {
           double composition = composition_;
           if (std::fabs(distance_from_plane.distance_from_plane) <= max_depth && std::fabs(distance_from_plane.distance_from_plane) >= min_depth)

--- a/source/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/features/fault_models/grains/random_uniform_distribution.cc
@@ -116,7 +116,7 @@ namespace WorldBuilder
                                               WorldBuilder::grains grains_,
                                               const double /*feature_min_depth*/,
                                               const double /*feature_max_depth*/,
-                                              const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
+                                              const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const
         {
           WorldBuilder::grains  grains_local = grains_;
           if (std::fabs(distance_from_planes.distance_from_plane) <= max_depth && std::fabs(distance_from_planes.distance_from_plane) >= min_depth)

--- a/source/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/features/fault_models/grains/random_uniform_distribution.cc
@@ -116,10 +116,10 @@ namespace WorldBuilder
                                               WorldBuilder::grains grains_,
                                               const double /*feature_min_depth*/,
                                               const double /*feature_max_depth*/,
-                                              const std::map<std::string,double> &distance_from_planes) const
+                                              const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
         {
           WorldBuilder::grains  grains_local = grains_;
-          if (std::fabs(distance_from_planes.at("distanceFromPlane")) <= max_depth && std::fabs(distance_from_planes.at("distanceFromPlane")) >= min_depth)
+          if (std::fabs(distance_from_planes.distance_from_plane) <= max_depth && std::fabs(distance_from_planes.distance_from_plane) >= min_depth)
             {
               for (unsigned int i =0; i < compositions.size(); ++i)
                 {

--- a/source/features/fault_models/grains/uniform.cc
+++ b/source/features/fault_models/grains/uniform.cc
@@ -139,10 +139,10 @@ namespace WorldBuilder
                             WorldBuilder::grains grains_,
                             const double /*feature_min_depth*/,
                             const double /*feature_max_depth*/,
-                            const std::map<std::string,double> &distance_from_planes) const
+                            const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
         {
           WorldBuilder::grains  grains_local = grains_;
-          if (std::fabs(distance_from_planes.at("distanceFromPlane")) <= max_depth && std::fabs(distance_from_planes.at("distanceFromPlane")) >= min_depth)
+          if (std::fabs(distance_from_planes.distance_from_plane) <= max_depth && std::fabs(distance_from_planes.distance_from_plane) >= min_depth)
             {
               for (unsigned int i =0; i < compositions.size(); ++i)
                 {

--- a/source/features/fault_models/grains/uniform.cc
+++ b/source/features/fault_models/grains/uniform.cc
@@ -139,7 +139,7 @@ namespace WorldBuilder
                             WorldBuilder::grains grains_,
                             const double /*feature_min_depth*/,
                             const double /*feature_max_depth*/,
-                            const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
+                            const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const
         {
           WorldBuilder::grains  grains_local = grains_;
           if (std::fabs(distance_from_planes.distance_from_plane) <= max_depth && std::fabs(distance_from_planes.distance_from_plane) >= min_depth)

--- a/source/features/fault_models/grains/uniform.cc_backup
+++ b/source/features/fault_models/grains/uniform.cc_backup
@@ -89,7 +89,7 @@ namespace WorldBuilder
                                  WorldBuilder::grains grains_,
                                  const double ,
                                  const double ,
-                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_plane) const
         {
           double grains = grains_;
           if (std::fabs(distance_from_plane.distance_from_plane) <= max_depth && std::fabs(distance_from_plane.distance_from_plane)) >= min_depth)

--- a/source/features/fault_models/grains/uniform.cc_backup
+++ b/source/features/fault_models/grains/uniform.cc_backup
@@ -89,10 +89,10 @@ namespace WorldBuilder
                                  WorldBuilder::grains grains_,
                                  const double ,
                                  const double ,
-                                 const std::map<std::string,double> &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
         {
           double grains = grains_;
-          if (std::fabs(distance_from_plane.at("distanceFromPlane")) <= max_depth && std::fabs(distance_from_plane.at("distanceFromPlane")) >= min_depth)
+          if (std::fabs(distance_from_plane.distance_from_plane) <= max_depth && std::fabs(distance_from_plane.distance_from_plane)) >= min_depth)
             {
               for (unsigned int i =0; i < compositions.size(); ++i)
                 {

--- a/source/features/fault_models/temperature/adiabatic.cc
+++ b/source/features/fault_models/temperature/adiabatic.cc
@@ -129,7 +129,7 @@ namespace WorldBuilder
                                    double temperature_,
                                    const double  /*feature_min_depth*/,
                                    const double  /*feature_max_depth*/,
-                                   const std::map<std::string,double> & /*distance_from_planes*/) const
+                                   const WorldBuilder::Utilities::PointPlaneDistance & /*distance_from_planes*/) const
         {
 
           if (depth <= max_depth && depth >= min_depth)

--- a/source/features/fault_models/temperature/adiabatic.cc
+++ b/source/features/fault_models/temperature/adiabatic.cc
@@ -129,7 +129,7 @@ namespace WorldBuilder
                                    double temperature_,
                                    const double  /*feature_min_depth*/,
                                    const double  /*feature_max_depth*/,
-                                   const WorldBuilder::Utilities::PointPlaneDistance & /*distance_from_planes*/) const
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes & /*distance_from_planes*/) const
         {
 
           if (depth <= max_depth && depth >= min_depth)

--- a/source/features/fault_models/temperature/linear.cc
+++ b/source/features/fault_models/temperature/linear.cc
@@ -94,10 +94,10 @@ namespace WorldBuilder
                                 double temperature_,
                                 const double /*feature_min_depth*/,
                                 const double /*feature_max_depth*/,
-                                const std::map<std::string,double> &distance_from_planes) const
+                                const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
         {
 
-          if (std::fabs(distance_from_planes.at("distanceFromPlane")) <= max_depth && std::fabs(distance_from_planes.at("distanceFromPlane")) >= min_depth)
+          if (std::fabs(distance_from_planes.distance_from_plane) <= max_depth && std::fabs(distance_from_planes.distance_from_plane) >= min_depth)
             {
               const double min_depth_local = min_depth;
               const double max_depth_local = max_depth;
@@ -119,7 +119,7 @@ namespace WorldBuilder
                 }
 
               const double new_temperature =   center_temperature_local +
-                                               (std::fabs(distance_from_planes.at("distanceFromPlane")) - min_depth_local) *
+                                               (std::fabs(distance_from_planes.distance_from_plane) - min_depth_local) *
                                                ((side_temperature_local - center_temperature_local) / (max_depth_local - min_depth_local));
 
               return Utilities::apply_operation(operation,temperature_,new_temperature);

--- a/source/features/fault_models/temperature/linear.cc
+++ b/source/features/fault_models/temperature/linear.cc
@@ -94,7 +94,7 @@ namespace WorldBuilder
                                 double temperature_,
                                 const double /*feature_min_depth*/,
                                 const double /*feature_max_depth*/,
-                                const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
+                                const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const
         {
 
           if (std::fabs(distance_from_planes.distance_from_plane) <= max_depth && std::fabs(distance_from_planes.distance_from_plane) >= min_depth)

--- a/source/features/fault_models/temperature/uniform.cc
+++ b/source/features/fault_models/temperature/uniform.cc
@@ -88,7 +88,7 @@ namespace WorldBuilder
                                  double temperature_,
                                  const double  /*feature_min_depth*/,
                                  const double  /*feature_max_depth*/,
-                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_plane) const
         {
 
           if (std::fabs(distance_from_plane.distance_from_plane) <= max_depth && std::fabs(distance_from_plane.distance_from_plane) >= min_depth)

--- a/source/features/fault_models/temperature/uniform.cc
+++ b/source/features/fault_models/temperature/uniform.cc
@@ -88,10 +88,10 @@ namespace WorldBuilder
                                  double temperature_,
                                  const double  /*feature_min_depth*/,
                                  const double  /*feature_max_depth*/,
-                                 const std::map<std::string,double> &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
         {
 
-          if (std::fabs(distance_from_plane.at("distanceFromPlane")) <= max_depth && std::fabs(distance_from_plane.at("distanceFromPlane")) >= min_depth)
+          if (std::fabs(distance_from_plane.distance_from_plane) <= max_depth && std::fabs(distance_from_plane.distance_from_plane) >= min_depth)
             {
               return Utilities::apply_operation(operation,temperature_,temperature);
             }

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -380,7 +380,7 @@ namespace WorldBuilder
                    "Internal error: The size of coordinates (" << coordinates.size()
                    << ") and one_dimensional_coordinates (" << one_dimensional_coordinates.size() << ") are different.");*/
           // todo: explain
-          std::map<std::string,double> distance_from_planes =
+          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -388,20 +388,20 @@ namespace WorldBuilder
                                                                        slab_segment_angles,
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
-                                                                       false,
+                                                                       true,
                                                                        interpolation_type,
                                                                        this->x_spline,
                                                                        this->y_spline,
                                                                        one_dimensional_coordinates);
 
-          const double distance_from_plane = distance_from_planes["distanceFromPlane"];
-          const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
-          const double section_fraction = distance_from_planes["sectionFraction"];
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[static_cast<size_t>(distance_from_planes["section"])]));
+          const double distance_from_plane = distance_from_planes.distance_from_plane;
+          const double distance_along_plane = distance_from_planes.distance_along_plane;
+          const double section_fraction = distance_from_planes.fraction_of_section;
+          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
           const size_t next_section = current_section + 1;
-          const size_t current_segment = static_cast<size_t>(distance_from_planes["segment"]); // the original value was a unsigned in, converting it back.
+          const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
-          const double segment_fraction = distance_from_planes["segmentFraction"];
+          const double segment_fraction = distance_from_planes.fraction_of_segment;
 
           if (abs(distance_from_plane) < INFINITY || (distance_along_plane) < INFINITY)
             {
@@ -416,7 +416,7 @@ namespace WorldBuilder
                                             * (slab_segment_thickness[next_section][current_segment][1]
                                                - slab_segment_thickness[current_section][current_segment][1]);
               const double thickness_local = thickness_up + segment_fraction * (thickness_down - thickness_up);
-              distance_from_planes["thicknessLocal"] = thickness_local;
+              distance_from_planes.local_thickness = thickness_local;
 
               // secondly for top truncation
               const double top_truncation_up = slab_segment_top_truncation[current_section][current_segment][0]
@@ -509,7 +509,7 @@ namespace WorldBuilder
       if (depth <= maximum_depth && depth >= starting_depth && depth <= maximum_total_slab_length + maximum_slab_thickness)
         {
           // todo: explain
-          std::map<std::string,double> distance_from_planes =
+          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -517,20 +517,20 @@ namespace WorldBuilder
                                                                        slab_segment_angles,
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
-                                                                       false,
+                                                                       true,
                                                                        interpolation_type,
                                                                        this->x_spline,
                                                                        this->y_spline,
                                                                        one_dimensional_coordinates);
 
-          const double distance_from_plane = distance_from_planes["distanceFromPlane"];
-          const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
-          const double section_fraction = distance_from_planes["sectionFraction"];
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[static_cast<size_t>(distance_from_planes["section"])]));
+          const double distance_from_plane = distance_from_planes.distance_from_plane;
+          const double distance_along_plane = distance_from_planes.distance_along_plane;
+          const double section_fraction = distance_from_planes.fraction_of_section;
+          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
           const size_t next_section = current_section + 1;
-          const size_t current_segment = static_cast<size_t>(distance_from_planes["segment"]); // the original value was a unsigned in, converting it back.
+          const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
-          const double segment_fraction = distance_from_planes["segmentFraction"];
+          const double segment_fraction = distance_from_planes.fraction_of_segment;
 
           if (abs(distance_from_plane) < INFINITY || (distance_along_plane) < INFINITY)
             {
@@ -545,7 +545,7 @@ namespace WorldBuilder
                                             * (slab_segment_thickness[next_section][current_segment][1]
                                                - slab_segment_thickness[current_section][current_segment][1]);
               const double thickness_local = thickness_up + segment_fraction * (thickness_down - thickness_up);
-              distance_from_planes["thicknessLocal"] = thickness_local;
+              distance_from_planes.local_thickness = thickness_local;
 
               // secondly for top truncation
               const double top_truncation_up = slab_segment_top_truncation[current_section][current_segment][0]
@@ -641,7 +641,7 @@ namespace WorldBuilder
       if (depth <= maximum_depth && depth >= starting_depth && depth <= maximum_total_slab_length + maximum_slab_thickness)
         {
           // todo: explain
-          std::map<std::string,double> distance_from_planes =
+          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -649,20 +649,20 @@ namespace WorldBuilder
                                                                        slab_segment_angles,
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
-                                                                       false,
+                                                                       true,
                                                                        interpolation_type,
                                                                        this->x_spline,
                                                                        this->y_spline,
                                                                        one_dimensional_coordinates);
 
-          const double distance_from_plane = distance_from_planes["distanceFromPlane"];
-          const double distance_along_plane = distance_from_planes["distanceAlongPlane"];
-          const double section_fraction = distance_from_planes["sectionFraction"];
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[static_cast<size_t>(distance_from_planes["section"])]));
+          const double distance_from_plane = distance_from_planes.distance_from_plane;
+          const double distance_along_plane = distance_from_planes.distance_along_plane;
+          const double section_fraction = distance_from_planes.fraction_of_section;
+          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
           const size_t next_section = current_section + 1;
-          const size_t current_segment = static_cast<size_t>(distance_from_planes["segment"]); // the original value was a unsigned in, converting it back.
+          const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
-          const double segment_fraction = distance_from_planes["segmentFraction"];
+          const double segment_fraction = distance_from_planes.fraction_of_segment;
 
           if (abs(distance_from_plane) < INFINITY || (distance_along_plane) < INFINITY)
             {
@@ -677,7 +677,7 @@ namespace WorldBuilder
                                             * (slab_segment_thickness[next_section][current_segment][1]
                                                - slab_segment_thickness[current_section][current_segment][1]);
               const double thickness_local = thickness_up + segment_fraction * (thickness_down - thickness_up);
-              distance_from_planes["thicknessLocal"] = thickness_local;
+              distance_from_planes.local_thickness = thickness_local;
 
               // secondly for top truncation
               const double top_truncation_up = slab_segment_top_truncation[current_section][current_segment][0]

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -380,7 +380,7 @@ namespace WorldBuilder
                    "Internal error: The size of coordinates (" << coordinates.size()
                    << ") and one_dimensional_coordinates (" << one_dimensional_coordinates.size() << ") are different.");*/
           // todo: explain
-          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
+          WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -388,7 +388,7 @@ namespace WorldBuilder
                                                                        slab_segment_angles,
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
-                                                                       true,
+                                                                       false,
                                                                        interpolation_type,
                                                                        this->x_spline,
                                                                        this->y_spline,
@@ -509,7 +509,7 @@ namespace WorldBuilder
       if (depth <= maximum_depth && depth >= starting_depth && depth <= maximum_total_slab_length + maximum_slab_thickness)
         {
           // todo: explain
-          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
+          WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -517,7 +517,7 @@ namespace WorldBuilder
                                                                        slab_segment_angles,
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
-                                                                       true,
+                                                                       false,
                                                                        interpolation_type,
                                                                        this->x_spline,
                                                                        this->y_spline,
@@ -641,7 +641,7 @@ namespace WorldBuilder
       if (depth <= maximum_depth && depth >= starting_depth && depth <= maximum_total_slab_length + maximum_slab_thickness)
         {
           // todo: explain
-          WorldBuilder::Utilities::PointPlaneDistance distance_from_planes =
+          WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
                                                                        reference_point,
                                                                        coordinates,
@@ -649,7 +649,7 @@ namespace WorldBuilder
                                                                        slab_segment_angles,
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
-                                                                       true,
+                                                                       false,
                                                                        interpolation_type,
                                                                        this->x_spline,
                                                                        this->y_spline,

--- a/source/features/subducting_plate_models/composition/uniform.cc
+++ b/source/features/subducting_plate_models/composition/uniform.cc
@@ -95,10 +95,10 @@ namespace WorldBuilder
                                  double composition_,
                                  const double  /*feature_min_depth*/,
                                  const double  /*feature_max_depth*/,
-                                 const std::map<std::string,double> &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
         {
           double composition = composition_;
-          if (distance_from_plane.at("distanceFromPlane") <= max_depth && distance_from_plane.at("distanceFromPlane") >= min_depth)
+          if (distance_from_plane.distance_from_plane <= max_depth && distance_from_plane.distance_from_plane >= min_depth)
             {
               for (unsigned int i =0; i < compositions.size(); ++i)
                 {

--- a/source/features/subducting_plate_models/composition/uniform.cc
+++ b/source/features/subducting_plate_models/composition/uniform.cc
@@ -95,7 +95,7 @@ namespace WorldBuilder
                                  double composition_,
                                  const double  /*feature_min_depth*/,
                                  const double  /*feature_max_depth*/,
-                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_plane) const
         {
           double composition = composition_;
           if (distance_from_plane.distance_from_plane <= max_depth && distance_from_plane.distance_from_plane >= min_depth)

--- a/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -116,7 +116,7 @@ namespace WorldBuilder
                                               WorldBuilder::grains grains_,
                                               const double /*feature_min_depth*/,
                                               const double /*feature_max_depth*/,
-                                              const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
+                                              const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const
         {
           WorldBuilder::grains  grains_local = grains_;
           if (distance_from_planes.distance_from_plane <= max_depth && distance_from_planes.distance_from_plane >= min_depth)

--- a/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -116,10 +116,10 @@ namespace WorldBuilder
                                               WorldBuilder::grains grains_,
                                               const double /*feature_min_depth*/,
                                               const double /*feature_max_depth*/,
-                                              const std::map<std::string,double> &distance_from_planes) const
+                                              const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
         {
           WorldBuilder::grains  grains_local = grains_;
-          if (distance_from_planes.at("distanceFromPlane") <= max_depth && distance_from_planes.at("distanceFromPlane") >= min_depth)
+          if (distance_from_planes.distance_from_plane <= max_depth && distance_from_planes.distance_from_plane >= min_depth)
             {
               for (unsigned int i =0; i < compositions.size(); ++i)
                 {

--- a/source/features/subducting_plate_models/grains/uniform.cc
+++ b/source/features/subducting_plate_models/grains/uniform.cc
@@ -139,7 +139,7 @@ namespace WorldBuilder
                             WorldBuilder::grains grains_,
                             const double /*feature_min_depth*/,
                             const double /*feature_max_depth*/,
-                            const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
+                            const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const
         {
           WorldBuilder::grains  grains_local = grains_;
           if (distance_from_planes.distance_from_plane <= max_depth && distance_from_planes.distance_from_plane >= min_depth)

--- a/source/features/subducting_plate_models/grains/uniform.cc
+++ b/source/features/subducting_plate_models/grains/uniform.cc
@@ -139,10 +139,10 @@ namespace WorldBuilder
                             WorldBuilder::grains grains_,
                             const double /*feature_min_depth*/,
                             const double /*feature_max_depth*/,
-                            const std::map<std::string,double> &distance_from_planes) const
+                            const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
         {
           WorldBuilder::grains  grains_local = grains_;
-          if (distance_from_planes.at("distanceFromPlane") <= max_depth && distance_from_planes.at("distanceFromPlane") >= min_depth)
+          if (distance_from_planes.distance_from_plane <= max_depth && distance_from_planes.distance_from_plane >= min_depth)
             {
               for (unsigned int i =0; i < compositions.size(); ++i)
                 {

--- a/source/features/subducting_plate_models/temperature/adiabatic.cc
+++ b/source/features/subducting_plate_models/temperature/adiabatic.cc
@@ -129,7 +129,7 @@ namespace WorldBuilder
                                    double temperature_,
                                    const double  /*feature_min_depth*/,
                                    const double  /*feature_max_depth*/,
-                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const
         {
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;

--- a/source/features/subducting_plate_models/temperature/adiabatic.cc
+++ b/source/features/subducting_plate_models/temperature/adiabatic.cc
@@ -129,10 +129,10 @@ namespace WorldBuilder
                                    double temperature_,
                                    const double  /*feature_min_depth*/,
                                    const double  /*feature_max_depth*/,
-                                   const std::map<std::string,double> &distance_from_planes) const
+                                   const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
         {
 
-          const double distance_from_plane = distance_from_planes.at("distanceFromPlane");
+          const double distance_from_plane = distance_from_planes.distance_from_plane;
           if (distance_from_plane <= max_depth && distance_from_plane >= min_depth)
             {
               const double adabatic_temperature = potential_mantle_temperature *

--- a/source/features/subducting_plate_models/temperature/linear.cc
+++ b/source/features/subducting_plate_models/temperature/linear.cc
@@ -93,9 +93,9 @@ namespace WorldBuilder
                                 double temperature_,
                                 const double /*feature_min_depth*/,
                                 const double /*feature_max_depth*/,
-                                const std::map<std::string,double> &distance_from_plane) const
+                                const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
         {
-          if (distance_from_plane.at("distanceFromPlane") <= max_depth && distance_from_plane.at("distanceFromPlane") >= min_depth)
+          if (distance_from_plane.distance_from_plane <= max_depth && distance_from_plane.distance_from_plane >= min_depth)
             {
               const double min_depth_local = min_depth;
               const double max_depth_local = max_depth;
@@ -118,7 +118,7 @@ namespace WorldBuilder
                 }
 
               const double new_temperature = top_temperature_local +
-                                             (distance_from_plane.at("distanceFromPlane") - min_depth_local) *
+                                             (distance_from_plane.distance_from_plane - min_depth_local) *
                                              ((bottom_temperature_local - top_temperature_local) / (max_depth_local - min_depth_local));
               return Utilities::apply_operation(operation,temperature_,new_temperature);
 

--- a/source/features/subducting_plate_models/temperature/linear.cc
+++ b/source/features/subducting_plate_models/temperature/linear.cc
@@ -93,7 +93,7 @@ namespace WorldBuilder
                                 double temperature_,
                                 const double /*feature_min_depth*/,
                                 const double /*feature_max_depth*/,
-                                const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
+                                const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_plane) const
         {
           if (distance_from_plane.distance_from_plane <= max_depth && distance_from_plane.distance_from_plane >= min_depth)
             {

--- a/source/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/features/subducting_plate_models/temperature/plate_model.cc
@@ -146,11 +146,11 @@ namespace WorldBuilder
                                     double temperature_,
                                     const double /*feature_min_depth*/,
                                     const double /*feature_max_depth*/,
-                                    const std::map<std::string,double> &distance_from_planes) const
+                                    const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
         {
-          const double thickness_local = std::min(distance_from_planes.at("thicknessLocal"), max_depth);
-          const double distance_from_plane = distance_from_planes.at("distanceFromPlane");
-          const double distance_along_plane = distance_from_planes.at("distanceAlongPlane");
+          const double thickness_local = std::min(distance_from_planes.local_thickness, max_depth);
+          const double distance_from_plane = distance_from_planes.distance_from_plane;
+          const double distance_along_plane = distance_from_planes.distance_along_plane;
 
           if (distance_from_plane <= max_depth && distance_from_plane >= min_depth)
             {

--- a/source/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/features/subducting_plate_models/temperature/plate_model.cc
@@ -146,7 +146,7 @@ namespace WorldBuilder
                                     double temperature_,
                                     const double /*feature_min_depth*/,
                                     const double /*feature_max_depth*/,
-                                    const WorldBuilder::Utilities::PointPlaneDistance &distance_from_planes) const
+                                    const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes) const
         {
           const double thickness_local = std::min(distance_from_planes.local_thickness, max_depth);
           const double distance_from_plane = distance_from_planes.distance_from_plane;

--- a/source/features/subducting_plate_models/temperature/uniform.cc
+++ b/source/features/subducting_plate_models/temperature/uniform.cc
@@ -89,10 +89,10 @@ namespace WorldBuilder
                                  double temperature_,
                                  const double  /*feature_min_depth*/,
                                  const double  /*feature_max_depth*/,
-                                 const std::map<std::string,double> &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
         {
 
-          if (distance_from_plane.at("distanceFromPlane") <= max_depth && distance_from_plane.at("distanceFromPlane") >= min_depth)
+          if (distance_from_plane.distance_from_plane <= max_depth && distance_from_plane.distance_from_plane >= min_depth)
             {
               return Utilities::apply_operation(operation,temperature_,temperature);
             }

--- a/source/features/subducting_plate_models/temperature/uniform.cc
+++ b/source/features/subducting_plate_models/temperature/uniform.cc
@@ -89,7 +89,7 @@ namespace WorldBuilder
                                  double temperature_,
                                  const double  /*feature_min_depth*/,
                                  const double  /*feature_max_depth*/,
-                                 const WorldBuilder::Utilities::PointPlaneDistance &distance_from_plane) const
+                                 const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_plane) const
         {
 
           if (distance_from_plane.distance_from_plane <= max_depth && distance_from_plane.distance_from_plane >= min_depth)

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -431,7 +431,7 @@ namespace WorldBuilder
       return Point<3>(x,y,z,a.get_coordinate_system());
     }
 
-    PointPlaneDistance
+    PointDistanceFromCurvedPlanes
     distance_point_from_curved_planes(const Point<3> &check_point, // cartesian point in spherical system
                                       const Point<2> &reference_point, // in (rad) spherical coordinates in spherical system
                                       const std::vector<Point<2> > &point_list, // in  (rad) spherical coordinates in spherical system
@@ -768,7 +768,7 @@ namespace WorldBuilder
                                         + fraction_CPL_P1P2 * (plane_segment_angles[original_next_section][0][0]
                                                                - plane_segment_angles[original_current_section][0][0]);
 
-                  PointPlaneDistance return_values;
+                  PointDistanceFromCurvedPlanes return_values;
                   return_values.distance_from_plane = 0.0;
                   return_values.distance_along_plane = 0.0;
                   return_values.fraction_of_section = fraction_CPL_P1P2;
@@ -1168,7 +1168,7 @@ namespace WorldBuilder
             }
         }
 
-      PointPlaneDistance return_values;
+      PointDistanceFromCurvedPlanes return_values;
       return_values.distance_from_plane = distance;
       return_values.distance_along_plane = along_plane_distance;
       return_values.fraction_of_section = section_fraction;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -431,7 +431,7 @@ namespace WorldBuilder
       return Point<3>(x,y,z,a.get_coordinate_system());
     }
 
-    std::map<std::string,double>
+    PointPlaneDistance
     distance_point_from_curved_planes(const Point<3> &check_point, // cartesian point in spherical system
                                       const Point<2> &reference_point, // in (rad) spherical coordinates in spherical system
                                       const std::vector<Point<2> > &point_list, // in  (rad) spherical coordinates in spherical system
@@ -768,14 +768,14 @@ namespace WorldBuilder
                                         + fraction_CPL_P1P2 * (plane_segment_angles[original_next_section][0][0]
                                                                - plane_segment_angles[original_current_section][0][0]);
 
-                  std::map<std::string, double> return_values;
-                  return_values["distanceFromPlane"] = 0.0;
-                  return_values["distanceAlongPlane"] = 0.0;
-                  return_values["sectionFraction"] = fraction_CPL_P1P2;
-                  return_values["segmentFraction"] = 0.0;
-                  return_values["section"] = static_cast<double>(i_section_min_distance);
-                  return_values["segment"] = 0.;
-                  return_values["averageAngle"] = total_average_angle;
+                  PointPlaneDistance return_values;
+                  return_values.distance_from_plane = 0.0;
+                  return_values.distance_along_plane = 0.0;
+                  return_values.fraction_of_section = fraction_CPL_P1P2;
+                  return_values.fraction_of_segment = 0.0;
+                  return_values.section = i_section_min_distance;
+                  return_values.segment = 0;
+                  return_values.average_angle = total_average_angle;
                   return return_values;
                 }
             }
@@ -1168,14 +1168,14 @@ namespace WorldBuilder
             }
         }
 
-      std::map<std::string, double> return_values;
-      return_values["distanceFromPlane"] = distance;
-      return_values["distanceAlongPlane"] = along_plane_distance;
-      return_values["sectionFraction"] = section_fraction;
-      return_values["segmentFraction"] = segment_fraction;
-      return_values["section"] = static_cast<double>(section);
-      return_values["segment"] = (double)segment;
-      return_values["averageAngle"] = total_average_angle;
+      PointPlaneDistance return_values;
+      return_values.distance_from_plane = distance;
+      return_values.distance_along_plane = along_plane_distance;
+      return_values.fraction_of_section = section_fraction;
+      return_values.fraction_of_segment = segment_fraction;
+      return_values.section = section;
+      return_values.segment = segment;
+      return_values.average_angle = total_average_angle;
       return return_values;
     }
 

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -6792,7 +6792,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   Utilities::interpolation y_spline;
   Utilities::InterpolationType interpolation_type = Utilities::InterpolationType::None;
 
-  std::map<std::string,double> distance_from_planes =
+  WorldBuiler::Utilities::PointPlaneDistance distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
                                                  reference_point,
                                                  coordinates,

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -4633,7 +4633,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   Utilities::interpolation y_spline;
   Utilities::InterpolationType interpolation_type = Utilities::InterpolationType::None;
 
-  std::map<std::string,double> distance_from_planes =
+  WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
                                                  reference_point,
                                                  coordinates,
@@ -4646,12 +4646,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // practically zero
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(std::sqrt(10*10+10*10)));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
+  CHECK(distance_from_planes.distance_along_plane == Approx(std::sqrt(10*10+10*10)));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
   // center square test 2
@@ -4670,12 +4670,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(std::sqrt(10*10+10*10)));
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(std::fabs(distance_from_planes["segmentFraction"]) < 1e-14); // practically zero
+  CHECK(distance_from_planes.distance_from_plane == Approx(std::sqrt(10*10+10*10)));
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
 
   // center square test 3
   position[1] = 20;
@@ -4693,12 +4693,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // practically zero
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(std::sqrt(10*10+10*10)));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
+  CHECK(distance_from_planes.distance_along_plane == Approx(std::sqrt(10*10+10*10)));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // center square test 4
   reference_point[1] = 0;
@@ -4716,12 +4716,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(std::sqrt(10*10+10*10)));
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(std::fabs(distance_from_planes["segmentFraction"]) < 1e-14); // practically zero
+  CHECK(distance_from_planes.distance_from_plane == Approx(std::sqrt(10*10+10*10)));
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
 
   // center square test 5
   position[1] = -10;
@@ -4740,12 +4740,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(sqrt(20*20+20*20))); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0707106781)); // practically zero
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(sqrt(20*20+20*20))); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0707106781)); // practically zero
 
   // begin section square test 6
   position[0] = 0;
@@ -4763,12 +4763,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(sqrt(20*20+20*20))); // practically zero
-  CHECK(std::fabs(distance_from_planes["sectionFraction"]) < 1e-14);
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0707106781)); // practically zero
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(sqrt(20*20+20*20))); // practically zero
+  CHECK(std::fabs(distance_from_planes.fraction_of_section) < 1e-14);
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0707106781)); // practically zero
 
 
   // end section square test 7
@@ -4787,12 +4787,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(sqrt(20*20+20*20))); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(1.0));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0707106781)); // practically zero
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(sqrt(20*20+20*20))); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(1.0));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0707106781)); // practically zero
 
   // before begin section square test 8
   position[0] = -10;
@@ -4810,12 +4810,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == INFINITY);
-  CHECK(distance_from_planes["distanceAlongPlane"] == INFINITY);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.0));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(std::fabs(distance_from_planes["segmentFraction"]) < 1e-14); // practically zero
+  CHECK(distance_from_planes.distance_from_plane == INFINITY);
+  CHECK(distance_from_planes.distance_along_plane == INFINITY);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.0));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
 
   // beyond end section square test 9
   position[0] = 25;
@@ -4833,12 +4833,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == INFINITY);
-  CHECK(distance_from_planes["distanceAlongPlane"] == INFINITY);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.0));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(std::fabs(distance_from_planes["segmentFraction"]) < 1e-14); // practically zero
+  CHECK(distance_from_planes.distance_from_plane == INFINITY);
+  CHECK(distance_from_planes.distance_along_plane == INFINITY);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.0));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
 
 
   // beyond end section square test 10
@@ -4859,12 +4859,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(-3.5355339059));
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(10.6066017178));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.75));
+  CHECK(distance_from_planes.distance_from_plane == Approx(-3.5355339059));
+  CHECK(distance_from_planes.distance_along_plane == Approx(10.6066017178));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.75));
 
   // beyond end section square test 10 (only positive version)
   position[0] = 10;
@@ -4884,12 +4884,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(3.5355339059));
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(10.6066017178));
-  CHECK(distance_from_planes["sectionFraction"] ==  Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.75));
+  CHECK(distance_from_planes.distance_from_plane == Approx(3.5355339059));
+  CHECK(distance_from_planes.distance_along_plane == Approx(10.6066017178));
+  CHECK(distance_from_planes.fraction_of_section ==  Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.75));
 
 
   // beyond end section square test 11
@@ -4910,12 +4910,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(3.5355339059));
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(17.6776695297));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0176776695));
+  CHECK(distance_from_planes.distance_from_plane == Approx(3.5355339059));
+  CHECK(distance_from_planes.distance_along_plane == Approx(17.6776695297));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0176776695));
 
 
   // beyond end section square test 11 (only positve version)
@@ -4936,12 +4936,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(3.5355339059));
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(17.6776695297));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0176776695));
+  CHECK(distance_from_planes.distance_from_plane == Approx(3.5355339059));
+  CHECK(distance_from_planes.distance_along_plane == Approx(17.6776695297));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0176776695));
 
   // add coordinate
   position[0] = 25;
@@ -4971,12 +4971,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // practically zero
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(std::sqrt(10*10+10*10)));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
+  CHECK(distance_from_planes.distance_along_plane == Approx(std::sqrt(10*10+10*10)));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // different angle
   slab_segment_angles[0][0][0] = 22.5 * dtr;
@@ -5005,12 +5005,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // practically zero
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(10.8239219938));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.7653668647));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
+  CHECK(distance_from_planes.distance_along_plane == Approx(10.8239219938));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.7653668647));
 
   // check interpolation 1 (in the middle of a segment with 22.5 degree and a segement with 45)
   position[0] = 25;
@@ -5030,12 +5030,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(12.0268977387)); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.8504300948));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(12.0268977387)); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.8504300948));
 
   // check interpolation 2 (at the end of the segment at 45 degree)
   position[0] = 30;
@@ -5055,12 +5055,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(14.1421356237)); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(1.0));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(14.1421356237)); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(1.0));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // check length interpolation with 90 degree angles for simplicity
   // check length interpolation first segment center 1
@@ -5101,12 +5101,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(100.0)); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(100.0)); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // check length interpolation first segment center 2
   position[0] = 10;
@@ -5126,12 +5126,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(101.0)); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.01));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(101.0)); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.01));
 
   // check length interpolation first segment center 3
   position[0] = 10;
@@ -5151,12 +5151,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(200.0));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(200.0));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
 
@@ -5178,12 +5178,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == INFINITY);
-  CHECK(distance_from_planes["distanceAlongPlane"] == INFINITY);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.0));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(distance_from_planes.distance_from_plane == INFINITY);
+  CHECK(distance_from_planes.distance_along_plane == INFINITY);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.0));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
 
   // Now check the center of the second segment, each segment should have a length of 75.
@@ -5205,12 +5205,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(75.0)); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(75.0)); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // check length interpolation second segment center 2
   position[0] = 25;
@@ -5230,12 +5230,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(76.0)); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.01333333333333));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(76.0)); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.01333333333333));
 
   // check length interpolation second segment center 3
   position[0] = 25;
@@ -5255,12 +5255,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(150.0));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(150.0));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
 
@@ -5282,12 +5282,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == INFINITY);
-  CHECK(distance_from_planes["distanceAlongPlane"] == INFINITY);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.0));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(distance_from_planes.distance_from_plane == INFINITY);
+  CHECK(distance_from_planes.distance_along_plane == INFINITY);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.0));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
   // Now check the end of the second segment, each segment should have a length of 50.
   // check length interpolation second segment center 1
@@ -5308,12 +5308,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(50.0)); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(1.0));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(50.0)); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(1.0));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // check length interpolation second segment center 2
   position[0] = 30;
@@ -5333,12 +5333,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(51.0)); // practically zero
-  CHECK(distance_from_planes["sectionFraction"] == Approx(1.0));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.02));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(51.0)); // practically zero
+  CHECK(distance_from_planes.fraction_of_section == Approx(1.0));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.02));
 
   // check length interpolation second segment center 3
   position[0] = 30;
@@ -5358,12 +5358,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(100.0));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(1.0));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  CHECK(distance_from_planes.distance_along_plane == Approx(100.0));
+  CHECK(distance_from_planes.fraction_of_section == Approx(1.0));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
 
@@ -5385,12 +5385,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == INFINITY);
-  CHECK(distance_from_planes["distanceAlongPlane"] == INFINITY);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.0));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(distance_from_planes.distance_from_plane == INFINITY);
+  CHECK(distance_from_planes.distance_along_plane == INFINITY);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.0));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 }
 
 TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes cartesian part 2")
@@ -5458,7 +5458,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   Utilities::interpolation y_spline;
   Utilities::InterpolationType interpolation_type = Utilities::InterpolationType::None;
 
-  std::map<std::string,double> distance_from_planes =
+  WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
                                                  reference_point,
                                                  coordinates,
@@ -5471,12 +5471,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 2
   position[0] = 10;
@@ -5496,12 +5496,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(5.0)); // checked that it should be about 5 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(distance_from_planes.distance_from_plane == Approx(5.0)); // checked that it should be about 5 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 3
   position[0] = 10;
@@ -5521,12 +5521,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(-5.0)); // checked that it should be about -5 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(distance_from_planes.distance_from_plane == Approx(-5.0)); // checked that it should be about -5 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
   // curve test 4
@@ -5547,12 +5547,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(45.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(45.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 5
   position[0] = 10;
@@ -5572,12 +5572,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(-10.0)); // checked that it should be about -10 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(45.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(distance_from_planes.distance_from_plane == Approx(-10.0)); // checked that it should be about -10 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(45.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 6
   position[0] = 10;
@@ -5597,16 +5597,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(10.0)); // checked that it should be about 10 this with a drawing
+  CHECK(distance_from_planes.distance_from_plane == Approx(10.0)); // checked that it should be about 10 this with a drawing
   // This is a special case where the point coincides with the center of the circle.
   // Because all the points on the circle are equally close, we have chosen in the
   // code to define this case as that this point belongs to the top of the top segment
   // where the check point has angle 0. This means that the distanceAlongPlate is zero.
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(0.0));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(distance_from_planes.distance_along_plane == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
 
   // curve test 7
@@ -5627,12 +5627,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == INFINITY);
-  CHECK(distance_from_planes["distanceAlongPlane"] == INFINITY);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.0));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(distance_from_planes.distance_from_plane == INFINITY);
+  CHECK(distance_from_planes.distance_along_plane == INFINITY);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.0));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
   // curve test 8
   slab_segment_lengths[0][0] = 5 * 45 * dtr;
@@ -5657,12 +5657,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.0 * Utilities::const_pi/180 * 5));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.0 * Utilities::const_pi/180 * 5));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 9
   position[0] = 10;
@@ -5682,12 +5682,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(45.0 * Utilities::const_pi/180 * 5));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(45.0 * Utilities::const_pi/180 * 5));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
   // curve test 10
@@ -5722,12 +5722,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 11
   position[0] = 10;
@@ -5747,12 +5747,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(45.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.5));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(45.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.5));
 
   // curve test 12
   position[0] = 10;
@@ -5772,12 +5772,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(135.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.5));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(135.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.5));
 
 
   // curve test 13
@@ -5798,12 +5798,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(180.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(180.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 14
   slab_segment_angles[0][0][0] = 0.0 * dtr;
@@ -5837,12 +5837,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.5));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.5));
 
   // curve test 15
   position[0] = 10;
@@ -5862,12 +5862,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(180.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(180.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 16
   position[0] = 10;
@@ -5887,12 +5887,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(-1.0)); // checked that it should be about -1 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(180.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(distance_from_planes.distance_from_plane == Approx(-1.0)); // checked that it should be about -1 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(180.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 16
   position[0] = 10;
@@ -5912,12 +5912,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(1.0)); // checked that it should be about -1 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(180.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(distance_from_planes.distance_from_plane == Approx(1.0)); // checked that it should be about -1 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(180.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 17
   position[0] = 10;
@@ -5937,12 +5937,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(270.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(270.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
   // curve test 18
@@ -5963,12 +5963,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(-1.0)); // checked that it should be about 1 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(270.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(distance_from_planes.distance_from_plane == Approx(-1.0)); // checked that it should be about 1 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(270.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 19
   position[0] = 10;
@@ -5988,12 +5988,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(1.0)); // checked that it should be about 1 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(270.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(distance_from_planes.distance_from_plane == Approx(1.0)); // checked that it should be about 1 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(270.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
   // curve test 20
@@ -6028,12 +6028,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0/3.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0/3.0));
 
   // curve test 21
   position[0] = 10;
@@ -6053,12 +6053,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(180.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(2.0/3.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(180.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(2.0/3.0));
 
   // curve test 21
   position[0] = 10;
@@ -6078,12 +6078,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(270.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(270.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test 22
   position[0] = 10;
@@ -6103,12 +6103,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(315.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(315.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test start 45 degree 1
   slab_segment_angles[0][0][0] = 45.0 * dtr;
@@ -6145,12 +6145,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(-7.3205080757)); // checked that it should be about -7.3 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(9.5531661812));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.2163468959));
+  CHECK(distance_from_planes.distance_from_plane == Approx(-7.3205080757)); // checked that it should be about -7.3 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(9.5531661812));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.2163468959));
 
   // curve test change reference point 1
   reference_point[0] = 50;
@@ -6174,12 +6174,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  y_spline);
 
   // checked that distanceFromPlane should be infinity (it is on the other side of the circle this with a drawing
-  CHECK(distance_from_planes["distanceFromPlane"] == INFINITY);
-  CHECK(distance_from_planes["distanceAlongPlane"] == INFINITY);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.0));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(distance_from_planes.distance_from_plane == INFINITY);
+  CHECK(distance_from_planes.distance_along_plane == INFINITY);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.0));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
   // curve test change reference point 2
   position[0] = 10;
@@ -6199,12 +6199,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(2.3463313527)); // checked that it should be about 2.3 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(11.780972451));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.5));
+  CHECK(distance_from_planes.distance_from_plane == Approx(2.3463313527)); // checked that it should be about 2.3 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(11.780972451));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.5));
 
   // curve test angle interpolation 1
   reference_point[0] = 0;
@@ -6242,12 +6242,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(2.0/3.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(2.0/3.0));
 
   // curve test reverse angle 1
   reference_point[0] = 0;
@@ -6284,12 +6284,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test reverse angle 2
   position[0] = 10;
@@ -6309,12 +6309,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(180.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(180.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test reverse angle 3
   position[0] = 10;
@@ -6334,12 +6334,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(135.0 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.5));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(135.0 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.5));
 
   // curve test reverse angle 4
   position[0] = 10;
@@ -6361,12 +6361,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.1 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0011111111));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.1 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0011111111));
 
 
   // curve test reverse angle 5
@@ -6387,12 +6387,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90.001 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.000011111111));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90.001 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.000011111111));
 
   // curve test reverse angle 6
   slab_segment_angles[0][0][0] = 0.0 * dtr;
@@ -6426,12 +6426,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(45 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(45 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test reverse angle 6
   position[0] = 10;
@@ -6452,12 +6452,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(45 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(45 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
   // curve test reverse angle 6
   position[0] = 10;
@@ -6478,12 +6478,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(45 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(45 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
   // curve test reverse angle 7
@@ -6505,12 +6505,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(46 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0222222222));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(46 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0222222222));
 
 
 
@@ -6533,12 +6533,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(0.0697227738)); // checked that it should be small positive this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx((90 - 44.4093) * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0131266424));
+  CHECK(distance_from_planes.distance_from_plane == Approx(0.0697227738)); // checked that it should be small positive this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx((90 - 44.4093) * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0131266424));
 
   // curve test reverse angle 9
   position[0] = 10;
@@ -6559,12 +6559,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(-0.0692053058)); // checked that it should be small negative this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx((90 - 43.585) * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.031445048));
+  CHECK(distance_from_planes.distance_from_plane == Approx(-0.0692053058)); // checked that it should be small negative this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx((90 - 43.585) * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.031445048));
 
   // curve test reverse angle 10
   position[0] = 10;
@@ -6585,12 +6585,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(90 * Utilities::const_pi/180 * 10));
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(1.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(1.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(90 * Utilities::const_pi/180 * 10));
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(1.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
 
 
   // global_x_list test 1
@@ -6613,12 +6613,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  y_spline,
   {0,1,2});
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
   // global_x_list test 2
   position[0] = 10;
@@ -6639,12 +6639,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  y_spline,
   {0,0.5,1});
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.25));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.25));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
   // global_x_list test 3
   position[0] = 15;
@@ -6665,12 +6665,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  y_spline,
   {0,0.5,1});
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.375));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.375));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
   // global_x_list test 4
   position[0] = 20;
@@ -6691,12 +6691,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  y_spline,
   {0,0.5,1});
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
   // global_x_list test 5
   position[0] = 25;
@@ -6716,12 +6716,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  y_spline,
   {0,0.5,1});
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-12);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.75));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(std::fabs(distance_from_planes["segmentFraction"]) < 1e-12);
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-12);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.75));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-12);
 
 
 
@@ -6744,12 +6744,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  y_spline,
   {0,0.5,1});
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // checked that it should be about 0 this with a drawing
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(1.0));
-  CHECK(distance_from_planes["section"] == Approx(1.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  CHECK(distance_from_planes.fraction_of_section == Approx(1.0));
+  CHECK(distance_from_planes.section == Approx(1.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
 
 }
 
@@ -6792,7 +6792,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   Utilities::interpolation y_spline;
   Utilities::InterpolationType interpolation_type = Utilities::InterpolationType::None;
 
-  WorldBuiler::Utilities::PointPlaneDistance distance_from_planes =
+  WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
                                                  reference_point,
                                                  coordinates,
@@ -6805,12 +6805,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // practically zero
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14);
-  CHECK(std::fabs(distance_from_planes["sectionFraction"]) < 1e-14);
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(std::fabs(distance_from_planes["segmentFraction"]) < 1e-14);
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  CHECK(std::fabs(distance_from_planes.fraction_of_section) < 1e-14);
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
   // spherical test 2
@@ -6830,12 +6830,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // practically zero
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(1.0));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(std::fabs(distance_from_planes["segmentFraction"]) < 1e-14);
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  CHECK(distance_from_planes.fraction_of_section == Approx(1.0));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
   // spherical test 2
@@ -6859,12 +6859,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14); // practically zero
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14);
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(std::fabs(distance_from_planes["segmentFraction"]) < 1e-14);
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
 // spherical test 3
@@ -6883,12 +6883,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(10*sqrt(2)/4)); // checked it with a geometric drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(10*sqrt(2)/4)); // checked it with a geometric drawing
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.25));
+  CHECK(distance_from_planes.distance_from_plane == Approx(10*sqrt(2)/4)); // checked it with a geometric drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(10*sqrt(2)/4)); // checked it with a geometric drawing
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.25));
 
 
   /**
@@ -6918,12 +6918,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(10*sqrt(2)/2)); // checked it with a geometric drawing
-  CHECK(std::fabs(distance_from_planes["distanceAlongPlane"]) < 1e-14); // checked it with a geometric drawing
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(std::fabs(distance_from_planes["segmentFraction"]) < 1e-14);
+  CHECK(distance_from_planes.distance_from_plane == Approx(10*sqrt(2)/2)); // checked it with a geometric drawing
+  CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14); // checked it with a geometric drawing
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
   // spherical test 5
@@ -6943,12 +6943,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(std::fabs(distance_from_planes["distanceFromPlane"]) < 1e-14);  // checked it with a geometric drawing
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(10*sqrt(2)/2)); // checked it with a geometric drawing
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.5));
+  CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);  // checked it with a geometric drawing
+  CHECK(distance_from_planes.distance_along_plane == Approx(10*sqrt(2)/2)); // checked it with a geometric drawing
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.5));
 
   // spherical curve test 1
   // This test has not been checked analytically or with a drawing, but
@@ -6980,12 +6980,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  x_spline,
                                                  y_spline);
 
-  CHECK(distance_from_planes["distanceFromPlane"] == Approx(4.072033215));  // see comment at the top of the test
-  CHECK(distance_from_planes["distanceAlongPlane"] == Approx(6.6085171895)); // see comment at the top of the test
-  CHECK(distance_from_planes["sectionFraction"] == Approx(0.5));
-  CHECK(distance_from_planes["section"] == Approx(0.0));
-  CHECK(distance_from_planes["segment"] == Approx(0.0));
-  CHECK(distance_from_planes["segmentFraction"] == Approx(0.4672927318));*/
+  CHECK(distance_from_planes.distance_from_plane == Approx(4.072033215));  // see comment at the top of the test
+  CHECK(distance_from_planes.distance_along_plane == Approx(6.6085171895)); // see comment at the top of the test
+  CHECK(distance_from_planes.fraction_of_section == Approx(0.5));
+  CHECK(distance_from_planes.section == Approx(0.0));
+  CHECK(distance_from_planes.segment == Approx(0.0));
+  CHECK(distance_from_planes.fraction_of_segment == Approx(0.4672927318));*/
 }
 
 TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes spherical depth methods")


### PR DESCRIPTION
Hi @MFraters,
@jdannberg, @alarshi and I were looking into optimizing our world builder application and I noticed that more than 50% of the time in the world builder is spent on creating and accessing this map parameter. I know this is an intrusive change in your interface, but I think it would be worth considering. Generally a map is a very slow container, because it needs to dynamically allocate memory for every insertion, and even worse, for a map that uses strings as keys (like here) it needs to do multiple string comparisons every time you insert or access an entry. What you really want to hand over is a structure that is known at compile time, and for that a simple `struct` like I created here is completely sufficient and much faster. It can also be extended as necessary if later you want to hand over more parameters. What do you think?