### PR TITLE
Use DEBUG to indicate debug mode

### DIFF
--- a/include/world_builder/assert.h
+++ b/include/world_builder/assert.h
@@ -26,7 +26,7 @@
 
 namespace WorldBuilder
 {
-#ifndef NDEBUG
+#ifdef DEBUG
 #   define WBAssert(condition, message) \
   do { \
       if (! (condition)) { \
@@ -37,7 +37,7 @@ namespace WorldBuilder
         } \
     } while (false)
 #else
-#   define WBAssert(condition, message) do { } while (false)
+#   define WBAssert(condition, message) {}
 #endif
 
 #   define WBAssertThrow(condition, message) \


### PR DESCRIPTION
I will get back to #289 soon, but first a question: Is there a reason that world builder uses NDEBUG to distinguish between debug and release mode? deal.II and ASPECT uses DEBUG, which leads to the fact that currently in aspect all `WBAssert` calls are executed even in release mode. I have seen that RapidJSON seems to use NDEBUG, but it matters in neither case, because world builder does not seem to set DEBUG or NDEBUG at the moment. The change I did below saves about 20-25% for my example model (mostly because operations on world builder points become much faster).

If you agree that this makes sense, I can change the remaining occurences of NDEBUG into DEBUG (all in the tests folder). In order for the world builder itself to distinguish between debug and release mode the world builder build system would need to set this variable if necessary. This fix will only affect WB if it is compiled by ASPECT.