### PR TITLE
clang-tidy option in cmake an fix for cpp 14 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,23 @@ set (WORLD_BUILDER_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 # generate version.cc
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/source/config.cc.in" "${CMAKE_BINARY_DIR}/source/config.cc" @ONLY)
 
+# determine whether to use clang-tidy
+set(WB_CHECK_CLANG_TIDY OFF CACHE BOOL "Whether or not to check the code with clang-tidy while compiling the world builder.")
+
+if(WB_CHECK_CLANG_TIDY)
+  set(WB_CHECK_CLANG_TIDY_CHECKS "clang-analyzer-*,performance-*,modernize-a*,modernize-c*,modernize-c*,modernize-l*,modernize-m*,modernize-p*,modernize-r*\
+,modernize-s*,modernize-un*,modernize-use-b*,modernize-use-d*,modernize-use-e*,modernize-use-n*,modernize-use-o*,modernize-use-tran*,modernize-use-u*\
+,misc-*,mpi-*,readability-a*,readability-c*,readability-d*,readability-e*,readability-i*,readability-mak*,readability-mi*,readability-n*,llvm-*\
+,readability-q*,readability-r*,readability-s*,readability-u*"
+  CACHE STRING "A list of items to check with clang-tidy")
+  set(WB_CHECK_CLANG_TIDY_FIX OFF CACHE BOOL "Whether or not to try to automatically fix the clang-tidy issues when found.")
+  if(WB_CHECK_CLANG_TIDY_FIX)
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=${WB_CHECK_CLANG_TIDY_CHECKS};--fix")
+  else()
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=${WB_CHECK_CLANG_TIDY_CHECKS}")
+  endif()
+endif()
+
 # finding support for different languages
 # finding a fortran compiler
 set(WB_MAKE_FORTRAN_WRAPPER TRUE CACHE STRING "Whether or not to create a Fortran wrapper for the world builder.")

--- a/app/main.cc
+++ b/app/main.cc
@@ -27,11 +27,11 @@
 #include <iostream>
 #include <memory>
 
-#include <world_builder/assert.h>
-#include <world_builder/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/assert.h"
+#include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
-#include <app/main.h>
+#include "app/main.h"
 
 using namespace WorldBuilder::Utilities;
 

--- a/app/main.cc
+++ b/app/main.cc
@@ -23,8 +23,8 @@
 
 #include <algorithm>
 #include <exception>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <memory>
 
 #include <world_builder/assert.h>

--- a/app/main.cc
+++ b/app/main.cc
@@ -25,6 +25,7 @@
 #include <exception>
 #include <iostream>
 #include <fstream>
+#include <memory>
 
 #include <world_builder/assert.h>
 #include <world_builder/utilities.h>
@@ -102,7 +103,7 @@ int main(int argc, char **argv)
       //try
       {
         std::string output_dir = wb_file.substr(0,wb_file.find_last_of("/\\") + 1);
-        world = std::unique_ptr<WorldBuilder::World>(new WorldBuilder::World(wb_file, true, output_dir));
+        world = std::make_unique<WorldBuilder::World>(wb_file, true, output_dir);
       }
       /*catch (std::exception &e)
         {

--- a/examples/C/example.c
+++ b/examples/C/example.c
@@ -1,5 +1,5 @@
 
-#include <world_builder/wrapper_c.h>
+#include "world_builder/wrapper_c.h"
 #include <stdio.h>
 
 int main() {

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -402,7 +402,7 @@ RAPIDJSON_NAMESPACE_END
           \ref RAPIDJSON_ERRORS APIs.
 */
 #ifndef RAPIDJSON_ASSERT
-#include <world_builder/assert.h>
+#include "world_builder/assert.h"
 #define RAPIDJSON_ASSERT(x) WBAssertThrow(x, "RapidJSON error.")
 #endif // RAPIDJSON_ASSERT
 

--- a/include/visualization/main.h
+++ b/include/visualization/main.h
@@ -20,6 +20,9 @@
 #ifndef WORLD_BUILDER_VISUALIZATION_MAIN_H_
 #define WORLD_BUILDER_VISUALIZATION_MAIN_H_
 
+#include <vector>
+#include <string>
+
 void project_on_sphere(double, double &, double &, double &);
 
 void lay_points(double x1, double y1, double z1,

--- a/include/world_builder/coordinate_systems/cartesian.h
+++ b/include/world_builder/coordinate_systems/cartesian.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_coordinate_systems_cartesian_h
 #define _world_builder_coordinate_systems_cartesian_h
 
-#include <world_builder/utilities.h>
-#include <world_builder/coordinate_systems/interface.h>
+#include "world_builder/utilities.h"
+#include "world_builder/coordinate_systems/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -20,11 +20,11 @@
 #ifndef _world_builder_coordinate_systems_interface_h
 #define _world_builder_coordinate_systems_interface_h
 
-#include <world_builder/coordinate_system.h>
-#include <world_builder/parameters.h>
-#include <world_builder/utilities.h>
-#include <world_builder/world.h>
-#include <world_builder/types/string.h>
+#include "world_builder/coordinate_system.h"
+#include "world_builder/parameters.h"
+#include "world_builder/utilities.h"
+#include "world_builder/world.h"
+#include "world_builder/types/string.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/coordinate_systems/spherical.h
+++ b/include/world_builder/coordinate_systems/spherical.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_coordinate_systems_spherical_h
 #define _world_builder_coordinate_systems_spherical_h
 
-#include <world_builder/utilities.h>
-#include <world_builder/coordinate_systems/interface.h>
+#include "world_builder/utilities.h"
+#include "world_builder/coordinate_systems/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -20,12 +20,12 @@
 #ifndef _world_feature_features_continental_plate_h
 #define _world_feature_features_continental_plate_h
 
-#include <world_builder/features/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/interface.h"
+#include "world_builder/world.h"
 
-#include <world_builder/features/continental_plate_models/temperature/interface.h>
-#include <world_builder/features/continental_plate_models/composition/interface.h>
-#include <world_builder/features/continental_plate_models/grains/interface.h>
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
+#include "world_builder/features/continental_plate_models/composition/interface.h"
+#include "world_builder/features/continental_plate_models/grains/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/continental_plate_models/composition/interface.h
+++ b/include/world_builder/features/continental_plate_models/composition/interface.h
@@ -24,9 +24,9 @@
 #include <map>
 
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/continental_plate_models/composition/uniform.h
+++ b/include/world_builder/features/continental_plate_models/composition/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_continental_plate_composition_uniform_h
 #define _world_builder_features_continental_plate_composition_uniform_h
 
-#include <world_builder/features/continental_plate_models/composition/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/continental_plate_models/composition/interface.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/continental_plate_models/grains/interface.h
+++ b/include/world_builder/features/continental_plate_models/grains/interface.h
@@ -24,9 +24,9 @@
 #include <map>
 
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_continental_plate_grains_random_uniform_distribution_h
 #define _world_builder_features_continental_plate_grains_random_uniform_distribution_h
 
-#include <world_builder/features/continental_plate_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/continental_plate_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/continental_plate_models/grains/uniform.h
+++ b/include/world_builder/features/continental_plate_models/grains/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_continental_plate_grains_uniform_h
 #define _world_builder_features_continental_plate_grains_uniform_h
 
-#include <world_builder/features/continental_plate_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/continental_plate_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_continental_plate_temperature_adiabatic_h
 #define _world_builder_features_continental_plate_temperature_adiabatic_h
 
-#include <world_builder/features/continental_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/continental_plate_models/temperature/interface.h
+++ b/include/world_builder/features/continental_plate_models/temperature/interface.h
@@ -23,9 +23,9 @@
 #include <vector>
 #include <map>
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/continental_plate_models/temperature/linear.h
+++ b/include/world_builder/features/continental_plate_models/temperature/linear.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_continental_plate_temperature_linear_h
 #define _world_builder_features_continental_plate_temperature_linear_h
 
-#include <world_builder/features/continental_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/continental_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/continental_plate_models/temperature/uniform.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_continental_plate_temperature_uniform_h
 #define _world_builder_features_continental_plate_temperature_uniform_h
 
-#include <world_builder/features/continental_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -20,13 +20,13 @@
 #ifndef _world_feature_features_fault_h
 #define _world_feature_features_fault_h
 
-#include <world_builder/features/interface.h>
-#include <world_builder/world.h>
-#include <world_builder/types/segment.h>
+#include "world_builder/features/interface.h"
+#include "world_builder/world.h"
+#include "world_builder/types/segment.h"
 
-#include <world_builder/features/fault_models/temperature/interface.h>
-#include <world_builder/features/fault_models/composition/interface.h>
-#include <world_builder/features/fault_models/grains/interface.h>
+#include "world_builder/features/fault_models/temperature/interface.h"
+#include "world_builder/features/fault_models/composition/interface.h"
+#include "world_builder/features/fault_models/grains/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/fault_models/composition/interface.h
+++ b/include/world_builder/features/fault_models/composition/interface.h
@@ -20,14 +20,13 @@
 #ifndef _world_builder_features_fault_composition_interface_h
 #define _world_builder_features_fault_composition_interface_h
 
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
+#include "world_builder/utilities.h"
+
 #include <vector>
 #include <map>
-
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
-#include <world_builder/utilities.h>
-
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/fault_models/composition/uniform.h
+++ b/include/world_builder/features/fault_models/composition/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_fault_composition_uniform_h
 #define _world_builder_features_fault_composition_uniform_h
 
-#include <world_builder/features/fault_models/composition/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/fault_models/composition/interface.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/fault_models/grains/interface.h
+++ b/include/world_builder/features/fault_models/grains/interface.h
@@ -20,14 +20,13 @@
 #ifndef _world_builder_features_fault_grains_interface_h
 #define _world_builder_features_fault_grains_interface_h
 
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
+#include "world_builder/utilities.h"
+
 #include <vector>
 #include <map>
-
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
-#include <world_builder/utilities.h>
-
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_fault_grains_random_uniform_distribution_h
 #define _world_builder_features_fault_grains_random_uniform_distribution_h
 
-#include <world_builder/features/fault_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/fault_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/fault_models/grains/uniform.h
+++ b/include/world_builder/features/fault_models/grains/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_fault_grains_uniform_h
 #define _world_builder_features_fault_grains_uniform_h
 
-#include <world_builder/features/fault_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/fault_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/fault_models/temperature/adiabatic.h
+++ b/include/world_builder/features/fault_models/temperature/adiabatic.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_fault_temperature_adiabatic_h
 #define _world_builder_features_fault_temperature_adiabatic_h
 
-#include <world_builder/features/fault_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/fault_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/fault_models/temperature/interface.h
+++ b/include/world_builder/features/fault_models/temperature/interface.h
@@ -20,14 +20,13 @@
 #ifndef _world_builder_features_fault_temperature_interface_h
 #define _world_builder_features_fault_temperature_interface_h
 
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
+#include "world_builder/utilities.h"
+
 #include <vector>
 #include <map>
-
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
-#include <world_builder/utilities.h>
-
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/fault_models/temperature/linear.h
+++ b/include/world_builder/features/fault_models/temperature/linear.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_fault_temperature_linear_h
 #define _world_builder_features_fault_temperature_linear_h
 
-#include <world_builder/features/fault_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/fault_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/fault_models/temperature/uniform.h
+++ b/include/world_builder/features/fault_models/temperature/uniform.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_fault_temperature_uniform_h
 #define _world_builder_features_fault_temperature_uniform_h
 
-#include <world_builder/features/fault_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/fault_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -23,10 +23,10 @@
 #include <map>
 #include <vector>
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
-#include <world_builder/utilities.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
+#include "world_builder/utilities.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -20,12 +20,12 @@
 #ifndef _world_feature_features_mantle_layer_h
 #define _world_feature_features_mantle_layer_h
 
-#include <world_builder/features/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/interface.h"
+#include "world_builder/world.h"
 
-#include <world_builder/features/mantle_layer_models/temperature/interface.h>
-#include <world_builder/features/mantle_layer_models/composition/interface.h>
-#include <world_builder/features/mantle_layer_models/grains/interface.h>
+#include "world_builder/features/mantle_layer_models/temperature/interface.h"
+#include "world_builder/features/mantle_layer_models/composition/interface.h"
+#include "world_builder/features/mantle_layer_models/grains/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_models/composition/interface.h
+++ b/include/world_builder/features/mantle_layer_models/composition/interface.h
@@ -23,9 +23,9 @@
 #include <vector>
 #include <map>
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_models/composition/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/composition/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_mantle_layer_composition_uniform_h
 #define _world_builder_features_mantle_layer_composition_uniform_h
 
-#include <world_builder/features/mantle_layer_models/composition/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/mantle_layer_models/composition/interface.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_models/grains/interface.h
+++ b/include/world_builder/features/mantle_layer_models/grains/interface.h
@@ -24,9 +24,9 @@
 #include <map>
 
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_mantle_layer_grains_random_uniform_distribution_h
 #define _world_builder_features_mantle_layer_grains_random_uniform_distribution_h
 
-#include <world_builder/features/mantle_layer_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/mantle_layer_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/mantle_layer_models/grains/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/grains/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_mantle_layer_grains_uniform_h
 #define _world_builder_features_mantle_layer_grains_uniform_h
 
-#include <world_builder/features/mantle_layer_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/mantle_layer_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_mantle_layer_temperature_adiabatic_h
 #define _world_builder_features_mantle_layer_temperature_adiabatic_h
 
-#include <world_builder/features/mantle_layer_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/mantle_layer_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_models/temperature/interface.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/interface.h
@@ -23,9 +23,9 @@
 #include <vector>
 #include <map>
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_models/temperature/linear.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/linear.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_mantle_layer_temperature_linear_h
 #define _world_builder_features_mantle_layer_temperature_linear_h
 
-#include <world_builder/features/mantle_layer_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/mantle_layer_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_models/temperature/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/uniform.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_mantle_layer_temperature_uniform_h
 #define _world_builder_features_mantle_layer_temperature_uniform_h
 
-#include <world_builder/features/mantle_layer_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/mantle_layer_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -20,11 +20,11 @@
 #ifndef _world_feature_features_oceanic_plate_h
 #define _world_feature_features_oceanic_plate_h
 
-#include <world_builder/features/interface.h>
-#include <world_builder/world.h>
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
-#include <world_builder/features/oceanic_plate_models/composition/interface.h>
-#include <world_builder/features/oceanic_plate_models/grains/interface.h>
+#include "world_builder/features/interface.h"
+#include "world_builder/world.h"
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
+#include "world_builder/features/oceanic_plate_models/composition/interface.h"
+#include "world_builder/features/oceanic_plate_models/grains/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/oceanic_plate_models/composition/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/interface.h
@@ -23,9 +23,9 @@
 #include <vector>
 #include <map>
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/oceanic_plate_models/composition/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_oceanic_plate_composition_uniform_h
 #define _world_builder_features_oceanic_plate_composition_uniform_h
 
-#include <world_builder/features/oceanic_plate_models/composition/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/oceanic_plate_models/composition/interface.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/oceanic_plate_models/grains/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/interface.h
@@ -24,9 +24,9 @@
 #include <map>
 
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_oceanic_plate_grains_random_uniform_distribution_h
 #define _world_builder_features_oceanic_plate_grains_random_uniform_distribution_h
 
-#include <world_builder/features/oceanic_plate_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/oceanic_plate_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/oceanic_plate_models/grains/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_oceanic_plate_grains_uniform_h
 #define _world_builder_features_oceanic_plate_grains_uniform_h
 
-#include <world_builder/features/oceanic_plate_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/oceanic_plate_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_oceanic_plate_temperature_adiabatic_h
 #define _world_builder_features_oceanic_plate_temperature_adiabatic_h
 
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/oceanic_plate_models/temperature/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/interface.h
@@ -23,9 +23,9 @@
 #include <vector>
 #include <map>
 
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/oceanic_plate_models/temperature/linear.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/linear.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_oceanic_plate_temperature_linear_h
 #define _world_builder_features_oceanic_plate_temperature_linear_h
 
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_oceanic_plate_temperature_plate_model_h
 #define _world_builder_features_oceanic_plate_temperature_plate_model_h
 
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_oceanic_plate_temperature_uniform_h
 #define _world_builder_features_oceanic_plate_temperature_uniform_h
 
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -20,13 +20,13 @@
 #ifndef _world_feature_features_subducting_plate_h
 #define _world_feature_features_subducting_plate_h
 
-#include <world_builder/features/interface.h>
-#include <world_builder/world.h>
-#include <world_builder/types/segment.h>
+#include "world_builder/features/interface.h"
+#include "world_builder/world.h"
+#include "world_builder/types/segment.h"
 
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
-#include <world_builder/features/subducting_plate_models/composition/interface.h>
-#include <world_builder/features/subducting_plate_models/grains/interface.h>
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
+#include "world_builder/features/subducting_plate_models/composition/interface.h"
+#include "world_builder/features/subducting_plate_models/grains/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/subducting_plate_models/composition/interface.h
+++ b/include/world_builder/features/subducting_plate_models/composition/interface.h
@@ -20,14 +20,13 @@
 #ifndef _world_builder_features_subducting_plate_composition_interface_h
 #define _world_builder_features_subducting_plate_composition_interface_h
 
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
+#include "world_builder/utilities.h"
+
 #include <vector>
 #include <map>
-
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
-#include <world_builder/utilities.h>
-
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/subducting_plate_models/composition/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/composition/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_subducting_plate_composition_uniform_h
 #define _world_builder_features_subducting_plate_composition_uniform_h
 
-#include <world_builder/features/subducting_plate_models/composition/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/subducting_plate_models/composition/interface.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/subducting_plate_models/grains/interface.h
+++ b/include/world_builder/features/subducting_plate_models/grains/interface.h
@@ -20,14 +20,13 @@
 #ifndef _world_builder_features_subducting_plate_grains_interface_h
 #define _world_builder_features_subducting_plate_grains_interface_h
 
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
+#include "world_builder/utilities.h"
+
 #include <vector>
 #include <map>
-
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
-#include <world_builder/utilities.h>
-
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_subducting_plate_grains_random_uniform_distribution_h
 #define _world_builder_features_subducting_plate_grains_random_uniform_distribution_h
 
-#include <world_builder/features/subducting_plate_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/subducting_plate_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/subducting_plate_models/grains/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/grains/uniform.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_features_subducting_plate_grains_uniform_h
 #define _world_builder_features_subducting_plate_grains_uniform_h
 
-#include <world_builder/features/subducting_plate_models/grains/interface.h>
-#include <world_builder/world.h>
+#include "world_builder/features/subducting_plate_models/grains/interface.h"
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_subducting_plate_temperature_adiabatic_h
 #define _world_builder_features_subducting_plate_temperature_adiabatic_h
 
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/subducting_plate_models/temperature/interface.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/interface.h
@@ -20,14 +20,13 @@
 #ifndef _world_builder_features_subducting_plate_temperature_interface_h
 #define _world_builder_features_subducting_plate_temperature_interface_h
 
+#include "world_builder/world.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
+#include "world_builder/utilities.h"
+
 #include <vector>
 #include <map>
-
-#include <world_builder/world.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
-#include <world_builder/utilities.h>
-
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/subducting_plate_models/temperature/linear.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/linear.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_subducting_plate_temperature_linear_h
 #define _world_builder_features_subducting_plate_temperature_linear_h
 
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_subducting_plate_temperature_plate_model_h
 #define _world_builder_features_subducting_plate_temperature_plate_model_h
 
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/subducting_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/uniform.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_features_subducting_plate_temperature_uniform_h
 #define _world_builder_features_subducting_plate_temperature_uniform_h
 
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
-#include <world_builder/features/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
+#include "world_builder/features/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/utilities.h
+++ b/include/world_builder/features/utilities.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <limits>
 
-#include <world_builder/assert.h>
+#include "world_builder/assert.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/nan.h
+++ b/include/world_builder/nan.h
@@ -20,7 +20,7 @@
 #ifndef _world_nan_h
 #define _world_nan_h
 
-#include <cmath>
+#include <limits>
 
 namespace WorldBuilder
 {

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -203,7 +203,7 @@ namespace WorldBuilder
       void
       declare_model_entries(const std::string &model_group_name,
                             const std::string &parent_name,
-                            std::map<std::string, void ( *)(Parameters &,const std::string &)> declare_map,
+                            const std::map<std::string, void ( *)(Parameters &,const std::string &)>& declare_map,
                             const std::vector<std::string> &required_entries = {},
                             const std::vector<std::tuple<std::string,const WorldBuilder::Types::Interface &, std::string> > &extra_declarations = {});
 

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -203,7 +203,7 @@ namespace WorldBuilder
       void
       declare_model_entries(const std::string &model_group_name,
                             const std::string &parent_name,
-                            const std::map<std::string, void ( *)(Parameters &,const std::string &)>& declare_map,
+                            const std::map<std::string, void ( *)(Parameters &,const std::string &)> &declare_map,
                             const std::vector<std::string> &required_entries = {},
                             const std::vector<std::tuple<std::string,const WorldBuilder::Types::Interface &, std::string> > &extra_declarations = {});
 

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -30,7 +30,7 @@
 #include <rapidjson/document.h>
 #include "rapidjson/schema.h"
 
-#include <world_builder/point.h>
+#include "world_builder/point.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -24,8 +24,8 @@
 #include <array>
 #include <iostream>
 
-#include <world_builder/coordinate_system.h>
-#include <world_builder/assert.h>
+#include "world_builder/coordinate_system.h"
+#include "world_builder/assert.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/types/array.h
+++ b/include/world_builder/types/array.h
@@ -20,7 +20,7 @@
 #ifndef _world_feature_types_array_h
 #define _world_feature_types_array_h
 
-#include <world_builder/types/interface.h>
+#include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/types/bool.h
+++ b/include/world_builder/types/bool.h
@@ -20,7 +20,7 @@
 #ifndef _world_feature_types_bool_h
 #define _world_feature_types_bool_h
 
-#include <world_builder/types/interface.h>
+#include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/types/double.h
+++ b/include/world_builder/types/double.h
@@ -20,7 +20,7 @@
 #ifndef _world_feature_types_double_h
 #define _world_feature_types_double_h
 
-#include <world_builder/types/interface.h>
+#include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/types/object.h
+++ b/include/world_builder/types/object.h
@@ -20,7 +20,7 @@
 #ifndef _world_feature_types_object_h
 #define _world_feature_types_object_h
 
-#include <world_builder/types/interface.h>
+#include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/types/plugin_system.h
+++ b/include/world_builder/types/plugin_system.h
@@ -20,8 +20,8 @@
 #ifndef _world_feature_types_plugin_system_h
 #define _world_feature_types_plugin_system_h
 
-#include <world_builder/types/interface.h>
-#include <world_builder/features/interface.h>
+#include "world_builder/types/interface.h"
+#include "world_builder/features/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/types/point.h
+++ b/include/world_builder/types/point.h
@@ -20,8 +20,8 @@
 #ifndef _world_feature_types_point_h
 #define _world_feature_types_point_h
 
-#include <world_builder/types/interface.h>
-#include <world_builder/point.h>
+#include "world_builder/types/interface.h"
+#include "world_builder/point.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/types/segment.h
+++ b/include/world_builder/types/segment.h
@@ -20,9 +20,9 @@
 #ifndef _world_feature_types_segment_h
 #define _world_feature_types_segment_h
 
-#include <world_builder/types/interface.h>
-#include <world_builder/point.h>
-#include <world_builder/types/plugin_system.h>
+#include "world_builder/types/interface.h"
+#include "world_builder/point.h"
+#include "world_builder/types/plugin_system.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/types/string.h
+++ b/include/world_builder/types/string.h
@@ -20,7 +20,7 @@
 #ifndef _world_feature_types_string_h
 #define _world_feature_types_string_h
 
-#include <world_builder/types/interface.h>
+#include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/types/unsigned_int.h
+++ b/include/world_builder/types/unsigned_int.h
@@ -20,7 +20,7 @@
 #ifndef _world_feature_types_unsigned_int_h
 #define _world_feature_types_unsigned_int_h
 
-#include <world_builder/types/interface.h>
+#include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -23,9 +23,9 @@
 #include <vector>
 #include <map>
 
-#include <world_builder/point.h>
-#include <world_builder/coordinate_system.h>
-#include <world_builder/coordinate_systems/interface.h>
+#include "world_builder/point.h"
+#include "world_builder/coordinate_system.h"
+#include "world_builder/coordinate_systems/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -22,8 +22,8 @@
 
 #include <random>
 
-#include <world_builder/parameters.h>
-#include <world_builder/grains.h>
+#include "world_builder/parameters.h"
+#include "world_builder/grains.h"
 
 
 

--- a/source/coordinate_systems/cartesian.cc
+++ b/source/coordinate_systems/cartesian.cc
@@ -17,8 +17,9 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/assert.h>
 #include <world_builder/coordinate_systems/cartesian.h>
+
+#include <world_builder/assert.h>
 
 namespace WorldBuilder
 {
@@ -87,6 +88,6 @@ namespace WorldBuilder
      * Register plugin
      */
     WB_REGISTER_COORDINATE_SYSTEM(Cartesian, cartesian)
-  }
-}
+  } // namespace CoordinateSystems
+} // namespace WorldBuilder
 

--- a/source/coordinate_systems/cartesian.cc
+++ b/source/coordinate_systems/cartesian.cc
@@ -17,9 +17,9 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/coordinate_systems/cartesian.h>
+#include "world_builder/coordinate_systems/cartesian.h"
 
-#include <world_builder/assert.h>
+#include "world_builder/assert.h"
 
 namespace WorldBuilder
 {

--- a/source/coordinate_systems/interface.cc
+++ b/source/coordinate_systems/interface.cc
@@ -18,11 +18,10 @@
 */
 
 #include <world_builder/coordinate_systems/interface.h>
-#include <world_builder/coordinate_systems/cartesian.h>
-#include <world_builder/coordinate_systems/spherical.h>
-#include <world_builder/assert.h>
 
+#include <world_builder/assert.h>
 #include <world_builder/types/object.h>
+
 #include <algorithm>
 
 
@@ -97,6 +96,6 @@ namespace WorldBuilder
       // thrown when the name is not present.
       return get_factory_map().at(lower_case_name)->create(world);
     }
-  }
-}
+  } // namespace CoordinateSystems
+} // namespace WorldBuilder
 

--- a/source/coordinate_systems/interface.cc
+++ b/source/coordinate_systems/interface.cc
@@ -17,10 +17,10 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/coordinate_systems/interface.h>
+#include "world_builder/coordinate_systems/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
 
 #include <algorithm>
 

--- a/source/coordinate_systems/spherical.cc
+++ b/source/coordinate_systems/spherical.cc
@@ -17,10 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/assert.h>
 #include <world_builder/coordinate_systems/spherical.h>
-#include <world_builder/types/string.h>
+
+#include <world_builder/assert.h>
 #include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
 
 namespace WorldBuilder
 {
@@ -132,6 +133,6 @@ namespace WorldBuilder
      * Register plugin
      */
     WB_REGISTER_COORDINATE_SYSTEM(Spherical, spherical)
-  }
-}
+  } // namespace CoordinateSystems
+} // namespace WorldBuilder
 

--- a/source/coordinate_systems/spherical.cc
+++ b/source/coordinate_systems/spherical.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/coordinate_systems/spherical.h>
+#include "world_builder/coordinate_systems/spherical.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 namespace WorldBuilder
 {

--- a/source/features/continental_plate.cc
+++ b/source/features/continental_plate.cc
@@ -18,20 +18,17 @@
 */
 
 #include <world_builder/features/continental_plate.h>
-#include <world_builder/features/continental_plate_models/temperature/interface.h>
-#include <world_builder/features/continental_plate_models/composition/interface.h>
 
-#include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -237,5 +234,5 @@ namespace WorldBuilder
 
     WB_REGISTER_FEATURE(ContinentalPlate, continental plate)
 
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder

--- a/source/features/continental_plate.cc
+++ b/source/features/continental_plate.cc
@@ -149,7 +149,7 @@ namespace WorldBuilder
           Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                   world->parameters.coordinate_system->natural_coordinate_system())))
         {
-          for (auto &temperature_model: temperature_models)
+          for (const auto &temperature_model: temperature_models)
             {
               temperature = temperature_model->get_temperature(position,
                                                                depth,
@@ -182,7 +182,7 @@ namespace WorldBuilder
           Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                   world->parameters.coordinate_system->natural_coordinate_system())))
         {
-          for (auto &composition_model: composition_models)
+          for (const auto &composition_model: composition_models)
             {
               composition = composition_model->get_composition(position,
                                                                depth,
@@ -215,7 +215,7 @@ namespace WorldBuilder
           Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                   world->parameters.coordinate_system->natural_coordinate_system())))
         {
-          for (auto &grains_model: grains_models)
+          for (const auto &grains_model: grains_models)
             {
               grains = grains_model->get_grains(position,
                                                 depth,

--- a/source/features/continental_plate.cc
+++ b/source/features/continental_plate.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate.h>
+#include "world_builder/features/continental_plate.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/continental_plate_models/composition/interface.cc
+++ b/source/features/continental_plate_models/composition/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate_models/composition/interface.h>
+#include "world_builder/features/continental_plate_models/composition/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/continental_plate_models/composition/interface.cc
+++ b/source/features/continental_plate_models/composition/interface.cc
@@ -17,13 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
+#include <world_builder/features/continental_plate_models/composition/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/continental_plate_models/composition/interface.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 
 namespace WorldBuilder
@@ -78,8 +78,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/continental_plate_models/composition/uniform.cc
+++ b/source/features/continental_plate_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate_models/composition/uniform.h>
+#include "world_builder/features/continental_plate_models/composition/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/continental_plate_models/composition/uniform.cc
+++ b/source/features/continental_plate_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/continental_plate_models/composition/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>
-#include <world_builder/features/continental_plate_models/composition/uniform.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -114,9 +114,9 @@ namespace WorldBuilder
           return composition;
         }
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_COMPOSITION_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/continental_plate_models/grains/interface.cc
+++ b/source/features/continental_plate_models/grains/interface.cc
@@ -17,14 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
-
-#include <world_builder/assert.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
 #include <world_builder/features/continental_plate_models/grains/interface.h>
 
+#include <world_builder/assert.h>
+#include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -78,8 +77,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/continental_plate_models/grains/interface.cc
+++ b/source/features/continental_plate_models/grains/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate_models/grains/interface.h>
+#include "world_builder/features/continental_plate_models/grains/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/continental_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/continental_plate_models/grains/random_uniform_distribution.cc
@@ -159,7 +159,7 @@ namespace WorldBuilder
                           double r  = std::sqrt( z );
                           double Vx = std::sin( phi ) * r;
                           double Vy = std::cos( phi ) * r;
-                          double Vz = std::sqrt( 2.f - z );
+                          double Vz = std::sqrt( 2.F - z );
 
                           // Compute the row vector S = Transpose(V) * R, where R is a simple
                           // rotation by theta about the z-axis.  No need to compute Sz since

--- a/source/features/continental_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/continental_plate_models/grains/random_uniform_distribution.cc
@@ -17,19 +17,19 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate_models/grains/random_uniform_distribution.h>
+#include "world_builder/features/continental_plate_models/grains/random_uniform_distribution.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/bool.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 #include <algorithm>
 

--- a/source/features/continental_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/continental_plate_models/grains/random_uniform_distribution.cc
@@ -17,19 +17,19 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/continental_plate_models/grains/random_uniform_distribution.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/bool.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/continental_plate_models/grains/random_uniform_distribution.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
 #include <algorithm>
 
@@ -208,9 +208,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_GRAINS_MODEL(RandomUniformDistribution, random uniform distribution)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/continental_plate_models/grains/uniform.cc
+++ b/source/features/continental_plate_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate_models/grains/uniform.h>
+#include "world_builder/features/continental_plate_models/grains/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 #include <algorithm>
 

--- a/source/features/continental_plate_models/grains/uniform.cc
+++ b/source/features/continental_plate_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/continental_plate_models/grains/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/continental_plate_models/grains/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
 #include <algorithm>
 
@@ -160,9 +160,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_GRAINS_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/continental_plate_models/temperature/adiabatic.cc
+++ b/source/features/continental_plate_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/continental_plate_models/temperature/adiabatic.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/continental_plate_models/temperature/adiabatic.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -156,8 +156,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TEMPERATURE_MODEL(Adiabatic, adiabatic)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/continental_plate_models/temperature/adiabatic.cc
+++ b/source/features/continental_plate_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate_models/temperature/adiabatic.h>
+#include "world_builder/features/continental_plate_models/temperature/adiabatic.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/continental_plate_models/temperature/interface.cc
+++ b/source/features/continental_plate_models/temperature/interface.cc
@@ -17,16 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
+#include <world_builder/features/continental_plate_models/temperature/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/continental_plate_models/temperature/interface.h>
-#include <world_builder/features/continental_plate_models/temperature/adiabatic.h>
-#include <world_builder/features/continental_plate_models/temperature/linear.h>
-#include <world_builder/features/continental_plate_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -92,8 +89,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/continental_plate_models/temperature/interface.cc
+++ b/source/features/continental_plate_models/temperature/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate_models/temperature/interface.h>
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/continental_plate_models/temperature/linear.cc
+++ b/source/features/continental_plate_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate_models/temperature/linear.h>
+#include "world_builder/features/continental_plate_models/temperature/linear.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/continental_plate_models/temperature/linear.cc
+++ b/source/features/continental_plate_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/continental_plate_models/temperature/linear.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/continental_plate_models/temperature/linear.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -128,8 +128,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TEMPERATURE_MODEL(Linear, linear)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/continental_plate_models/temperature/uniform.cc
+++ b/source/features/continental_plate_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/continental_plate_models/temperature/uniform.h>
+#include "world_builder/features/continental_plate_models/temperature/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/continental_plate_models/temperature/uniform.cc
+++ b/source/features/continental_plate_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/continental_plate_models/temperature/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/continental_plate_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -99,8 +99,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TEMPERATURE_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -18,18 +18,18 @@
  */
 
 #include <world_builder/features/fault.h>
-#include <world_builder/utilities.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/segment.h>
+#include <world_builder/types/plugin_system.h>
 #include <world_builder/types/point.h>
+#include <world_builder/types/segment.h>
 #include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>
-#include <world_builder/types/plugin_system.h>
+#include <world_builder/utilities.h>
 
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/stringbuffer.h"
@@ -762,6 +762,6 @@ namespace WorldBuilder
      * Register plugin
      */
     WB_REGISTER_FEATURE(Fault, fault)
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -17,19 +17,19 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <world_builder/features/fault.h>
+#include "world_builder/features/fault.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/segment.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/point.h"
+#include "world_builder/types/segment.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/stringbuffer.h"

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -434,7 +434,7 @@ namespace WorldBuilder
                   double temperature_current_section = temperature;
                   double temperature_next_section = temperature;
 
-                  for (auto &temperature_model: segment_vector[current_section][current_segment].temperature_systems)
+                  for (const auto &temperature_model: segment_vector[current_section][current_segment].temperature_systems)
                     {
                       temperature_current_section = temperature_model->get_temperature(position,
                                                                                        depth,
@@ -450,7 +450,7 @@ namespace WorldBuilder
                                << ", based on a temperature model with the name " << temperature_model->get_name());
                     }
 
-                  for (auto &temperature_model: segment_vector[next_section][current_segment].temperature_systems)
+                  for (const auto &temperature_model: segment_vector[next_section][current_segment].temperature_systems)
                     {
                       temperature_next_section = temperature_model->get_temperature(position,
                                                                                     depth,
@@ -566,7 +566,7 @@ namespace WorldBuilder
                   double composition_current_section = composition;
                   double composition_next_section = composition;
 
-                  for (auto &composition_model: segment_vector[current_section][current_segment].composition_systems)
+                  for (const auto &composition_model: segment_vector[current_section][current_segment].composition_systems)
                     {
                       composition_current_section = composition_model->get_composition(position,
                                                                                        depth,
@@ -583,7 +583,7 @@ namespace WorldBuilder
 
                     }
 
-                  for (auto &composition_model: segment_vector[next_section][current_segment].composition_systems)
+                  for (const auto &composition_model: segment_vector[next_section][current_segment].composition_systems)
                     {
                       composition_next_section = composition_model->get_composition(position,
                                                                                     depth,
@@ -700,7 +700,7 @@ namespace WorldBuilder
                   WorldBuilder::grains  grains_current_section = grains;
                   WorldBuilder::grains  grains_next_section = grains;
 
-                  for (auto &grains_model: segment_vector[current_section][current_segment].grains_systems)
+                  for (const auto &grains_model: segment_vector[current_section][current_segment].grains_systems)
                     {
                       grains_current_section = grains_model->get_grains(position,
                                                                         depth,
@@ -717,7 +717,7 @@ namespace WorldBuilder
 
                     }
 
-                  for (auto &grains_model: segment_vector[next_section][current_segment].grains_systems)
+                  for (const auto &grains_model: segment_vector[next_section][current_segment].grains_systems)
                     {
                       grains_next_section = grains_model->get_grains(position,
                                                                      depth,

--- a/source/features/fault_models/composition/interface.cc
+++ b/source/features/fault_models/composition/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/fault_models/composition/interface.h>
+#include "world_builder/features/fault_models/composition/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/fault_models/composition/interface.cc
+++ b/source/features/fault_models/composition/interface.cc
@@ -17,15 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
+#include <world_builder/features/fault_models/composition/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/fault_models/composition/interface.h>
-#include <world_builder/features/fault_models/composition/uniform.h>
+#include <world_builder/types/string.h>
 
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -79,8 +77,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/fault_models/composition/uniform.cc
+++ b/source/features/fault_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/fault_models/composition/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>
-#include <world_builder/features/fault_models/composition/uniform.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -114,9 +114,9 @@ namespace WorldBuilder
           return composition;
         }
         WB_REGISTER_FEATURE_FAULT_COMPOSITION_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/fault_models/composition/uniform.cc
+++ b/source/features/fault_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/fault_models/composition/uniform.h>
+#include "world_builder/features/fault_models/composition/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/fault_models/grains/interface.cc
+++ b/source/features/fault_models/grains/interface.cc
@@ -17,14 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
-
-#include <world_builder/assert.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
 #include <world_builder/features/fault_models/grains/interface.h>
 
+#include <world_builder/assert.h>
+#include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -106,8 +105,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/fault_models/grains/interface.cc
+++ b/source/features/fault_models/grains/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/fault_models/grains/interface.h>
+#include "world_builder/features/fault_models/grains/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/features/fault_models/grains/random_uniform_distribution.cc
@@ -17,22 +17,21 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
+#include <world_builder/features/fault_models/grains/random_uniform_distribution.h>
 
-#include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/bool.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/fault_models/grains/random_uniform_distribution.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -208,9 +207,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_FAULT_GRAINS_MODEL(RandomUniformDistribution, random uniform distribution)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/features/fault_models/grains/random_uniform_distribution.cc
@@ -160,7 +160,7 @@ namespace WorldBuilder
                           double r  = std::sqrt( z );
                           double Vx = std::sin( phi ) * r;
                           double Vy = std::cos( phi ) * r;
-                          double Vz = std::sqrt( 2.f - z );
+                          double Vz = std::sqrt( 2.F - z );
 
                           // Compute the row vector S = Transpose(V) * R, where R is a simple
                           // rotation by theta about the z-axis.  No need to compute Sz since

--- a/source/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/features/fault_models/grains/random_uniform_distribution.cc
@@ -17,19 +17,19 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/fault_models/grains/random_uniform_distribution.h>
+#include "world_builder/features/fault_models/grains/random_uniform_distribution.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/bool.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 #include <algorithm>
 

--- a/source/features/fault_models/grains/uniform.cc
+++ b/source/features/fault_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/fault_models/grains/uniform.h>
+#include "world_builder/features/fault_models/grains/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/fault_models/grains/uniform.cc
+++ b/source/features/fault_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/fault_models/grains/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/fault_models/grains/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -160,9 +160,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_FAULT_GRAINS_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/fault_models/grains/uniform.cc_backup
+++ b/source/features/fault_models/grains/uniform.cc_backup
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
+#include "world_builder/utilities.h"
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
 
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/features/fault_models/grains/uniform.h>
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/features/fault_models/grains/uniform.h"
 
 
 namespace WorldBuilder

--- a/source/features/fault_models/temperature/adiabatic.cc
+++ b/source/features/fault_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/fault_models/temperature/adiabatic.h>
+#include "world_builder/features/fault_models/temperature/adiabatic.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/fault_models/temperature/adiabatic.cc
+++ b/source/features/fault_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/fault_models/temperature/adiabatic.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/fault_models/temperature/adiabatic.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -157,8 +157,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_FAULT_TEMPERATURE_MODEL(Adiabatic, adiabatic)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/fault_models/temperature/interface.cc
+++ b/source/features/fault_models/temperature/interface.cc
@@ -18,16 +18,13 @@
 */
 
 
-#include <algorithm>
+#include <world_builder/features/fault_models/temperature/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/fault_models/temperature/interface.h>
-#include <world_builder/features/fault_models/temperature/adiabatic.h>
-#include <world_builder/features/fault_models/temperature/linear.h>
-#include <world_builder/features/fault_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
 
+#include <algorithm>
 namespace WorldBuilder
 {
   namespace Features
@@ -92,8 +89,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/fault_models/temperature/interface.cc
+++ b/source/features/fault_models/temperature/interface.cc
@@ -18,11 +18,11 @@
 */
 
 
-#include <world_builder/features/fault_models/temperature/interface.h>
+#include "world_builder/features/fault_models/temperature/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 namespace WorldBuilder

--- a/source/features/fault_models/temperature/linear.cc
+++ b/source/features/fault_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/fault_models/temperature/linear.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/fault_models/temperature/linear.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -130,8 +130,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_FAULT_TEMPERATURE_MODEL(Linear, linear)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/fault_models/temperature/linear.cc
+++ b/source/features/fault_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/fault_models/temperature/linear.h>
+#include "world_builder/features/fault_models/temperature/linear.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/fault_models/temperature/uniform.cc
+++ b/source/features/fault_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/fault_models/temperature/uniform.h>
+#include "world_builder/features/fault_models/temperature/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/fault_models/temperature/uniform.cc
+++ b/source/features/fault_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/fault_models/temperature/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/fault_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -99,8 +99,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_FAULT_TEMPERATURE_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/interface.cc
+++ b/source/features/interface.cc
@@ -17,23 +17,16 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
-
 #include <world_builder/features/interface.h>
-#include <world_builder/features/continental_plate.h>
-#include <world_builder/features/fault.h>
-#include <world_builder/features/oceanic_plate.h>
-#include <world_builder/features/subducting_plate.h>
-#include <world_builder/features/mantle_layer.h>
+
 #include <world_builder/assert.h>
-#include <world_builder/utilities.h>
-
-
 #include <world_builder/types/array.h>
+#include <world_builder/types/object.h>
 #include <world_builder/types/point.h>
 #include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
+#include <world_builder/utilities.h>
 
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -74,7 +67,7 @@ namespace WorldBuilder
 
         return InterpolationType::Invalid;
       }
-    }
+    } // namespace Internal
     Interface::Interface()
       = default;
 
@@ -244,6 +237,6 @@ namespace WorldBuilder
       return get_factory_map().at(lower_case_name)->create(world);
     }
 
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/interface.cc
+++ b/source/features/interface.cc
@@ -17,14 +17,14 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/interface.h>
+#include "world_builder/features/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/point.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 #include <algorithm>
 

--- a/source/features/mantle_layer.cc
+++ b/source/features/mantle_layer.cc
@@ -18,16 +18,16 @@
 */
 
 #include <world_builder/features/mantle_layer.h>
-#include <world_builder/utilities.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/plugin_system.h>
+#include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -231,5 +231,5 @@ namespace WorldBuilder
 
     WB_REGISTER_FEATURE(MantleLayer, mantle layer)
 
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder

--- a/source/features/mantle_layer.cc
+++ b/source/features/mantle_layer.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer.h>
+#include "world_builder/features/mantle_layer.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/mantle_layer.cc
+++ b/source/features/mantle_layer.cc
@@ -141,7 +141,7 @@ namespace WorldBuilder
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
-          for (auto &temperature_model: temperature_models)
+          for (const auto &temperature_model: temperature_models)
             {
               temperature = temperature_model->get_temperature(position,
                                                                depth,
@@ -174,7 +174,7 @@ namespace WorldBuilder
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
-          for (auto &composition_model: composition_models)
+          for (const auto &composition_model: composition_models)
             {
               composition = composition_model->get_composition(position,
                                                                depth,
@@ -209,7 +209,7 @@ namespace WorldBuilder
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
-          for (auto &grains_model: grains_models)
+          for (const auto &grains_model: grains_models)
             {
               grains = grains_model->get_grains(position,
                                                 depth,

--- a/source/features/mantle_layer_models/composition/interface.cc
+++ b/source/features/mantle_layer_models/composition/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer_models/composition/interface.h>
+#include "world_builder/features/mantle_layer_models/composition/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/mantle_layer_models/composition/interface.cc
+++ b/source/features/mantle_layer_models/composition/interface.cc
@@ -17,15 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
+#include <world_builder/features/mantle_layer_models/composition/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/mantle_layer_models/composition/interface.h>
-#include <world_builder/features/mantle_layer_models/composition/uniform.h>
+#include <world_builder/types/string.h>
 
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -79,8 +77,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/mantle_layer_models/composition/uniform.cc
+++ b/source/features/mantle_layer_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer_models/composition/uniform.h>
+#include "world_builder/features/mantle_layer_models/composition/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/mantle_layer_models/composition/uniform.cc
+++ b/source/features/mantle_layer_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/mantle_layer_models/composition/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>
-#include <world_builder/features/mantle_layer_models/composition/uniform.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -114,9 +114,9 @@ namespace WorldBuilder
           return composition;
         }
         WB_REGISTER_FEATURE_MANTLE_LAYER_COMPOSITION_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/mantle_layer_models/grains/interface.cc
+++ b/source/features/mantle_layer_models/grains/interface.cc
@@ -17,14 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
-
-#include <world_builder/assert.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
 #include <world_builder/features/mantle_layer_models/grains/interface.h>
 
+#include <world_builder/assert.h>
+#include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -106,8 +105,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/mantle_layer_models/grains/interface.cc
+++ b/source/features/mantle_layer_models/grains/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer_models/grains/interface.h>
+#include "world_builder/features/mantle_layer_models/grains/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
+++ b/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
@@ -159,7 +159,7 @@ namespace WorldBuilder
                           double r  = std::sqrt( z );
                           double Vx = std::sin( phi ) * r;
                           double Vy = std::cos( phi ) * r;
-                          double Vz = std::sqrt( 2.f - z );
+                          double Vz = std::sqrt( 2.F - z );
 
                           // Compute the row vector S = Transpose(V) * R, where R is a simple
                           // rotation by theta about the z-axis.  No need to compute Sz since

--- a/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
+++ b/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
@@ -17,19 +17,19 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h>
+#include "world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/bool.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 #include <algorithm>
 

--- a/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
+++ b/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
@@ -17,22 +17,21 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
+#include <world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h>
 
-#include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/bool.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -207,9 +206,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_MANTLE_LAYER_GRAINS_MODEL(RandomUniformDistribution, random uniform distribution)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/mantle_layer_models/grains/uniform.cc
+++ b/source/features/mantle_layer_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/mantle_layer_models/grains/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/mantle_layer_models/grains/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -157,9 +157,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_MANTLE_LAYER_GRAINS_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/mantle_layer_models/grains/uniform.cc
+++ b/source/features/mantle_layer_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer_models/grains/uniform.h>
+#include "world_builder/features/mantle_layer_models/grains/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/mantle_layer_models/temperature/adiabatic.cc
+++ b/source/features/mantle_layer_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer_models/temperature/adiabatic.h>
+#include "world_builder/features/mantle_layer_models/temperature/adiabatic.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/mantle_layer_models/temperature/adiabatic.cc
+++ b/source/features/mantle_layer_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/mantle_layer_models/temperature/adiabatic.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/mantle_layer_models/temperature/adiabatic.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -151,8 +151,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_MANTLE_LAYER_TEMPERATURE_MODEL(Adiabatic, adiabatic)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/mantle_layer_models/temperature/interface.cc
+++ b/source/features/mantle_layer_models/temperature/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer_models/temperature/interface.h>
+#include "world_builder/features/mantle_layer_models/temperature/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/mantle_layer_models/temperature/interface.cc
+++ b/source/features/mantle_layer_models/temperature/interface.cc
@@ -16,15 +16,14 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <algorithm>
+
+#include <world_builder/features/mantle_layer_models/temperature/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/mantle_layer_models/temperature/interface.h>
-#include <world_builder/features/mantle_layer_models/temperature/adiabatic.h>
-#include <world_builder/features/mantle_layer_models/temperature/linear.h>
-#include <world_builder/features/mantle_layer_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -90,8 +89,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/mantle_layer_models/temperature/linear.cc
+++ b/source/features/mantle_layer_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/mantle_layer_models/temperature/linear.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/mantle_layer_models/temperature/linear.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -128,8 +128,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_MANTLE_LAYER_TEMPERATURE_MODEL(Linear, linear)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/mantle_layer_models/temperature/linear.cc
+++ b/source/features/mantle_layer_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer_models/temperature/linear.h>
+#include "world_builder/features/mantle_layer_models/temperature/linear.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/mantle_layer_models/temperature/uniform.cc
+++ b/source/features/mantle_layer_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/mantle_layer_models/temperature/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/mantle_layer_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -100,8 +100,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_MANTLE_LAYER_TEMPERATURE_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/mantle_layer_models/temperature/uniform.cc
+++ b/source/features/mantle_layer_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/mantle_layer_models/temperature/uniform.h>
+#include "world_builder/features/mantle_layer_models/temperature/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate.cc
+++ b/source/features/oceanic_plate.cc
@@ -18,20 +18,17 @@
  */
 
 #include <world_builder/features/oceanic_plate.h>
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
-#include <world_builder/features/oceanic_plate_models/composition/interface.h>
 
-#include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
+#include <world_builder/types/plugin_system.h>
 #include <world_builder/types/point.h>
 #include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>
-#include <world_builder/types/plugin_system.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -239,6 +236,6 @@ namespace WorldBuilder
      * Register plugin
      */
     WB_REGISTER_FEATURE(OceanicPlate, oceanic plate)
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/oceanic_plate.cc
+++ b/source/features/oceanic_plate.cc
@@ -149,7 +149,7 @@ namespace WorldBuilder
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
-          for (auto &temperature_model: temperature_models)
+          for (const auto &temperature_model: temperature_models)
             {
               temperature = temperature_model->get_temperature(position,
                                                                depth,
@@ -182,7 +182,7 @@ namespace WorldBuilder
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
-          for (auto &composition_model: composition_models)
+          for (const auto &composition_model: composition_models)
             {
               composition = composition_model->get_composition(position,
                                                                depth,
@@ -215,7 +215,7 @@ namespace WorldBuilder
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
-          for (auto &grains_model: grains_models)
+          for (const auto &grains_model: grains_models)
             {
               grains = grains_model->get_grains(position,
                                                 depth,

--- a/source/features/oceanic_plate.cc
+++ b/source/features/oceanic_plate.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <world_builder/features/oceanic_plate.h>
+#include "world_builder/features/oceanic_plate.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/point.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate_models/composition/interface.cc
+++ b/source/features/oceanic_plate_models/composition/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/composition/interface.h>
+#include "world_builder/features/oceanic_plate_models/composition/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/oceanic_plate_models/composition/interface.cc
+++ b/source/features/oceanic_plate_models/composition/interface.cc
@@ -17,15 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
+#include <world_builder/features/oceanic_plate_models/composition/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/oceanic_plate_models/composition/interface.h>
-#include <world_builder/features/oceanic_plate_models/composition/uniform.h>
+#include <world_builder/types/string.h>
 
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -79,8 +77,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/oceanic_plate_models/composition/uniform.cc
+++ b/source/features/oceanic_plate_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/composition/uniform.h>
+#include "world_builder/features/oceanic_plate_models/composition/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate_models/composition/uniform.cc
+++ b/source/features/oceanic_plate_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/oceanic_plate_models/composition/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>
-#include <world_builder/features/oceanic_plate_models/composition/uniform.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -113,9 +113,9 @@ namespace WorldBuilder
           return composition;
         }
         WB_REGISTER_FEATURE_OCEANIC_PLATE_COMPOSITION_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/oceanic_plate_models/grains/interface.cc
+++ b/source/features/oceanic_plate_models/grains/interface.cc
@@ -17,14 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
-
-#include <world_builder/assert.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
 #include <world_builder/features/oceanic_plate_models/grains/interface.h>
 
+#include <world_builder/assert.h>
+#include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -106,8 +105,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/oceanic_plate_models/grains/interface.cc
+++ b/source/features/oceanic_plate_models/grains/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/grains/interface.h>
+#include "world_builder/features/oceanic_plate_models/grains/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -159,7 +159,7 @@ namespace WorldBuilder
                           double r  = std::sqrt( z );
                           double Vx = std::sin( phi ) * r;
                           double Vy = std::cos( phi ) * r;
-                          double Vz = std::sqrt( 2.f - z );
+                          double Vz = std::sqrt( 2.F - z );
 
                           // Compute the row vector S = Transpose(V) * R, where R is a simple
                           // rotation by theta about the z-axis.  No need to compute Sz since

--- a/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -17,22 +17,21 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
+#include <world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h>
 
-#include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/bool.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -207,9 +206,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_OCEANIC_PLATE_GRAINS_MODEL(RandomUniformDistribution, random uniform distribution)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -17,19 +17,19 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h>
+#include "world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/bool.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 #include <algorithm>
 

--- a/source/features/oceanic_plate_models/grains/uniform.cc
+++ b/source/features/oceanic_plate_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/oceanic_plate_models/grains/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/oceanic_plate_models/grains/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -158,9 +158,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_OCEANIC_PLATE_GRAINS_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/oceanic_plate_models/grains/uniform.cc
+++ b/source/features/oceanic_plate_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/grains/uniform.h>
+#include "world_builder/features/oceanic_plate_models/grains/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate_models/temperature/adiabatic.cc
+++ b/source/features/oceanic_plate_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/oceanic_plate_models/temperature/adiabatic.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/oceanic_plate_models/temperature/adiabatic.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -157,8 +157,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_OCEANIC_PLATE_TEMPERATURE_MODEL(Adiabatic, adiabatic)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/oceanic_plate_models/temperature/adiabatic.cc
+++ b/source/features/oceanic_plate_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/temperature/adiabatic.h>
+#include "world_builder/features/oceanic_plate_models/temperature/adiabatic.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate_models/temperature/interface.cc
+++ b/source/features/oceanic_plate_models/temperature/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/oceanic_plate_models/temperature/interface.cc
+++ b/source/features/oceanic_plate_models/temperature/interface.cc
@@ -17,16 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
+#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
-#include <world_builder/features/oceanic_plate_models/temperature/adiabatic.h>
-#include <world_builder/features/oceanic_plate_models/temperature/linear.h>
-#include <world_builder/features/oceanic_plate_models/temperature/plate_model.h>
-#include <world_builder/features/oceanic_plate_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -92,8 +89,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/oceanic_plate_models/temperature/linear.cc
+++ b/source/features/oceanic_plate_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/temperature/linear.h>
+#include "world_builder/features/oceanic_plate_models/temperature/linear.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate_models/temperature/linear.cc
+++ b/source/features/oceanic_plate_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/oceanic_plate_models/temperature/linear.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/oceanic_plate_models/temperature/linear.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -127,8 +127,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_OCEANIC_PLATE_TEMPERATURE_MODEL(Linear, linear)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/oceanic_plate_models/temperature/plate_model.cc
+++ b/source/features/oceanic_plate_models/temperature/plate_model.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/oceanic_plate_models/temperature/plate_model.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
+#include <world_builder/types/object.h>
 #include <world_builder/types/point.h>
 #include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
-#include <world_builder/features/oceanic_plate_models/temperature/plate_model.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -205,8 +205,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_OCEANIC_PLATE_TEMPERATURE_MODEL(PlateModel, plate model)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/oceanic_plate_models/temperature/plate_model.cc
+++ b/source/features/oceanic_plate_models/temperature/plate_model.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/temperature/plate_model.h>
+#include "world_builder/features/oceanic_plate_models/temperature/plate_model.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/point.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate_models/temperature/uniform.cc
+++ b/source/features/oceanic_plate_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/oceanic_plate_models/temperature/uniform.h>
+#include "world_builder/features/oceanic_plate_models/temperature/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate_models/temperature/uniform.cc
+++ b/source/features/oceanic_plate_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/oceanic_plate_models/temperature/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/oceanic_plate_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -99,8 +99,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_OCEANIC_PLATE_TEMPERATURE_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -17,19 +17,19 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <world_builder/features/subducting_plate.h>
+#include "world_builder/features/subducting_plate.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/point.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 #include "glm/glm.h"
 

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -450,7 +450,7 @@ namespace WorldBuilder
                   double temperature_current_section = temperature;
                   double temperature_next_section = temperature;
 
-                  for (auto &temperature_model: segment_vector[current_section][current_segment].temperature_systems)
+                  for (const auto &temperature_model: segment_vector[current_section][current_segment].temperature_systems)
                     {
                       temperature_current_section = temperature_model->get_temperature(position,
                                                                                        depth,
@@ -467,7 +467,7 @@ namespace WorldBuilder
 
                     }
 
-                  for (auto &temperature_model: segment_vector[next_section][current_segment].temperature_systems)
+                  for (const auto &temperature_model: segment_vector[next_section][current_segment].temperature_systems)
                     {
                       temperature_next_section = temperature_model->get_temperature(position,
                                                                                     depth,
@@ -579,7 +579,7 @@ namespace WorldBuilder
                   double composition_current_section = composition;
                   double composition_next_section = composition;
 
-                  for (auto &composition_model: segment_vector[current_section][current_segment].composition_systems)
+                  for (const auto &composition_model: segment_vector[current_section][current_segment].composition_systems)
                     {
                       composition_current_section = composition_model->get_composition(position,
                                                                                        depth,
@@ -596,7 +596,7 @@ namespace WorldBuilder
 
                     }
 
-                  for (auto &composition_model: segment_vector[next_section][current_segment].composition_systems)
+                  for (const auto &composition_model: segment_vector[next_section][current_segment].composition_systems)
                     {
                       composition_next_section = composition_model->get_composition(position,
                                                                                     depth,
@@ -711,7 +711,7 @@ namespace WorldBuilder
                   WorldBuilder::grains  grains_current_section = grains;
                   WorldBuilder::grains  grains_next_section = grains;
 
-                  for (auto &grains_model: segment_vector[current_section][current_segment].grains_systems)
+                  for (const auto &grains_model: segment_vector[current_section][current_segment].grains_systems)
                     {
                       grains_current_section = grains_model->get_grains(position,
                                                                         depth,
@@ -728,7 +728,7 @@ namespace WorldBuilder
 
                     }
 
-                  for (auto &grains_model: segment_vector[next_section][current_segment].grains_systems)
+                  for (const auto &grains_model: segment_vector[next_section][current_segment].grains_systems)
                     {
                       grains_next_section = grains_model->get_grains(position,
                                                                      depth,

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -18,24 +18,18 @@
  */
 
 #include <world_builder/features/subducting_plate.h>
-#include <world_builder/utilities.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
 #include <world_builder/types/plugin_system.h>
+#include <world_builder/types/point.h>
+#include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>
-
-#include <rapidjson/istreamwrapper.h>
-#include "rapidjson/pointer.h"
-#include "rapidjson/prettywriter.h"
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/error/en.h"
+#include <world_builder/utilities.h>
 
 #include "glm/glm.h"
 
@@ -774,6 +768,6 @@ namespace WorldBuilder
      * Register plugin
      */
     WB_REGISTER_FEATURE(SubductingPlate, subducting plate)
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/subducting_plate_models/composition/interface.cc
+++ b/source/features/subducting_plate_models/composition/interface.cc
@@ -17,14 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
+#include <world_builder/features/subducting_plate_models/composition/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/subducting_plate_models/composition/interface.h>
-#include <world_builder/features/subducting_plate_models/composition/uniform.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 
 namespace WorldBuilder
@@ -79,8 +78,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/subducting_plate_models/composition/interface.cc
+++ b/source/features/subducting_plate_models/composition/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/composition/interface.h>
+#include "world_builder/features/subducting_plate_models/composition/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/subducting_plate_models/composition/uniform.cc
+++ b/source/features/subducting_plate_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/composition/uniform.h>
+#include "world_builder/features/subducting_plate_models/composition/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/subducting_plate_models/composition/uniform.cc
+++ b/source/features/subducting_plate_models/composition/uniform.cc
@@ -17,17 +17,17 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/subducting_plate_models/composition/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>
-#include <world_builder/features/subducting_plate_models/composition/uniform.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -114,9 +114,9 @@ namespace WorldBuilder
           return composition;
         }
         WB_REGISTER_FEATURE_SUBDUCTING_PLATE_COMPOSITION_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/subducting_plate_models/grains/interface.cc
+++ b/source/features/subducting_plate_models/grains/interface.cc
@@ -17,14 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
-
-#include <world_builder/assert.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
 #include <world_builder/features/subducting_plate_models/grains/interface.h>
 
+#include <world_builder/assert.h>
+#include <world_builder/types/object.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -106,8 +105,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/subducting_plate_models/grains/interface.cc
+++ b/source/features/subducting_plate_models/grains/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/grains/interface.h>
+#include "world_builder/features/subducting_plate_models/grains/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -17,22 +17,21 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
+#include <world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h>
 
-#include <world_builder/utilities.h>
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/bool.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -208,9 +207,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_SUBDUCTING_PLATE_GRAINS_MODEL(RandomUniformDistribution, random uniform distribution)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -160,7 +160,7 @@ namespace WorldBuilder
                           double r  = std::sqrt( z );
                           double Vx = std::sin( phi ) * r;
                           double Vy = std::cos( phi ) * r;
-                          double Vz = std::sqrt( 2.f - z );
+                          double Vz = std::sqrt( 2.F - z );
 
                           // Compute the row vector S = Transpose(V) * R, where R is a simple
                           // rotation by theta about the z-axis.  No need to compute Sz since

--- a/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -17,19 +17,19 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h>
+#include "world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/bool.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 #include <algorithm>
 

--- a/source/features/subducting_plate_models/grains/uniform.cc
+++ b/source/features/subducting_plate_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/subducting_plate_models/grains/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/types/unsigned_int.h>
 #include <world_builder/types/plugin_system.h>
-#include <world_builder/features/subducting_plate_models/grains/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -160,9 +160,9 @@ namespace WorldBuilder
           return grains_local;
         }
         WB_REGISTER_FEATURE_SUBDUCTING_PLATE_GRAINS_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 

--- a/source/features/subducting_plate_models/grains/uniform.cc
+++ b/source/features/subducting_plate_models/grains/uniform.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/grains/uniform.h>
+#include "world_builder/features/subducting_plate_models/grains/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/subducting_plate_models/temperature/adiabatic.cc
+++ b/source/features/subducting_plate_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/temperature/adiabatic.h>
+#include "world_builder/features/subducting_plate_models/temperature/adiabatic.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/subducting_plate_models/temperature/adiabatic.cc
+++ b/source/features/subducting_plate_models/temperature/adiabatic.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/subducting_plate_models/temperature/adiabatic.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/subducting_plate_models/temperature/adiabatic.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -159,8 +159,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_SUBDUCTING_PLATE_TEMPERATURE_MODEL(Adiabatic, adiabatic)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/subducting_plate_models/temperature/interface.cc
+++ b/source/features/subducting_plate_models/temperature/interface.cc
@@ -17,11 +17,11 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
+#include "world_builder/assert.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
 
 #include <algorithm>
 

--- a/source/features/subducting_plate_models/temperature/interface.cc
+++ b/source/features/subducting_plate_models/temperature/interface.cc
@@ -17,17 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-#include <algorithm>
+#include <world_builder/features/subducting_plate_models/temperature/interface.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
-#include <world_builder/features/subducting_plate_models/temperature/adiabatic.h>
-#include <world_builder/features/subducting_plate_models/temperature/linear.h>
-#include <world_builder/features/subducting_plate_models/temperature/plate_model.h>
-#include <world_builder/features/subducting_plate_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
+
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -93,8 +89,8 @@ namespace WorldBuilder
           // thrown when the name is not present.
           return get_factory_map().at(lower_case_name)->create(world);
         }
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/subducting_plate_models/temperature/linear.cc
+++ b/source/features/subducting_plate_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/subducting_plate_models/temperature/linear.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/subducting_plate_models/temperature/linear.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -128,8 +128,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_SUBDUCTING_PLATE_TEMPERATURE_MODEL(Linear, linear)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/subducting_plate_models/temperature/linear.cc
+++ b/source/features/subducting_plate_models/temperature/linear.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/temperature/linear.h>
+#include "world_builder/features/subducting_plate_models/temperature/linear.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/features/subducting_plate_models/temperature/plate_model.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/subducting_plate_models/temperature/plate_model.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/array.h>
 #include <world_builder/types/bool.h>
 #include <world_builder/types/double.h>
+#include <world_builder/types/object.h>
 #include <world_builder/types/point.h>
 #include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
-#include <world_builder/features/subducting_plate_models/temperature/plate_model.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -218,8 +218,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_SUBDUCTING_PLATE_TEMPERATURE_MODEL(PlateModel, plate model)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/features/subducting_plate_models/temperature/plate_model.cc
@@ -17,18 +17,18 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/temperature/plate_model.h>
+#include "world_builder/features/subducting_plate_models/temperature/plate_model.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/bool.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/point.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/subducting_plate_models/temperature/uniform.cc
+++ b/source/features/subducting_plate_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/utilities.h>
+#include <world_builder/features/subducting_plate_models/temperature/uniform.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/nan.h>
 #include <world_builder/parameters.h>
-
 #include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
 #include <world_builder/types/object.h>
-#include <world_builder/features/subducting_plate_models/temperature/uniform.h>
+#include <world_builder/types/string.h>
+#include <world_builder/utilities.h>
 
 
 namespace WorldBuilder
@@ -101,8 +101,8 @@ namespace WorldBuilder
         }
 
         WB_REGISTER_FEATURE_SUBDUCTING_PLATE_TEMPERATURE_MODEL(Uniform, uniform)
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 

--- a/source/features/subducting_plate_models/temperature/uniform.cc
+++ b/source/features/subducting_plate_models/temperature/uniform.cc
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/subducting_plate_models/temperature/uniform.h>
+#include "world_builder/features/subducting_plate_models/temperature/uniform.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/string.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/features/utilities.cc
+++ b/source/features/utilities.cc
@@ -17,7 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/features/utilities.h>
+#include "world_builder/features/utilities.h"
 
 namespace WorldBuilder
 {

--- a/source/features/utilities.cc
+++ b/source/features/utilities.cc
@@ -34,6 +34,6 @@ namespace WorldBuilder
         WBAssert(operation == "replace", "Could not find operation: " << operation << ".");
         return Operations::REPLACE;
       }
-    }
-  }
-}
+    } // namespace Utilities
+  } // namespace Features
+} // namespace WorldBuilder

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -17,6 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <vector>
 #include <tuple>
@@ -1157,7 +1158,7 @@ namespace WorldBuilder
 
         for (size_t i = 0; i < array->Size(); ++i )
           {
-            vector.push_back(std::unique_ptr<Features::SubductingPlate>(new Features::SubductingPlate(&world)));
+            vector.push_back(std::make_unique<Features::SubductingPlate>(&world));
           }
       }
     else
@@ -1180,7 +1181,7 @@ namespace WorldBuilder
 
         for (size_t i = 0; i < array->Size(); ++i )
           {
-            vector.push_back(std::unique_ptr<Features::Fault>(new Features::Fault(&world)));
+            vector.push_back(std::make_unique<Features::Fault>(&world));
           }
       }
     else
@@ -1238,7 +1239,7 @@ namespace WorldBuilder
   void
   Parameters::declare_model_entries(const std::string &model_group_name,
                                     const std::string &parent_name,
-                                    const std::map<std::string, void ( *)(Parameters &,const std::string &)>& declare_map,
+                                    const std::map<std::string, void ( *)(Parameters &,const std::string &)> &declare_map,
                                     const std::vector<std::string> &required_entries,
                                     const std::vector<std::tuple<std::string,const WorldBuilder::Types::Interface &, std::string> > &extra_declarations)
   {
@@ -1331,7 +1332,7 @@ namespace WorldBuilder
 
                     // we need to get the json path relevant for the current declaration string
                     // we are interested in, which requires an offset of 2.
-                    WBAssert(Pointer((get_full_json_path(i+2) + "/model").c_str()).Get(parameters) != NULL, "Could not find model in: " << get_full_json_path(i+2) + "/model");
+                    WBAssert(Pointer((get_full_json_path(i+2) + "/model").c_str()).Get(parameters) != nullptr, "Could not find model in: " << get_full_json_path(i+2) + "/model");
                     std::string parameters_string = Pointer((get_full_json_path(i+2) + "/model").c_str()).Get(parameters)->GetString();
 
                     // currently in our case these are always objects, so go directly to find the option we need.

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -17,42 +17,42 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/parameters.h>
+#include "world_builder/parameters.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/config.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/config.h"
+#include "world_builder/utilities.h"
 
-#include <world_builder/types/array.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/segment.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/point.h"
+#include "world_builder/types/segment.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
 
-#include <world_builder/features/continental_plate_models/composition/interface.h>
-#include <world_builder/features/continental_plate_models/grains/interface.h>
-#include <world_builder/features/continental_plate_models/temperature/interface.h>
-#include <world_builder/features/mantle_layer_models/composition/interface.h>
-#include <world_builder/features/mantle_layer_models/grains/interface.h>
-#include <world_builder/features/mantle_layer_models/temperature/interface.h>
-#include <world_builder/features/oceanic_plate_models/composition/interface.h>
-#include <world_builder/features/oceanic_plate_models/grains/interface.h>
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
-#include <world_builder/features/subducting_plate_models/composition/interface.h>
-#include <world_builder/features/subducting_plate_models/grains/interface.h>
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
+#include "world_builder/features/continental_plate_models/composition/interface.h"
+#include "world_builder/features/continental_plate_models/grains/interface.h"
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
+#include "world_builder/features/mantle_layer_models/composition/interface.h"
+#include "world_builder/features/mantle_layer_models/grains/interface.h"
+#include "world_builder/features/mantle_layer_models/temperature/interface.h"
+#include "world_builder/features/oceanic_plate_models/composition/interface.h"
+#include "world_builder/features/oceanic_plate_models/grains/interface.h"
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
+#include "world_builder/features/subducting_plate_models/composition/interface.h"
+#include "world_builder/features/subducting_plate_models/grains/interface.h"
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
 
-#include <world_builder/features/fault.h>
-#include <world_builder/features/fault_models/composition/interface.h>
-#include <world_builder/features/fault_models/grains/interface.h>
-#include <world_builder/features/fault_models/temperature/interface.h>
-#include <world_builder/features/subducting_plate.h>
-#include <world_builder/features/subducting_plate_models/composition/interface.h>
-#include <world_builder/features/subducting_plate_models/grains/interface.h>
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
+#include "world_builder/features/fault.h"
+#include "world_builder/features/fault_models/composition/interface.h"
+#include "world_builder/features/fault_models/grains/interface.h"
+#include "world_builder/features/fault_models/temperature/interface.h"
+#include "world_builder/features/subducting_plate.h"
+#include "world_builder/features/subducting_plate_models/composition/interface.h"
+#include "world_builder/features/subducting_plate_models/grains/interface.h"
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
 
 
 #include "rapidjson/error/en.h"

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -1238,7 +1238,7 @@ namespace WorldBuilder
   void
   Parameters::declare_model_entries(const std::string &model_group_name,
                                     const std::string &parent_name,
-                                    std::map<std::string, void ( *)(Parameters &,const std::string &)> declare_map,
+                                    const std::map<std::string, void ( *)(Parameters &,const std::string &)>& declare_map,
                                     const std::vector<std::string> &required_entries,
                                     const std::vector<std::tuple<std::string,const WorldBuilder::Types::Interface &, std::string> > &extra_declarations)
   {

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -1244,7 +1244,7 @@ namespace WorldBuilder
                                     const std::vector<std::tuple<std::string,const WorldBuilder::Types::Interface &, std::string> > &extra_declarations)
   {
     unsigned int counter = 0;
-    for (auto &it : declare_map)
+    for (const auto &it : declare_map)
       {
         typedef std::tuple<std::string,const WorldBuilder::Types::Interface &, std::string> DeclareEntry;
         // prevent infinite recursion

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -16,54 +16,57 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <fstream>
-#include <memory>
-#include <sstream>
-#include <vector>
-#include <tuple>
 
-#include <rapidjson/istreamwrapper.h>
-#include "rapidjson/pointer.h"
-#include "rapidjson/prettywriter.h"
-#include "rapidjson/latexwriter.h"
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/error/en.h"
+#include <world_builder/parameters.h>
 
 #include <world_builder/assert.h>
 #include <world_builder/config.h>
-#include <world_builder/parameters.h>
 #include <world_builder/utilities.h>
 
-#include <world_builder/types/object.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/segment.h>
 #include <world_builder/types/array.h>
-#include <world_builder/types/unsigned_int.h>
+#include <world_builder/types/double.h>
+#include <world_builder/types/object.h>
 #include <world_builder/types/plugin_system.h>
+#include <world_builder/types/point.h>
+#include <world_builder/types/segment.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
 
-#include <world_builder/features/continental_plate_models/temperature/interface.h>
 #include <world_builder/features/continental_plate_models/composition/interface.h>
 #include <world_builder/features/continental_plate_models/grains/interface.h>
-#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
-#include <world_builder/features/oceanic_plate_models/composition/interface.h>
-#include <world_builder/features/oceanic_plate_models/grains/interface.h>
-#include <world_builder/features/mantle_layer_models/temperature/interface.h>
+#include <world_builder/features/continental_plate_models/temperature/interface.h>
 #include <world_builder/features/mantle_layer_models/composition/interface.h>
 #include <world_builder/features/mantle_layer_models/grains/interface.h>
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
+#include <world_builder/features/mantle_layer_models/temperature/interface.h>
+#include <world_builder/features/oceanic_plate_models/composition/interface.h>
+#include <world_builder/features/oceanic_plate_models/grains/interface.h>
+#include <world_builder/features/oceanic_plate_models/temperature/interface.h>
 #include <world_builder/features/subducting_plate_models/composition/interface.h>
 #include <world_builder/features/subducting_plate_models/grains/interface.h>
+#include <world_builder/features/subducting_plate_models/temperature/interface.h>
 
-#include <world_builder/features/subducting_plate.h>
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
-#include <world_builder/features/subducting_plate_models/composition/interface.h>
-#include <world_builder/features/subducting_plate_models/grains/interface.h>
 #include <world_builder/features/fault.h>
-#include <world_builder/features/fault_models/temperature/interface.h>
 #include <world_builder/features/fault_models/composition/interface.h>
 #include <world_builder/features/fault_models/grains/interface.h>
+#include <world_builder/features/fault_models/temperature/interface.h>
+#include <world_builder/features/subducting_plate.h>
+#include <world_builder/features/subducting_plate_models/composition/interface.h>
+#include <world_builder/features/subducting_plate_models/grains/interface.h>
+#include <world_builder/features/subducting_plate_models/temperature/interface.h>
+
+
+#include "rapidjson/error/en.h"
+#include "rapidjson/istreamwrapper.h"
+#include "rapidjson/latexwriter.h"
+#include "rapidjson/pointer.h"
+#include "rapidjson/prettywriter.h"
+#include "rapidjson/stringbuffer.h"
+
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <tuple>
+#include <vector>
 
 using namespace rapidjson;
 
@@ -1572,5 +1575,5 @@ namespace WorldBuilder
 
 
 
-}
+} // namespace WorldBuilder
 

--- a/source/point.cc
+++ b/source/point.cc
@@ -17,9 +17,9 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/point.h>
+#include "world_builder/point.h"
 
-#include <world_builder/assert.h>
+#include "world_builder/assert.h"
 
 #include <iostream>
 #include <limits>

--- a/source/point.cc
+++ b/source/point.cc
@@ -17,11 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <limits>
-#include <iostream>
-
 #include <world_builder/point.h>
+
 #include <world_builder/assert.h>
+
+#include <iostream>
+#include <limits>
+
 
 namespace WorldBuilder
 {
@@ -332,4 +334,4 @@ namespace WorldBuilder
    * Multiplies a 3d point with a scalar.
    */
   template Point<3> operator*(const double scalar, const Point<3> &point);
-}
+} // namespace WorldBuilder

--- a/source/types/array.cc
+++ b/source/types/array.cc
@@ -17,7 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/parameters.h>
 
@@ -80,6 +80,6 @@ namespace WorldBuilder
 
 
     }
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 

--- a/source/types/array.cc
+++ b/source/types/array.cc
@@ -16,10 +16,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <world_builder/types/array.h>
+#include "world_builder/types/array.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/parameters.h>
+#include "world_builder/assert.h"
+#include "world_builder/parameters.h"
 
 namespace WorldBuilder
 {

--- a/source/types/bool.cc
+++ b/source/types/bool.cc
@@ -16,10 +16,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <world_builder/types/bool.h>
+#include "world_builder/types/bool.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/utilities.h"
 
 namespace WorldBuilder
 {

--- a/source/types/bool.cc
+++ b/source/types/bool.cc
@@ -17,9 +17,9 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <world_builder/types/bool.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/utilities.h>
-#include <world_builder/parameters.h>
 
 namespace WorldBuilder
 {
@@ -58,6 +58,6 @@ namespace WorldBuilder
       Pointer((base + "/type").c_str()).Set(declarations,"boolean");
       Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
     }
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 

--- a/source/types/double.cc
+++ b/source/types/double.cc
@@ -16,10 +16,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <world_builder/types/double.h>
+#include "world_builder/types/double.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/utilities.h"
 
 namespace WorldBuilder
 {

--- a/source/types/double.cc
+++ b/source/types/double.cc
@@ -17,9 +17,9 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <world_builder/types/double.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/utilities.h>
-#include <world_builder/parameters.h>
 
 namespace WorldBuilder
 {
@@ -59,6 +59,6 @@ namespace WorldBuilder
       Pointer((base + "/type").c_str()).Set(declarations,"number");
       Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
     }
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 

--- a/source/types/interface.cc
+++ b/source/types/interface.cc
@@ -17,11 +17,12 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <algorithm>
+#include <world_builder/types/interface.h>
 
 #include <world_builder/assert.h>
 
-#include <world_builder/types/interface.h>
+#include <algorithm>
+
 
 
 namespace WorldBuilder
@@ -42,6 +43,6 @@ namespace WorldBuilder
     {
       return type_name;
     }
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 

--- a/source/types/interface.cc
+++ b/source/types/interface.cc
@@ -17,9 +17,9 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/types/interface.h>
+#include "world_builder/types/interface.h"
 
-#include <world_builder/assert.h>
+#include "world_builder/assert.h"
 
 #include <algorithm>
 

--- a/source/types/object.cc
+++ b/source/types/object.cc
@@ -17,10 +17,10 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/types/object.h>
+#include "world_builder/types/object.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/parameters.h>
+#include "world_builder/assert.h"
+#include "world_builder/parameters.h"
 
 #include <utility>
 

--- a/source/types/object.cc
+++ b/source/types/object.cc
@@ -16,7 +16,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+
 #include <world_builder/types/object.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/parameters.h>
 
@@ -86,6 +88,6 @@ namespace WorldBuilder
       }
       prm.enter_subsection("properties");
     }
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 

--- a/source/types/plugin_system.cc
+++ b/source/types/plugin_system.cc
@@ -16,9 +16,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <world_builder/types/plugin_system.h>
+#include "world_builder/types/plugin_system.h"
 
-#include <world_builder/assert.h>
+#include "world_builder/assert.h"
 
 #include <utility>
 

--- a/source/types/plugin_system.cc
+++ b/source/types/plugin_system.cc
@@ -39,7 +39,7 @@ namespace WorldBuilder
     {
       this->type_name = Types::type::PluginSystem;
 
-      WBAssert(declare_entries_ != NULL, "declare entries may not be a null pointer.");
+      WBAssert(declare_entries_ != nullptr, "declare entries may not be a null pointer.");
     }
 
 
@@ -75,7 +75,7 @@ namespace WorldBuilder
 
             prm.enter_subsection("items");
             {
-              WBAssert(this->declare_entries != NULL, "No declare entries given.");
+              WBAssert(this->declare_entries != nullptr, "No declare entries given.");
 
               this->declare_entries(prm, name, required_entries);
             }
@@ -86,7 +86,7 @@ namespace WorldBuilder
             Pointer((path + "/type").c_str()).Set(prm.declarations,"object");
 
             //std::cout << "-------use pluginsystem with name " << name << ", and pointer = " << declare_entries<< " and reqruied entires.size() = " << required_entries.size() << std::endl;
-            WBAssert(this->declare_entries != NULL, "No declare entries given.");
+            WBAssert(this->declare_entries != nullptr, "No declare entries given.");
             this->declare_entries(prm, name, required_entries);
 
 

--- a/source/types/plugin_system.cc
+++ b/source/types/plugin_system.cc
@@ -19,7 +19,6 @@
 #include <world_builder/types/plugin_system.h>
 
 #include <world_builder/assert.h>
-#include <world_builder/parameters.h>
 
 #include <utility>
 
@@ -94,6 +93,6 @@ namespace WorldBuilder
       }
       prm.leave_subsection();
     }
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 

--- a/source/types/point.cc
+++ b/source/types/point.cc
@@ -16,10 +16,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <world_builder/types/point.h>
+#include "world_builder/types/point.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/utilities.h"
 
 #include <utility>
 

--- a/source/types/point.cc
+++ b/source/types/point.cc
@@ -17,9 +17,9 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <world_builder/types/point.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/utilities.h>
-#include <world_builder/parameters.h>
 
 #include <utility>
 
@@ -172,6 +172,6 @@ namespace WorldBuilder
      * WorldBuilder::Point<3>.
      */
     template WorldBuilder::Point<3> operator*(const double scalar, const Point<3> &point);
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 

--- a/source/types/segment.cc
+++ b/source/types/segment.cc
@@ -17,17 +17,16 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <world_builder/types/segment.h>
+
 #include <world_builder/assert.h>
-#include <world_builder/utilities.h>
-#include <world_builder/parameters.h>
-
-
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
-#include <world_builder/features/subducting_plate_models/composition/interface.h>
-#include <world_builder/features/subducting_plate_models/grains/interface.h>
-#include <world_builder/features/fault_models/temperature/interface.h>
 #include <world_builder/features/fault_models/composition/interface.h>
 #include <world_builder/features/fault_models/grains/interface.h>
+#include <world_builder/features/fault_models/temperature/interface.h>
+#include <world_builder/features/subducting_plate_models/composition/interface.h>
+#include <world_builder/features/subducting_plate_models/grains/interface.h>
+#include <world_builder/features/subducting_plate_models/temperature/interface.h>
+#include <world_builder/parameters.h>
+#include <world_builder/utilities.h>
 
 namespace WorldBuilder
 {
@@ -140,7 +139,7 @@ namespace WorldBuilder
       prm.leave_subsection();
 
     }
-  }
+  } // namespace Types
 
   namespace Objects
   {
@@ -217,6 +216,6 @@ namespace WorldBuilder
     //template class
     //Segment<char,char>;
 
-  }
-}
+  } // namespace Objects
+} // namespace WorldBuilder
 

--- a/source/types/segment.cc
+++ b/source/types/segment.cc
@@ -16,17 +16,17 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <world_builder/types/segment.h>
+#include "world_builder/types/segment.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/features/fault_models/composition/interface.h>
-#include <world_builder/features/fault_models/grains/interface.h>
-#include <world_builder/features/fault_models/temperature/interface.h>
-#include <world_builder/features/subducting_plate_models/composition/interface.h>
-#include <world_builder/features/subducting_plate_models/grains/interface.h>
-#include <world_builder/features/subducting_plate_models/temperature/interface.h>
-#include <world_builder/parameters.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/features/fault_models/composition/interface.h"
+#include "world_builder/features/fault_models/grains/interface.h"
+#include "world_builder/features/fault_models/temperature/interface.h"
+#include "world_builder/features/subducting_plate_models/composition/interface.h"
+#include "world_builder/features/subducting_plate_models/grains/interface.h"
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
+#include "world_builder/parameters.h"
+#include "world_builder/utilities.h"
 
 namespace WorldBuilder
 {

--- a/source/types/string.cc
+++ b/source/types/string.cc
@@ -17,6 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <world_builder/types/string.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/parameters.h>
 
@@ -116,6 +117,6 @@ namespace WorldBuilder
         }
     }
 
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 

--- a/source/types/string.cc
+++ b/source/types/string.cc
@@ -16,10 +16,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <world_builder/types/string.h>
+#include "world_builder/types/string.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/parameters.h>
+#include "world_builder/assert.h"
+#include "world_builder/parameters.h"
 
 #include <utility>
 

--- a/source/types/unsigned_int.cc
+++ b/source/types/unsigned_int.cc
@@ -17,9 +17,9 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <world_builder/types/unsigned_int.h>
+
 #include <world_builder/assert.h>
 #include <world_builder/utilities.h>
-#include <world_builder/parameters.h>
 
 #include <world_builder/nan.h>
 
@@ -62,6 +62,6 @@ namespace WorldBuilder
       Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
 
     }
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 

--- a/source/types/unsigned_int.cc
+++ b/source/types/unsigned_int.cc
@@ -16,12 +16,12 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <world_builder/types/unsigned_int.h>
+#include "world_builder/types/unsigned_int.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/utilities.h"
 
-#include <world_builder/nan.h>
+#include "world_builder/nan.h"
 
 namespace WorldBuilder
 {

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1183,7 +1183,7 @@ namespace WorldBuilder
                                    const std::vector<double> &y,
                                    bool monotone_spline)
     {
-      WBAssert(x.size() != 0, "Internal error: The x in the set points function is zero.");
+      WBAssert(!x.empty(), "Internal error: The x in the set points function is zero.");
       assert(x.size() == y.size());
       m_x = x;
       m_y = y;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -17,10 +17,10 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/assert.h>
-#include <world_builder/coordinate_systems/interface.h>
-#include <world_builder/nan.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/coordinate_systems/interface.h"
+#include "world_builder/nan.h"
+#include "world_builder/utilities.h"
 
 #include <algorithm>
 #include <iomanip>

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -17,14 +17,14 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <iostream>
-#include <iomanip>
-#include <algorithm>
-
 #include <world_builder/assert.h>
 #include <world_builder/coordinate_systems/interface.h>
 #include <world_builder/nan.h>
 #include <world_builder/utilities.h>
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
 
 
 namespace WorldBuilder
@@ -1350,8 +1350,8 @@ namespace WorldBuilder
 
     template std::array<double,2> convert_point_to_array<2>(const Point<2> &point_);
     template std::array<double,3> convert_point_to_array<3>(const Point<3> &point_);
-  }
-}
+  } // namespace Utilities
+} // namespace WorldBuilder
 
 
 

--- a/source/world.cc
+++ b/source/world.cc
@@ -17,25 +17,25 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/world.h>
+#include "world_builder/world.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/config.h>
-#include <world_builder/coordinate_systems/interface.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/point.h>
-#include <world_builder/types/interface.h>
-#include <world_builder/utilities.h>
+#include "world_builder/assert.h"
+#include "world_builder/config.h"
+#include "world_builder/coordinate_systems/interface.h"
+#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
+#include "world_builder/point.h"
+#include "world_builder/types/interface.h"
+#include "world_builder/utilities.h"
 
-#include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
+#include "world_builder/types/array.h"
+#include "world_builder/types/bool.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/point.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
 
 #include "rapidjson/pointer.h"
 

--- a/source/world.cc
+++ b/source/world.cc
@@ -17,6 +17,28 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include <world_builder/world.h>
+
+#include <world_builder/assert.h>
+#include <world_builder/config.h>
+#include <world_builder/coordinate_systems/interface.h>
+#include <world_builder/nan.h>
+#include <world_builder/parameters.h>
+#include <world_builder/point.h>
+#include <world_builder/types/interface.h>
+#include <world_builder/utilities.h>
+
+#include <world_builder/types/array.h>
+#include <world_builder/types/bool.h>
+#include <world_builder/types/double.h>
+#include <world_builder/types/object.h>
+#include <world_builder/types/plugin_system.h>
+#include <world_builder/types/point.h>
+#include <world_builder/types/string.h>
+#include <world_builder/types/unsigned_int.h>
+
+#include "rapidjson/pointer.h"
+
 #ifdef WB_WITH_MPI
 #define OMPI_SKIP_MPICXX 1
 #include <mpi.h>
@@ -24,28 +46,6 @@
 
 #include <sstream>
 #include <utility>
-
-#include "rapidjson/pointer.h"
-
-#include <world_builder/config.h>
-#include <world_builder/world.h>
-#include <world_builder/utilities.h>
-#include <world_builder/assert.h>
-#include <world_builder/point.h>
-#include <world_builder/nan.h>
-#include <world_builder/parameters.h>
-#include <world_builder/coordinate_systems/interface.h>
-#include <world_builder/types/interface.h>
-
-#include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/unsigned_int.h>
-#include <world_builder/types/plugin_system.h>
-
 
 namespace WorldBuilder
 {
@@ -438,5 +438,5 @@ namespace WorldBuilder
     return random_number_engine;
   }
 
-}
+} // namespace WorldBuilder
 

--- a/source/wrapper_c.cc
+++ b/source/wrapper_c.cc
@@ -17,9 +17,10 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/world.h>
 #include <world_builder/wrapper_c.h>
+
 #include <world_builder/assert.h>
+#include <world_builder/world.h>
 
 extern "C" {
   /**

--- a/source/wrapper_c.cc
+++ b/source/wrapper_c.cc
@@ -17,10 +17,10 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <world_builder/wrapper_c.h>
+#include "world_builder/wrapper_c.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/world.h>
+#include "world_builder/assert.h"
+#include "world_builder/world.h"
 
 extern "C" {
   /**

--- a/source/wrapper_cpp.cc
+++ b/source/wrapper_cpp.cc
@@ -17,12 +17,12 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <utility>
+#include "world_builder/world.h"
 
 #include "world_builder/wrapper_cpp.h"
-#include "world_builder/world.h"
-#include "iostream"
 
+#include <iostream>
+#include <utility>
 using namespace WorldBuilder;
 namespace wrapper_cpp
 {
@@ -65,4 +65,4 @@ namespace wrapper_cpp
     std::array<double,3> position = {{x,y,z}};
     return reinterpret_cast<WorldBuilder::World *>(ptr_ptr_world)->composition(position,depth,composition_number);
   }
-}
+} // namespace wrapper_cpp

--- a/tests/C/example.c
+++ b/tests/C/example.c
@@ -1,5 +1,5 @@
 
-#include <world_builder/wrapper_c.h>
+#include "world_builder/wrapper_c.h"
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {

--- a/tests/CPP_MPI/example.cpp
+++ b/tests/CPP_MPI/example.cpp
@@ -1,5 +1,5 @@
 
-#include <world_builder/world.h>
+#include "world_builder/world.h"
 
 #include <stdio.h>
 #include <mpi.h>

--- a/tests/unit_tests/unit_test_wb_glm.cc
+++ b/tests/unit_tests/unit_test_wb_glm.cc
@@ -22,7 +22,7 @@
 
 #include <catch2.h>
 
-#include <world_builder/utilities.h>
+#include "world_builder/utilities.h"
 
 #include "glm/glm.h"
 

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -27,20 +27,20 @@
 #include <world_builder/config.h>
 #include <world_builder/coordinate_systems/interface.h>
 
-#include <world_builder/features/interface.h>
 #include <world_builder/features/continental_plate.h>
+#include <world_builder/features/fault_models/composition/uniform.h>
 #include <world_builder/features/fault_models/grains/interface.h>
 #include <world_builder/features/fault_models/temperature/uniform.h>
-#include <world_builder/features/fault_models/composition/uniform.h>
+#include <world_builder/features/interface.h>
 
 #include <world_builder/point.h>
 
 #include <world_builder/types/array.h>
 #include <world_builder/types/bool.h>
 #include <world_builder/types/double.h>
+#include <world_builder/types/object.h>
 #include <world_builder/types/plugin_system.h>
 #include <world_builder/types/point.h>
-#include <world_builder/types/object.h>
 #include <world_builder/types/segment.h>
 #include <world_builder/types/string.h>
 #include <world_builder/types/unsigned_int.h>

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -24,32 +24,32 @@
 
 #include <catch2.h>
 
-#include <world_builder/config.h>
-#include <world_builder/coordinate_systems/interface.h>
+#include "world_builder/config.h"
+#include "world_builder/coordinate_systems/interface.h"
 
-#include <world_builder/features/continental_plate.h>
-#include <world_builder/features/fault_models/composition/uniform.h>
-#include <world_builder/features/fault_models/grains/interface.h>
-#include <world_builder/features/fault_models/temperature/uniform.h>
-#include <world_builder/features/interface.h>
+#include "world_builder/features/continental_plate.h"
+#include "world_builder/features/fault_models/composition/uniform.h"
+#include "world_builder/features/fault_models/grains/interface.h"
+#include "world_builder/features/fault_models/temperature/uniform.h"
+#include "world_builder/features/interface.h"
 
-#include <world_builder/point.h>
+#include "world_builder/point.h"
 
-#include <world_builder/types/array.h>
-#include <world_builder/types/bool.h>
-#include <world_builder/types/double.h>
-#include <world_builder/types/object.h>
-#include <world_builder/types/plugin_system.h>
-#include <world_builder/types/point.h>
-#include <world_builder/types/segment.h>
-#include <world_builder/types/string.h>
-#include <world_builder/types/unsigned_int.h>
+#include "world_builder/types/array.h"
+#include "world_builder/types/bool.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/plugin_system.h"
+#include "world_builder/types/point.h"
+#include "world_builder/types/segment.h"
+#include "world_builder/types/string.h"
+#include "world_builder/types/unsigned_int.h"
 
-#include <world_builder/utilities.h>
+#include "world_builder/utilities.h"
 extern "C" {
-#include <world_builder/wrapper_c.h>
+#include "world_builder/wrapper_c.h"
 }
-#include <world_builder/wrapper_cpp.h>
+#include "world_builder/wrapper_cpp.h"
 
 #include "glm/glm.h"
 

--- a/visualization/main.cc
+++ b/visualization/main.cc
@@ -23,16 +23,16 @@
  * the author of GHOST.
  */
 
-#include <visualization/main.h>
+#include "visualization/main.h"
 
-#include <world_builder/assert.h>
-#include <world_builder/coordinate_system.h>
-#include <world_builder/nan.h>
-#include <world_builder/utilities.h>
-#include <world_builder/world.h>
+#include "world_builder/assert.h"
+#include "world_builder/coordinate_system.h"
+#include "world_builder/nan.h"
+#include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
-#include <vtu11/vtu11.hpp>
+#include "vtu11/vtu11.hpp"
 #undef max
 #undef min
 

--- a/visualization/main.cc
+++ b/visualization/main.cc
@@ -22,33 +22,33 @@
  * and was contribute to the World Builder with the permission and help of
  * the author of GHOST.
  */
-#include <cmath>
+
+#include <visualization/main.h>
+
+#include <world_builder/assert.h>
+#include <world_builder/coordinate_system.h>
+#include <world_builder/nan.h>
+#include <world_builder/utilities.h>
+#include <world_builder/world.h>
+
+
+#include <vtu11/vtu11.hpp>
+#undef max
+#undef min
 
 #ifdef WB_WITH_MPI
 #include <mpi.h>
 #endif
 
-
 #include <algorithm>
-#include <exception>
-#include <iostream>
 #include <array>
+#include <cmath>
+#include <exception>
 #include <fstream>
+#include <iostream>
 #include <memory>
 #include <thread>
 
-#include <world_builder/assert.h>
-#include <world_builder/nan.h>
-#include <world_builder/utilities.h>
-#include <world_builder/world.h>
-#include <world_builder/coordinate_system.h>
-
-#include <visualization/main.h>
-
-#include <vtu11/vtu11.hpp>
-
-#undef max
-#undef min
 
 using namespace WorldBuilder;
 using namespace WorldBuilder::Utilities;

--- a/visualization/main.cc
+++ b/visualization/main.cc
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <array>
 #include <fstream>
+#include <memory>
 #include <thread>
 
 #include <world_builder/assert.h>
@@ -309,7 +310,7 @@ int main(int argc, char **argv)
       std::unique_ptr<WorldBuilder::World> world;
       try
         {
-          world = std::unique_ptr<WorldBuilder::World>(new WorldBuilder::World(wb_file));
+          world = std::make_unique<WorldBuilder::World>(wb_file);
         }
       catch (std::exception &e)
         {


### PR DESCRIPTION
This adds an option to run the clang-tidy check when compiling. It is off by default, because it makes compiling slower and is only useful when developing (could turn it on in debug mode in the future). I also am rerunning and fixing a select set of clang-tidy checks clang-tidy now that I am using cpp14. I am not sure whether all changes have to do with c++14 or I just missed them before.

I am also considering adding a test whether there are any issues.