### PR TITLE
Fix clang and removed unneeded headers

### DIFF
--- a/app/main.cc
+++ b/app/main.cc
@@ -22,7 +22,6 @@
 #endif
 
 #include <algorithm>
-#include <exception>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -30,7 +29,6 @@
 #include "world_builder/assert.h"
 #include "world_builder/utilities.h"
 #include "world_builder/world.h"
-
 #include "app/main.h"
 
 using namespace WorldBuilder::Utilities;

--- a/app/main.cc
+++ b/app/main.cc
@@ -17,6 +17,13 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+
+#include "app/main.h"
+
+#include "world_builder/assert.h"
+#include "world_builder/utilities.h"
+#include "world_builder/world.h"
+
 #ifdef WB_WITH_MPI
 #include <mpi.h>
 #endif
@@ -25,11 +32,6 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-
-#include "world_builder/assert.h"
-#include "world_builder/utilities.h"
-#include "world_builder/world.h"
-#include "app/main.h"
 
 using namespace WorldBuilder::Utilities;
 

--- a/include/app/main.h
+++ b/include/app/main.h
@@ -20,6 +20,8 @@
 #ifndef WORLD_BUILDER_APP_MAIN_H_
 #define WORLD_BUILDER_APP_MAIN_H_
 
+#include <string>
+
 bool find_command_line_option(char **begin, char **end, const std::string &option);
 
 #endif

--- a/include/rapidjson/latexwriter.h
+++ b/include/rapidjson/latexwriter.h
@@ -16,7 +16,10 @@
 #define RAPIDJSON_LATEXWRITER_H_
 
 #include "writer.h"
+
 #include <iostream>
+#include <string>
+#include <vector>
 
 #ifdef __GNUC__
 RAPIDJSON_DIAG_PUSH

--- a/include/vtu11/vtu11.hpp
+++ b/include/vtu11/vtu11.hpp
@@ -6061,7 +6061,7 @@ namespace detail
 {
 
 template<typename T> inline
-void writeNumber( char (&buffer)[64], T value )
+void writeNumber( char (&/*buffer*/)[64], T /*value*/ )
 {
     VTU11_THROW( "Invalid data type." );
 }

--- a/include/world_builder/assert.h
+++ b/include/world_builder/assert.h
@@ -19,10 +19,7 @@
 #ifndef WORLD_BUILDER_ASSERT_H_
 #define WORLD_BUILDER_ASSERT_H_
 
-#include <iostream>
-#include <string>
 #include <sstream>
-#include <stdexcept>
 
 namespace WorldBuilder
 {

--- a/include/world_builder/coordinate_systems/cartesian.h
+++ b/include/world_builder/coordinate_systems/cartesian.h
@@ -20,8 +20,8 @@
 #ifndef _world_builder_coordinate_systems_cartesian_h
 #define _world_builder_coordinate_systems_cartesian_h
 
+
 #include "world_builder/utilities.h"
-#include "world_builder/coordinate_systems/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/coordinate_systems/cartesian.h
+++ b/include/world_builder/coordinate_systems/cartesian.h
@@ -20,12 +20,14 @@
 #ifndef _world_builder_coordinate_systems_cartesian_h
 #define _world_builder_coordinate_systems_cartesian_h
 
+#include "world_builder/coordinate_systems/interface.h"
 
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+
   namespace CoordinateSystems
   {
     /**

--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -20,15 +20,13 @@
 #ifndef _world_builder_coordinate_systems_interface_h
 #define _world_builder_coordinate_systems_interface_h
 
-#include "world_builder/coordinate_system.h"
 #include "world_builder/parameters.h"
-#include "world_builder/utilities.h"
-#include "world_builder/world.h"
 #include "world_builder/types/string.h"
 
 
 namespace WorldBuilder
 {
+
   namespace CoordinateSystems
   {
 

--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -20,12 +20,16 @@
 #ifndef _world_builder_coordinate_systems_interface_h
 #define _world_builder_coordinate_systems_interface_h
 
+#include "world_builder/coordinate_systems/interface.h"
+
+#include "world_builder/coordinate_system.h"
 #include "world_builder/parameters.h"
 #include "world_builder/types/string.h"
 
 
 namespace WorldBuilder
 {
+  class World;
 
   namespace CoordinateSystems
   {

--- a/include/world_builder/coordinate_systems/spherical.h
+++ b/include/world_builder/coordinate_systems/spherical.h
@@ -20,12 +20,14 @@
 #ifndef _world_builder_coordinate_systems_spherical_h
 #define _world_builder_coordinate_systems_spherical_h
 
-#include "world_builder/utilities.h"
 #include "world_builder/coordinate_systems/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+
   namespace CoordinateSystems
   {
     /**

--- a/include/world_builder/coordinate_systems/spherical.h
+++ b/include/world_builder/coordinate_systems/spherical.h
@@ -22,11 +22,10 @@
 
 #include "world_builder/coordinate_systems/interface.h"
 
+#include <string>
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
 
   namespace CoordinateSystems
   {

--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -20,18 +20,33 @@
 #ifndef _world_feature_features_continental_plate_h
 #define _world_feature_features_continental_plate_h
 
-#include "world_builder/features/interface.h"
-#include "world_builder/world.h"
 
-#include "world_builder/features/continental_plate_models/temperature/interface.h"
-#include "world_builder/features/continental_plate_models/composition/interface.h"
-#include "world_builder/features/continental_plate_models/grains/interface.h"
+#include "world_builder/features/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+
   namespace Features
   {
+    namespace ContinentalPlateModels
+    {
+      namespace Composition
+      {
+        class Interface;
+      }  // namespace Composition
+      namespace Grains
+      {
+        class Interface;
+      }  // namespace Grains
+      namespace Temperature
+      {
+        class Interface;
+      }  // namespace Temperature
+    }  // namespace ContinentalPlateModels
+
     /**
      * This class represents a continental plate and can implement submodules
      * for temperature and composition. These submodules determine what

--- a/include/world_builder/features/continental_plate_models/composition/interface.h
+++ b/include/world_builder/features/continental_plate_models/composition/interface.h
@@ -20,18 +20,15 @@
 #ifndef _world_builder_features_continental_plate_composition_interface_h
 #define _world_builder_features_continental_plate_composition_interface_h
 
-#include <vector>
-#include <map>
 
-
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
 
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/continental_plate_models/composition/interface.h
+++ b/include/world_builder/features/continental_plate_models/composition/interface.h
@@ -26,9 +26,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  class Parameters;
-  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/continental_plate_models/composition/uniform.h
+++ b/include/world_builder/features/continental_plate_models/composition/uniform.h
@@ -26,10 +26,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
-
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/composition/uniform.h
+++ b/include/world_builder/features/continental_plate_models/composition/uniform.h
@@ -20,12 +20,16 @@
 #ifndef _world_builder_features_continental_plate_composition_uniform_h
 #define _world_builder_features_continental_plate_composition_uniform_h
 
+
 #include "world_builder/features/continental_plate_models/composition/interface.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/grains/interface.h
+++ b/include/world_builder/features/continental_plate_models/grains/interface.h
@@ -20,18 +20,16 @@
 #ifndef _world_builder_features_continental_plate_grains_interface_h
 #define _world_builder_features_continental_plate_grains_interface_h
 
-#include <vector>
-#include <map>
 
-
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
+#include "world_builder/grains.h"
 
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/continental_plate_models/grains/interface.h
+++ b/include/world_builder/features/continental_plate_models/grains/interface.h
@@ -21,8 +21,8 @@
 #define _world_builder_features_continental_plate_grains_interface_h
 
 
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_continental_plate_grains_random_uniform_distribution_h
 #define _world_builder_features_continental_plate_grains_random_uniform_distribution_h
 
+
 #include "world_builder/features/continental_plate_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
@@ -26,8 +26,6 @@
 namespace WorldBuilder
 {
   class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/continental_plate_models/grains/uniform.h
+++ b/include/world_builder/features/continental_plate_models/grains/uniform.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_continental_plate_grains_uniform_h
 #define _world_builder_features_continental_plate_grains_uniform_h
 
+
 #include "world_builder/features/continental_plate_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/grains/uniform.h
+++ b/include/world_builder/features/continental_plate_models/grains/uniform.h
@@ -25,10 +25,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
-
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_continental_plate_temperature_adiabatic_h
 #define _world_builder_features_continental_plate_temperature_adiabatic_h
 
+
 #include "world_builder/features/continental_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/temperature/interface.h
+++ b/include/world_builder/features/continental_plate_models/temperature/interface.h
@@ -20,17 +20,15 @@
 #ifndef _world_builder_features_continental_plate_temperature_interface_h
 #define _world_builder_features_continental_plate_temperature_interface_h
 
-#include <vector>
-#include <map>
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
 
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/continental_plate_models/temperature/linear.h
+++ b/include/world_builder/features/continental_plate_models/temperature/linear.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/continental_plate_models/temperature/linear.h
+++ b/include/world_builder/features/continental_plate_models/temperature/linear.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_continental_plate_temperature_linear_h
 #define _world_builder_features_continental_plate_temperature_linear_h
 
+
 #include "world_builder/features/continental_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/continental_plate_models/temperature/uniform.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/continental_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/continental_plate_models/temperature/uniform.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_continental_plate_temperature_uniform_h
 #define _world_builder_features_continental_plate_temperature_uniform_h
 
+
 #include "world_builder/features/continental_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -20,10 +20,8 @@
 #ifndef _world_feature_features_fault_h
 #define _world_feature_features_fault_h
 
-#include "world_builder/features/interface.h"
-#include "world_builder/world.h"
-#include "world_builder/types/segment.h"
 
+#include "world_builder/types/segment.h"
 #include "world_builder/features/fault_models/temperature/interface.h"
 #include "world_builder/features/fault_models/composition/interface.h"
 #include "world_builder/features/fault_models/grains/interface.h"
@@ -31,8 +29,27 @@
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+
   namespace Features
   {
+    namespace FaultModels
+    {
+      namespace Composition
+      {
+        class Interface;
+      }  // namespace Composition
+      namespace Grains
+      {
+        class Interface;
+      }  // namespace Grains
+      namespace Temperature
+      {
+        class Interface;
+      }  // namespace Temperature
+    }  // namespace FaultModels
+
     /**
      * This class represents a fault and can implement submodules
      * for temperature and composition. These submodules determine what

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -21,10 +21,10 @@
 #define _world_feature_features_fault_h
 
 
-#include "world_builder/types/segment.h"
-#include "world_builder/features/fault_models/temperature/interface.h"
 #include "world_builder/features/fault_models/composition/interface.h"
 #include "world_builder/features/fault_models/grains/interface.h"
+#include "world_builder/features/fault_models/temperature/interface.h"
+#include "world_builder/types/segment.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/fault_models/composition/interface.h
+++ b/include/world_builder/features/fault_models/composition/interface.h
@@ -20,9 +20,8 @@
 #ifndef _world_builder_features_fault_composition_interface_h
 #define _world_builder_features_fault_composition_interface_h
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
+#include "world_builder/grains.h"
 #include "world_builder/utilities.h"
 
 #include <vector>
@@ -31,6 +30,8 @@
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/fault_models/composition/uniform.h
+++ b/include/world_builder/features/fault_models/composition/uniform.h
@@ -26,9 +26,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/fault_models/composition/uniform.h
+++ b/include/world_builder/features/fault_models/composition/uniform.h
@@ -20,12 +20,16 @@
 #ifndef _world_builder_features_fault_composition_uniform_h
 #define _world_builder_features_fault_composition_uniform_h
 
+
 #include "world_builder/features/fault_models/composition/interface.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace FaultModels

--- a/include/world_builder/features/fault_models/grains/interface.h
+++ b/include/world_builder/features/fault_models/grains/interface.h
@@ -20,9 +20,8 @@
 #ifndef _world_builder_features_fault_grains_interface_h
 #define _world_builder_features_fault_grains_interface_h
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
+#include "world_builder/grains.h"
 #include "world_builder/utilities.h"
 
 #include <vector>
@@ -31,6 +30,8 @@
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_fault_grains_random_uniform_distribution_h
 #define _world_builder_features_fault_grains_random_uniform_distribution_h
 
+
 #include "world_builder/features/fault_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace FaultModels

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
@@ -25,9 +25,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/fault_models/grains/uniform.h
+++ b/include/world_builder/features/fault_models/grains/uniform.h
@@ -25,9 +25,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/fault_models/grains/uniform.h
+++ b/include/world_builder/features/fault_models/grains/uniform.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_fault_grains_uniform_h
 #define _world_builder_features_fault_grains_uniform_h
 
+
 #include "world_builder/features/fault_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace FaultModels

--- a/include/world_builder/features/fault_models/temperature/adiabatic.h
+++ b/include/world_builder/features/fault_models/temperature/adiabatic.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/fault_models/temperature/adiabatic.h
+++ b/include/world_builder/features/fault_models/temperature/adiabatic.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_fault_temperature_adiabatic_h
 #define _world_builder_features_fault_temperature_adiabatic_h
 
+
 #include "world_builder/features/fault_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace FaultModels

--- a/include/world_builder/features/fault_models/temperature/interface.h
+++ b/include/world_builder/features/fault_models/temperature/interface.h
@@ -20,9 +20,8 @@
 #ifndef _world_builder_features_fault_temperature_interface_h
 #define _world_builder_features_fault_temperature_interface_h
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
+#include "world_builder/grains.h"
 #include "world_builder/utilities.h"
 
 #include <vector>
@@ -31,6 +30,8 @@
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/fault_models/temperature/linear.h
+++ b/include/world_builder/features/fault_models/temperature/linear.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/fault_models/temperature/linear.h
+++ b/include/world_builder/features/fault_models/temperature/linear.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_fault_temperature_linear_h
 #define _world_builder_features_fault_temperature_linear_h
 
+
 #include "world_builder/features/fault_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace FaultModels

--- a/include/world_builder/features/fault_models/temperature/uniform.h
+++ b/include/world_builder/features/fault_models/temperature/uniform.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_fault_temperature_uniform_h
 #define _world_builder_features_fault_temperature_uniform_h
 
+
 #include "world_builder/features/fault_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace FaultModels

--- a/include/world_builder/features/fault_models/temperature/uniform.h
+++ b/include/world_builder/features/fault_models/temperature/uniform.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -20,17 +20,14 @@
 #ifndef _world_builder_features_interface_h
 #define _world_builder_features_interface_h
 
-#include <map>
-#include <vector>
 
-#include "world_builder/world.h"
-#include "world_builder/parameters.h"
-#include "world_builder/point.h"
 #include "world_builder/utilities.h"
+#include "world_builder/grains.h"
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
 
 
   namespace Features

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -21,8 +21,8 @@
 #define _world_builder_features_interface_h
 
 
-#include "world_builder/utilities.h"
 #include "world_builder/grains.h"
+#include "world_builder/utilities.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -20,18 +20,33 @@
 #ifndef _world_feature_features_mantle_layer_h
 #define _world_feature_features_mantle_layer_h
 
-#include "world_builder/features/interface.h"
-#include "world_builder/world.h"
 
-#include "world_builder/features/mantle_layer_models/temperature/interface.h"
-#include "world_builder/features/mantle_layer_models/composition/interface.h"
-#include "world_builder/features/mantle_layer_models/grains/interface.h"
+#include "world_builder/features/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+
   namespace Features
   {
+    namespace MantleLayerModels
+    {
+      namespace Composition
+      {
+        class Interface;
+      }  // namespace Composition
+      namespace Grains
+      {
+        class Interface;
+      }  // namespace Grains
+      namespace Temperature
+      {
+        class Interface;
+      }  // namespace Temperature
+    }  // namespace MantleLayerModels
+
     /**
      * This class represents a mantle layer and can implement submodules
      * for temperature and composition. These submodules determine what

--- a/include/world_builder/features/mantle_layer_models/composition/interface.h
+++ b/include/world_builder/features/mantle_layer_models/composition/interface.h
@@ -20,17 +20,15 @@
 #ifndef _world_builder_features_mantle_layer_composition_interface_h
 #define _world_builder_features_mantle_layer_composition_interface_h
 
-#include <vector>
-#include <map>
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
 
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/mantle_layer_models/composition/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/composition/uniform.h
@@ -26,9 +26,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/mantle_layer_models/composition/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/composition/uniform.h
@@ -20,12 +20,16 @@
 #ifndef _world_builder_features_mantle_layer_composition_uniform_h
 #define _world_builder_features_mantle_layer_composition_uniform_h
 
+
 #include "world_builder/features/mantle_layer_models/composition/interface.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace MantleLayerModels

--- a/include/world_builder/features/mantle_layer_models/grains/interface.h
+++ b/include/world_builder/features/mantle_layer_models/grains/interface.h
@@ -20,18 +20,16 @@
 #ifndef _world_builder_features_mantle_layer_grains_interface_h
 #define _world_builder_features_mantle_layer_grains_interface_h
 
-#include <vector>
-#include <map>
 
-
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
+#include "world_builder/grains.h"
 
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/mantle_layer_models/grains/interface.h
+++ b/include/world_builder/features/mantle_layer_models/grains/interface.h
@@ -21,8 +21,8 @@
 #define _world_builder_features_mantle_layer_grains_interface_h
 
 
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
@@ -25,9 +25,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_mantle_layer_grains_random_uniform_distribution_h
 #define _world_builder_features_mantle_layer_grains_random_uniform_distribution_h
 
+
 #include "world_builder/features/mantle_layer_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace MantleLayerModels

--- a/include/world_builder/features/mantle_layer_models/grains/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/grains/uniform.h
@@ -25,9 +25,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/mantle_layer_models/grains/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/grains/uniform.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_mantle_layer_grains_uniform_h
 #define _world_builder_features_mantle_layer_grains_uniform_h
 
+
 #include "world_builder/features/mantle_layer_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace MantleLayerModels

--- a/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_mantle_layer_temperature_adiabatic_h
 #define _world_builder_features_mantle_layer_temperature_adiabatic_h
 
+
 #include "world_builder/features/mantle_layer_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace MantleLayerModels

--- a/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/mantle_layer_models/temperature/interface.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/interface.h
@@ -20,17 +20,15 @@
 #ifndef _world_builder_features_mantle_layer_temperature_interface_h
 #define _world_builder_features_mantle_layer_temperature_interface_h
 
-#include <vector>
-#include <map>
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
 
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/mantle_layer_models/temperature/linear.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/linear.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_mantle_layer_temperature_linear_h
 #define _world_builder_features_mantle_layer_temperature_linear_h
 
+
 #include "world_builder/features/mantle_layer_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace MantleLayerModels

--- a/include/world_builder/features/mantle_layer_models/temperature/linear.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/linear.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/mantle_layer_models/temperature/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/uniform.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/mantle_layer_models/temperature/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/uniform.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_mantle_layer_temperature_uniform_h
 #define _world_builder_features_mantle_layer_temperature_uniform_h
 
+
 #include "world_builder/features/mantle_layer_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace MantleLayerModels

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -20,17 +20,33 @@
 #ifndef _world_feature_features_oceanic_plate_h
 #define _world_feature_features_oceanic_plate_h
 
+
 #include "world_builder/features/interface.h"
-#include "world_builder/world.h"
-#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
-#include "world_builder/features/oceanic_plate_models/composition/interface.h"
-#include "world_builder/features/oceanic_plate_models/grains/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+
   namespace Features
   {
+    namespace OceanicPlateModels
+    {
+      namespace Composition
+      {
+        class Interface;
+      }  // namespace Composition
+      namespace Grains
+      {
+        class Interface;
+      }  // namespace Grains
+      namespace Temperature
+      {
+        class Interface;
+      }  // namespace Temperature
+    }  // namespace OceanicPlateModels
+
     /**
      * This class represents a oceanic plate and can implement submodules
      * for temperature and composition. These submodules determine what

--- a/include/world_builder/features/oceanic_plate_models/composition/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/interface.h
@@ -20,17 +20,15 @@
 #ifndef _world_builder_features_oceanic_plate_composition_interface_h
 #define _world_builder_features_oceanic_plate_composition_interface_h
 
-#include <vector>
-#include <map>
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
 
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/oceanic_plate_models/composition/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/uniform.h
@@ -26,9 +26,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/oceanic_plate_models/composition/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/uniform.h
@@ -20,12 +20,16 @@
 #ifndef _world_builder_features_oceanic_plate_composition_uniform_h
 #define _world_builder_features_oceanic_plate_composition_uniform_h
 
+
 #include "world_builder/features/oceanic_plate_models/composition/interface.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace OceanicPlateModels

--- a/include/world_builder/features/oceanic_plate_models/grains/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/interface.h
@@ -21,16 +21,12 @@
 #define _world_builder_features_oceanic_plate_grains_interface_h
 
 
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 
 
 namespace WorldBuilder
 {
-  class World;
-  class Parameters;
-  template <int dim> class Point;
-
   /**
    * This class is an interface for the specific plate tectonic feature classes,
    * such as oceanic plate, oceanic plate and subduction zone.

--- a/include/world_builder/features/oceanic_plate_models/grains/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/interface.h
@@ -20,18 +20,16 @@
 #ifndef _world_builder_features_oceanic_plate_grains_interface_h
 #define _world_builder_features_oceanic_plate_grains_interface_h
 
-#include <vector>
-#include <map>
 
-
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
+#include "world_builder/grains.h"
 
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_oceanic_plate_grains_random_uniform_distribution_h
 #define _world_builder_features_oceanic_plate_grains_random_uniform_distribution_h
 
+
 #include "world_builder/features/oceanic_plate_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace OceanicPlateModels

--- a/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
@@ -25,9 +25,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/oceanic_plate_models/grains/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/uniform.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_oceanic_plate_grains_uniform_h
 #define _world_builder_features_oceanic_plate_grains_uniform_h
 
+
 #include "world_builder/features/oceanic_plate_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace OceanicPlateModels

--- a/include/world_builder/features/oceanic_plate_models/grains/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/uniform.h
@@ -25,9 +25,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_oceanic_plate_temperature_adiabatic_h
 #define _world_builder_features_oceanic_plate_temperature_adiabatic_h
 
+
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace OceanicPlateModels

--- a/include/world_builder/features/oceanic_plate_models/temperature/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/interface.h
@@ -20,17 +20,15 @@
 #ifndef _world_builder_features_oceanic_plate_temperature_interface_h
 #define _world_builder_features_oceanic_plate_temperature_interface_h
 
-#include <vector>
-#include <map>
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
 
 
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/oceanic_plate_models/temperature/linear.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/linear.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/oceanic_plate_models/temperature/linear.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/linear.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_oceanic_plate_temperature_linear_h
 #define _world_builder_features_oceanic_plate_temperature_linear_h
 
+
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace OceanicPlateModels

--- a/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
@@ -20,13 +20,16 @@
 #ifndef _world_builder_features_oceanic_plate_temperature_plate_model_h
 #define _world_builder_features_oceanic_plate_temperature_plate_model_h
 
+
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+
   namespace Features
   {
     namespace OceanicPlateModels

--- a/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_oceanic_plate_temperature_uniform_h
 #define _world_builder_features_oceanic_plate_temperature_uniform_h
 
+
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace OceanicPlateModels

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -20,10 +20,8 @@
 #ifndef _world_feature_features_subducting_plate_h
 #define _world_feature_features_subducting_plate_h
 
-#include "world_builder/features/interface.h"
-#include "world_builder/world.h"
-#include "world_builder/types/segment.h"
 
+#include "world_builder/types/segment.h"
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
 #include "world_builder/features/subducting_plate_models/composition/interface.h"
 #include "world_builder/features/subducting_plate_models/grains/interface.h"
@@ -31,8 +29,27 @@
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+
   namespace Features
   {
+    namespace SubductingPlateModels
+    {
+      namespace Composition
+      {
+        class Interface;
+      }  // namespace Composition
+      namespace Grains
+      {
+        class Interface;
+      }  // namespace Grains
+      namespace Temperature
+      {
+        class Interface;
+      }  // namespace Temperature
+    }  // namespace SubductingPlateModels
+
     /**
      * This class represents a subducting plate and can implement submodules
      * for temperature and composition. These submodules determine what

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -21,10 +21,10 @@
 #define _world_feature_features_subducting_plate_h
 
 
-#include "world_builder/types/segment.h"
-#include "world_builder/features/subducting_plate_models/temperature/interface.h"
 #include "world_builder/features/subducting_plate_models/composition/interface.h"
 #include "world_builder/features/subducting_plate_models/grains/interface.h"
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
+#include "world_builder/types/segment.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/features/subducting_plate_models/composition/interface.h
+++ b/include/world_builder/features/subducting_plate_models/composition/interface.h
@@ -20,9 +20,8 @@
 #ifndef _world_builder_features_subducting_plate_composition_interface_h
 #define _world_builder_features_subducting_plate_composition_interface_h
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
+#include "world_builder/grains.h"
 #include "world_builder/utilities.h"
 
 #include <vector>
@@ -31,6 +30,8 @@
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/subducting_plate_models/composition/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/composition/uniform.h
@@ -26,9 +26,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/subducting_plate_models/composition/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/composition/uniform.h
@@ -20,12 +20,16 @@
 #ifndef _world_builder_features_subducting_plate_composition_uniform_h
 #define _world_builder_features_subducting_plate_composition_uniform_h
 
+
 #include "world_builder/features/subducting_plate_models/composition/interface.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace SubductingPlateModels

--- a/include/world_builder/features/subducting_plate_models/grains/interface.h
+++ b/include/world_builder/features/subducting_plate_models/grains/interface.h
@@ -20,9 +20,8 @@
 #ifndef _world_builder_features_subducting_plate_grains_interface_h
 #define _world_builder_features_subducting_plate_grains_interface_h
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
+#include "world_builder/grains.h"
 #include "world_builder/utilities.h"
 
 #include <vector>
@@ -31,6 +30,8 @@
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_subducting_plate_grains_random_uniform_distribution_h
 #define _world_builder_features_subducting_plate_grains_random_uniform_distribution_h
 
+
 #include "world_builder/features/subducting_plate_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace SubductingPlateModels

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
@@ -25,9 +25,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/subducting_plate_models/grains/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/grains/uniform.h
@@ -25,9 +25,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/subducting_plate_models/grains/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/grains/uniform.h
@@ -20,11 +20,15 @@
 #ifndef _world_builder_features_subducting_plate_grains_uniform_h
 #define _world_builder_features_subducting_plate_grains_uniform_h
 
+
 #include "world_builder/features/subducting_plate_models/grains/interface.h"
-#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace SubductingPlateModels

--- a/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_subducting_plate_temperature_adiabatic_h
 #define _world_builder_features_subducting_plate_temperature_adiabatic_h
 
+
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace SubductingPlateModels

--- a/include/world_builder/features/subducting_plate_models/temperature/interface.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/interface.h
@@ -20,9 +20,8 @@
 #ifndef _world_builder_features_subducting_plate_temperature_interface_h
 #define _world_builder_features_subducting_plate_temperature_interface_h
 
-#include "world_builder/world.h"
 #include "world_builder/parameters.h"
-#include "world_builder/point.h"
+#include "world_builder/grains.h"
 #include "world_builder/utilities.h"
 
 #include <vector>
@@ -31,6 +30,8 @@
 namespace WorldBuilder
 {
   class World;
+  class Parameters;
+  template <int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/include/world_builder/features/subducting_plate_models/temperature/linear.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/linear.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/subducting_plate_models/temperature/linear.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/linear.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_subducting_plate_temperature_linear_h
 #define _world_builder_features_subducting_plate_temperature_linear_h
 
+
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace SubductingPlateModels

--- a/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_subducting_plate_temperature_plate_model_h
 #define _world_builder_features_subducting_plate_temperature_plate_model_h
 
+
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace SubductingPlateModels

--- a/include/world_builder/features/subducting_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/uniform.h
@@ -27,9 +27,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-  template <int dim> class Point;
 
   namespace Features
   {

--- a/include/world_builder/features/subducting_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/uniform.h
@@ -20,13 +20,17 @@
 #ifndef _world_builder_features_subducting_plate_temperature_uniform_h
 #define _world_builder_features_subducting_plate_temperature_uniform_h
 
+
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
 #include "world_builder/features/utilities.h"
-#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+  template <int dim> class Point;
+
   namespace Features
   {
     namespace SubductingPlateModels

--- a/include/world_builder/features/utilities.h
+++ b/include/world_builder/features/utilities.h
@@ -21,7 +21,6 @@
 #ifndef _world_builder_features_utilities_h
 #define _world_builder_features_utilities_h
 
-#include <string>
 #include <limits>
 
 #include "world_builder/assert.h"

--- a/include/world_builder/grains.h
+++ b/include/world_builder/grains.h
@@ -20,6 +20,9 @@
 #ifndef _world_builder_grains_h
 #define _world_builder_grains_h
 
+#include <array>
+#include <vector>
+
 namespace WorldBuilder
 {
   /**

--- a/include/world_builder/grains.h
+++ b/include/world_builder/grains.h
@@ -19,8 +19,6 @@
 
 #ifndef _world_builder_grains_h
 #define _world_builder_grains_h
-#include <vector>
-#include <array>
 
 namespace WorldBuilder
 {

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -20,16 +20,11 @@
 #ifndef _world_builder_parameters_h
 #define _world_builder_parameters_h
 
-#include <string>
 #include <vector>
-#include <unordered_map>
 #include <map>
 #include <memory>
 
-
-#include <rapidjson/document.h>
 #include "rapidjson/schema.h"
-
 #include "world_builder/point.h"
 
 namespace WorldBuilder

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -20,9 +20,9 @@
 #ifndef _world_builder_parameters_h
 #define _world_builder_parameters_h
 
-#include <vector>
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "rapidjson/schema.h"
 #include "world_builder/point.h"

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -22,7 +22,6 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <array>
-#include <iostream>
 
 #include "world_builder/coordinate_system.h"
 #include "world_builder/assert.h"
@@ -197,13 +196,13 @@ namespace WorldBuilder
        * Outputs the values of the point to std cout separated by spaces. This does not
        * output the coordinate system.
        */
-      friend std::ostream &operator<<( std::ostream &output, const Point<dim> &point )
+      friend std::ostream &operator<<( std::ostream &output, const Point<dim> &stream_point )
       {
         for (size_t i = 0; i < dim-1; i++)
           {
-            output <<  point[i] << " ";
+            output <<  stream_point[i] << " ";
           }
-        output << point[dim-1];
+        output << stream_point[dim-1];
 
         return output;
       }
@@ -229,7 +228,7 @@ namespace WorldBuilder
     inline double fmod(const double x, const double y)
     {
       const double x_div_y = x/y;
-      return (x_div_y-(int)x_div_y)*y;
+      return (x_div_y-static_cast<int>(x_div_y))*y;
     }
 
     /**

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -20,11 +20,11 @@
 #ifndef _world_builder_point_h
 #define _world_builder_point_h
 #define _USE_MATH_DEFINES
-#include <cmath>
 #include <array>
+#include <cmath>
 
-#include "world_builder/coordinate_system.h"
 #include "world_builder/assert.h"
+#include "world_builder/coordinate_system.h"
 
 namespace WorldBuilder
 {

--- a/include/world_builder/types/array.h
+++ b/include/world_builder/types/array.h
@@ -20,11 +20,14 @@
 #ifndef _world_feature_types_array_h
 #define _world_feature_types_array_h
 
+
 #include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+
   namespace Types
   {
     /**

--- a/include/world_builder/types/bool.h
+++ b/include/world_builder/types/bool.h
@@ -20,11 +20,14 @@
 #ifndef _world_feature_types_bool_h
 #define _world_feature_types_bool_h
 
+
 #include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+
   namespace Types
   {
 

--- a/include/world_builder/types/double.h
+++ b/include/world_builder/types/double.h
@@ -20,11 +20,14 @@
 #ifndef _world_feature_types_double_h
 #define _world_feature_types_double_h
 
+
 #include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+
   namespace Types
   {
 

--- a/include/world_builder/types/interface.h
+++ b/include/world_builder/types/interface.h
@@ -20,17 +20,13 @@
 #ifndef _world_builder_types_interface_h
 #define _world_builder_types_interface_h
 
-#include <string>
-#include <vector>
-#include <memory>
-#include <map>
-
-#include <rapidjson/document.h>
 #include <rapidjson/pointer.h>
+#include <memory>
 
 namespace WorldBuilder
 {
   class Parameters;
+
   /**
    * This class is an interface for the specific plate tectonic feature classes,
    * such as continental plate, oceanic plate and subduction zone.

--- a/include/world_builder/types/interface.h
+++ b/include/world_builder/types/interface.h
@@ -20,7 +20,8 @@
 #ifndef _world_builder_types_interface_h
 #define _world_builder_types_interface_h
 
-#include <rapidjson/pointer.h>
+#include "rapidjson/pointer.h"
+
 #include <memory>
 
 namespace WorldBuilder

--- a/include/world_builder/types/object.h
+++ b/include/world_builder/types/object.h
@@ -20,11 +20,15 @@
 #ifndef _world_feature_types_object_h
 #define _world_feature_types_object_h
 
+#include <vector>
+
 #include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+
   namespace Types
   {
     /**

--- a/include/world_builder/types/plugin_system.h
+++ b/include/world_builder/types/plugin_system.h
@@ -20,12 +20,14 @@
 #ifndef _world_feature_types_plugin_system_h
 #define _world_feature_types_plugin_system_h
 
-#include "world_builder/types/interface.h"
+
 #include "world_builder/features/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+
   namespace Types
   {
 

--- a/include/world_builder/types/point.h
+++ b/include/world_builder/types/point.h
@@ -21,8 +21,8 @@
 #define _world_feature_types_point_h
 
 
-#include "world_builder/types/interface.h"
 #include "world_builder/point.h"
+#include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder

--- a/include/world_builder/types/point.h
+++ b/include/world_builder/types/point.h
@@ -20,12 +20,15 @@
 #ifndef _world_feature_types_point_h
 #define _world_feature_types_point_h
 
+
 #include "world_builder/types/interface.h"
 #include "world_builder/point.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+
   namespace Types
   {
 

--- a/include/world_builder/types/segment.h
+++ b/include/world_builder/types/segment.h
@@ -20,13 +20,14 @@
 #ifndef _world_feature_types_segment_h
 #define _world_feature_types_segment_h
 
-#include "world_builder/types/interface.h"
-#include "world_builder/point.h"
+
 #include "world_builder/types/plugin_system.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+
   namespace Types
   {
 

--- a/include/world_builder/types/string.h
+++ b/include/world_builder/types/string.h
@@ -20,11 +20,15 @@
 #ifndef _world_feature_types_string_h
 #define _world_feature_types_string_h
 
+#include <vector>
+
 #include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+
   namespace Types
   {
 

--- a/include/world_builder/types/unsigned_int.h
+++ b/include/world_builder/types/unsigned_int.h
@@ -20,11 +20,14 @@
 #ifndef _world_feature_types_unsigned_int_h
 #define _world_feature_types_unsigned_int_h
 
+
 #include "world_builder/types/interface.h"
 
 
 namespace WorldBuilder
 {
+  class Parameters;
+
   namespace Types
   {
 

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -20,11 +20,7 @@
 #ifndef _world_builder_utilities_h
 #define _world_builder_utilities_h
 
-#include <vector>
-#include <map>
 
-#include "world_builder/point.h"
-#include "world_builder/coordinate_system.h"
 #include "world_builder/coordinate_systems/interface.h"
 
 

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -20,12 +20,10 @@
 #ifndef _world_builder_world_h
 #define _world_builder_world_h
 
-#include <random>
-
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 
-
+#include <random>
 
 namespace WorldBuilder
 {

--- a/include/world_builder/wrapper_c.h
+++ b/include/world_builder/wrapper_c.h
@@ -20,7 +20,6 @@
 #ifndef _world_builder_wrapper_c_h
 #define _world_builder_wrapper_c_h
 
-#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/world_builder/wrapper_c.h
+++ b/include/world_builder/wrapper_c.h
@@ -20,6 +20,7 @@
 #ifndef _world_builder_wrapper_c_h
 #define _world_builder_wrapper_c_h
 
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/world_builder/wrapper_cpp.h
+++ b/include/world_builder/wrapper_cpp.h
@@ -20,7 +20,6 @@
 #ifndef _world_builder_wrapper_cpp_h
 #define _world_builder_wrapper_cpp_h
 
-#include <string>
 
 namespace wrapper_cpp
 {

--- a/include/world_builder/wrapper_cpp.h
+++ b/include/world_builder/wrapper_cpp.h
@@ -20,6 +20,7 @@
 #ifndef _world_builder_wrapper_cpp_h
 #define _world_builder_wrapper_cpp_h
 
+#include <string>
 
 namespace wrapper_cpp
 {

--- a/source/coordinate_systems/cartesian.cc
+++ b/source/coordinate_systems/cartesian.cc
@@ -19,10 +19,12 @@
 
 #include "world_builder/coordinate_systems/cartesian.h"
 
-#include "world_builder/assert.h"
 
 namespace WorldBuilder
 {
+  class Parameters;
+  class World;
+
   namespace CoordinateSystems
   {
     Cartesian::Cartesian(WorldBuilder::World *world_)

--- a/source/coordinate_systems/cartesian.cc
+++ b/source/coordinate_systems/cartesian.cc
@@ -22,9 +22,6 @@
 
 namespace WorldBuilder
 {
-  class Parameters;
-  class World;
-
   namespace CoordinateSystems
   {
     Cartesian::Cartesian(WorldBuilder::World *world_)

--- a/source/coordinate_systems/interface.cc
+++ b/source/coordinate_systems/interface.cc
@@ -19,14 +19,15 @@
 
 #include "world_builder/coordinate_systems/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-
 #include <algorithm>
+
+#include "world_builder/types/object.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+
   namespace CoordinateSystems
   {
 

--- a/source/coordinate_systems/interface.cc
+++ b/source/coordinate_systems/interface.cc
@@ -26,8 +26,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-
   namespace CoordinateSystems
   {
 

--- a/source/coordinate_systems/spherical.cc
+++ b/source/coordinate_systems/spherical.cc
@@ -25,8 +25,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-
   namespace CoordinateSystems
   {
     Spherical::Spherical(WorldBuilder::World *world_)

--- a/source/coordinate_systems/spherical.cc
+++ b/source/coordinate_systems/spherical.cc
@@ -19,12 +19,14 @@
 
 #include "world_builder/coordinate_systems/spherical.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
+#include "world_builder/utilities.h"
 
 namespace WorldBuilder
 {
+  class World;
+
   namespace CoordinateSystems
   {
     Spherical::Spherical(WorldBuilder::World *world_)

--- a/source/features/continental_plate.cc
+++ b/source/features/continental_plate.cc
@@ -20,13 +20,13 @@
 #include "world_builder/features/continental_plate.h"
 
 
+#include "world_builder/features/continental_plate_models/composition/interface.h"
+#include "world_builder/features/continental_plate_models/grains/interface.h"
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/plugin_system.h"
-#include "world_builder/features/continental_plate_models/composition/interface.h"
-#include "world_builder/features/continental_plate_models/grains/interface.h"
-#include "world_builder/features/continental_plate_models/temperature/interface.h"
 #include "world_builder/world.h"
 
 

--- a/source/features/continental_plate.cc
+++ b/source/features/continental_plate.cc
@@ -19,16 +19,15 @@
 
 #include "world_builder/features/continental_plate.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
-#include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
-#include "world_builder/types/unsigned_int.h"
-#include "world_builder/utilities.h"
+#include "world_builder/features/continental_plate_models/composition/interface.h"
+#include "world_builder/features/continental_plate_models/grains/interface.h"
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/source/features/continental_plate_models/composition/interface.cc
+++ b/source/features/continental_plate_models/composition/interface.cc
@@ -19,11 +19,8 @@
 
 #include "world_builder/features/continental_plate_models/composition/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
 
 
 namespace WorldBuilder

--- a/source/features/continental_plate_models/composition/interface.cc
+++ b/source/features/continental_plate_models/composition/interface.cc
@@ -21,8 +21,6 @@
 
 #include <algorithm>
 
-
-
 namespace WorldBuilder
 {
   namespace Features

--- a/source/features/continental_plate_models/composition/uniform.cc
+++ b/source/features/continental_plate_models/composition/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/continental_plate_models/composition/uniform.cc
+++ b/source/features/continental_plate_models/composition/uniform.cc
@@ -19,19 +19,20 @@
 
 #include "world_builder/features/continental_plate_models/composition/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/continental_plate_models/grains/interface.cc
+++ b/source/features/continental_plate_models/grains/interface.cc
@@ -19,11 +19,8 @@
 
 #include "world_builder/features/continental_plate_models/grains/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
 
 namespace WorldBuilder
 {

--- a/source/features/continental_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/continental_plate_models/grains/random_uniform_distribution.cc
@@ -19,23 +19,22 @@
 
 #include "world_builder/features/continental_plate_models/grains/random_uniform_distribution.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
-
-#include <algorithm>
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/continental_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/continental_plate_models/grains/random_uniform_distribution.cc
@@ -33,8 +33,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/continental_plate_models/grains/uniform.cc
+++ b/source/features/continental_plate_models/grains/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/continental_plate_models/grains/uniform.cc
+++ b/source/features/continental_plate_models/grains/uniform.cc
@@ -19,22 +19,20 @@
 
 #include "world_builder/features/continental_plate_models/grains/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
-
-#include <algorithm>
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/continental_plate_models/temperature/adiabatic.cc
+++ b/source/features/continental_plate_models/temperature/adiabatic.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/continental_plate_models/temperature/adiabatic.cc
+++ b/source/features/continental_plate_models/temperature/adiabatic.cc
@@ -19,17 +19,17 @@
 
 #include "world_builder/features/continental_plate_models/temperature/adiabatic.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/continental_plate_models/temperature/interface.cc
+++ b/source/features/continental_plate_models/temperature/interface.cc
@@ -25,11 +25,6 @@
 
 namespace WorldBuilder
 {
-  namespace Types
-  {
-    class Interface;
-  }  // namespace Types
-
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/source/features/continental_plate_models/temperature/interface.cc
+++ b/source/features/continental_plate_models/temperature/interface.cc
@@ -19,14 +19,17 @@
 
 #include "world_builder/features/continental_plate_models/temperature/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
+#include "world_builder/types/string.h"
 
 namespace WorldBuilder
 {
+  namespace Types
+  {
+    class Interface;
+  }  // namespace Types
+
   namespace Features
   {
     namespace ContinentalPlateModels

--- a/source/features/continental_plate_models/temperature/linear.cc
+++ b/source/features/continental_plate_models/temperature/linear.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/continental_plate_models/temperature/linear.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/continental_plate_models/temperature/linear.cc
+++ b/source/features/continental_plate_models/temperature/linear.cc
@@ -29,8 +29,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/continental_plate_models/temperature/uniform.cc
+++ b/source/features/continental_plate_models/temperature/uniform.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/continental_plate_models/temperature/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/continental_plate_models/temperature/uniform.cc
+++ b/source/features/continental_plate_models/temperature/uniform.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -20,11 +20,11 @@
 #include "world_builder/features/fault.h"
 
 
+#include "glm/glm.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/point.h"
 #include "world_builder/types/unsigned_int.h"
-#include "glm/glm.h"
 #include "world_builder/world.h"
 
 using namespace std;

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -19,22 +19,13 @@
 
 #include "world_builder/features/fault.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/nan.h"
-#include "world_builder/parameters.h"
+
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
-#include "world_builder/types/plugin_system.h"
 #include "world_builder/types/point.h"
-#include "world_builder/types/segment.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
-#include "world_builder/utilities.h"
-
-#include "rapidjson/prettywriter.h"
-#include "rapidjson/stringbuffer.h"
-
 #include "glm/glm.h"
+#include "world_builder/world.h"
 
 using namespace std;
 

--- a/source/features/fault_models/composition/interface.cc
+++ b/source/features/fault_models/composition/interface.cc
@@ -19,11 +19,8 @@
 
 #include "world_builder/features/fault_models/composition/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
 
 namespace WorldBuilder
 {

--- a/source/features/fault_models/composition/uniform.cc
+++ b/source/features/fault_models/composition/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/fault_models/composition/uniform.cc
+++ b/source/features/fault_models/composition/uniform.cc
@@ -19,19 +19,20 @@
 
 #include "world_builder/features/fault_models/composition/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/fault_models/grains/interface.cc
+++ b/source/features/fault_models/grains/interface.cc
@@ -19,11 +19,10 @@
 
 #include "world_builder/features/fault_models/grains/interface.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/types/object.h"
 #include "world_builder/types/string.h"
-
-#include <algorithm>
 
 namespace WorldBuilder
 {

--- a/source/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/features/fault_models/grains/random_uniform_distribution.cc
@@ -32,8 +32,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/features/fault_models/grains/random_uniform_distribution.cc
@@ -19,22 +19,21 @@
 
 #include "world_builder/features/fault_models/grains/random_uniform_distribution.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
-
-#include <algorithm>
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/fault_models/grains/uniform.cc
+++ b/source/features/fault_models/grains/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/fault_models/grains/uniform.cc
+++ b/source/features/fault_models/grains/uniform.cc
@@ -19,20 +19,20 @@
 
 #include "world_builder/features/fault_models/grains/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/fault_models/temperature/adiabatic.cc
+++ b/source/features/fault_models/temperature/adiabatic.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/fault_models/temperature/adiabatic.cc
+++ b/source/features/fault_models/temperature/adiabatic.cc
@@ -19,17 +19,17 @@
 
 #include "world_builder/features/fault_models/temperature/adiabatic.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/fault_models/temperature/interface.cc
+++ b/source/features/fault_models/temperature/interface.cc
@@ -20,13 +20,17 @@
 
 #include "world_builder/features/fault_models/temperature/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
+#include <algorithm>
+
 #include "world_builder/types/string.h"
 
-#include <algorithm>
 namespace WorldBuilder
 {
+  namespace Types
+  {
+    class Interface;
+  }  // namespace Types
+
   namespace Features
   {
     namespace FaultModels

--- a/source/features/fault_models/temperature/interface.cc
+++ b/source/features/fault_models/temperature/interface.cc
@@ -26,11 +26,6 @@
 
 namespace WorldBuilder
 {
-  namespace Types
-  {
-    class Interface;
-  }  // namespace Types
-
   namespace Features
   {
     namespace FaultModels

--- a/source/features/fault_models/temperature/linear.cc
+++ b/source/features/fault_models/temperature/linear.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/fault_models/temperature/linear.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/fault_models/temperature/linear.cc
+++ b/source/features/fault_models/temperature/linear.cc
@@ -29,8 +29,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/fault_models/temperature/uniform.cc
+++ b/source/features/fault_models/temperature/uniform.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/fault_models/temperature/uniform.cc
+++ b/source/features/fault_models/temperature/uniform.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/fault_models/temperature/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/interface.cc
+++ b/source/features/interface.cc
@@ -19,14 +19,12 @@
 
 #include "world_builder/features/interface.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/types/array.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/point.h"
-#include "world_builder/types/string.h"
-#include "world_builder/utilities.h"
-
-#include <algorithm>
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {

--- a/source/features/mantle_layer.cc
+++ b/source/features/mantle_layer.cc
@@ -19,15 +19,13 @@
 
 #include "world_builder/features/mantle_layer.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/nan.h"
-#include "world_builder/parameters.h"
-#include "world_builder/types/array.h"
+
 #include "world_builder/types/double.h"
 #include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
-#include "world_builder/types/unsigned_int.h"
-#include "world_builder/utilities.h"
+#include "world_builder/features/mantle_layer_models/composition/interface.h"
+#include "world_builder/features/mantle_layer_models/grains/interface.h"
+#include "world_builder/features/mantle_layer_models/temperature/interface.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/source/features/mantle_layer.cc
+++ b/source/features/mantle_layer.cc
@@ -20,11 +20,11 @@
 #include "world_builder/features/mantle_layer.h"
 
 
-#include "world_builder/types/double.h"
-#include "world_builder/types/plugin_system.h"
 #include "world_builder/features/mantle_layer_models/composition/interface.h"
 #include "world_builder/features/mantle_layer_models/grains/interface.h"
 #include "world_builder/features/mantle_layer_models/temperature/interface.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/plugin_system.h"
 #include "world_builder/world.h"
 
 

--- a/source/features/mantle_layer_models/composition/interface.cc
+++ b/source/features/mantle_layer_models/composition/interface.cc
@@ -19,11 +19,8 @@
 
 #include "world_builder/features/mantle_layer_models/composition/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
 
 namespace WorldBuilder
 {

--- a/source/features/mantle_layer_models/composition/uniform.cc
+++ b/source/features/mantle_layer_models/composition/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/mantle_layer_models/composition/uniform.cc
+++ b/source/features/mantle_layer_models/composition/uniform.cc
@@ -19,19 +19,20 @@
 
 #include "world_builder/features/mantle_layer_models/composition/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/mantle_layer_models/grains/interface.cc
+++ b/source/features/mantle_layer_models/grains/interface.cc
@@ -19,11 +19,10 @@
 
 #include "world_builder/features/mantle_layer_models/grains/interface.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/types/object.h"
 #include "world_builder/types/string.h"
-
-#include <algorithm>
 
 namespace WorldBuilder
 {

--- a/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
+++ b/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
@@ -19,22 +19,21 @@
 
 #include "world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
-
-#include <algorithm>
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
+++ b/source/features/mantle_layer_models/grains/random_uniform_distribution.cc
@@ -32,8 +32,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/mantle_layer_models/grains/uniform.cc
+++ b/source/features/mantle_layer_models/grains/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/mantle_layer_models/grains/uniform.cc
+++ b/source/features/mantle_layer_models/grains/uniform.cc
@@ -19,20 +19,20 @@
 
 #include "world_builder/features/mantle_layer_models/grains/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/mantle_layer_models/temperature/adiabatic.cc
+++ b/source/features/mantle_layer_models/temperature/adiabatic.cc
@@ -19,17 +19,17 @@
 
 #include "world_builder/features/mantle_layer_models/temperature/adiabatic.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/mantle_layer_models/temperature/adiabatic.cc
+++ b/source/features/mantle_layer_models/temperature/adiabatic.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/mantle_layer_models/temperature/interface.cc
+++ b/source/features/mantle_layer_models/temperature/interface.cc
@@ -25,11 +25,6 @@
 
 namespace WorldBuilder
 {
-  namespace Types
-  {
-    class Interface;
-  }  // namespace Types
-
   namespace Features
   {
     namespace MantleLayerModels

--- a/source/features/mantle_layer_models/temperature/interface.cc
+++ b/source/features/mantle_layer_models/temperature/interface.cc
@@ -19,14 +19,17 @@
 
 #include "world_builder/features/mantle_layer_models/temperature/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
+#include "world_builder/types/string.h"
 
 namespace WorldBuilder
 {
+  namespace Types
+  {
+    class Interface;
+  }  // namespace Types
+
   namespace Features
   {
     namespace MantleLayerModels

--- a/source/features/mantle_layer_models/temperature/linear.cc
+++ b/source/features/mantle_layer_models/temperature/linear.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/mantle_layer_models/temperature/linear.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/mantle_layer_models/temperature/linear.cc
+++ b/source/features/mantle_layer_models/temperature/linear.cc
@@ -29,8 +29,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/mantle_layer_models/temperature/uniform.cc
+++ b/source/features/mantle_layer_models/temperature/uniform.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/mantle_layer_models/temperature/uniform.cc
+++ b/source/features/mantle_layer_models/temperature/uniform.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/mantle_layer_models/temperature/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate.cc
+++ b/source/features/oceanic_plate.cc
@@ -20,12 +20,12 @@
 #include "world_builder/features/oceanic_plate.h"
 
 
-#include "world_builder/nan.h"
-#include "world_builder/types/double.h"
-#include "world_builder/types/plugin_system.h"
 #include "world_builder/features/oceanic_plate_models/composition/interface.h"
 #include "world_builder/features/oceanic_plate_models/grains/interface.h"
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
+#include "world_builder/nan.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/plugin_system.h"
 #include "world_builder/world.h"
 
 

--- a/source/features/oceanic_plate.cc
+++ b/source/features/oceanic_plate.cc
@@ -19,16 +19,14 @@
 
 #include "world_builder/features/oceanic_plate.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
-#include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/plugin_system.h"
-#include "world_builder/types/point.h"
-#include "world_builder/types/string.h"
-#include "world_builder/types/unsigned_int.h"
-#include "world_builder/utilities.h"
+#include "world_builder/features/oceanic_plate_models/composition/interface.h"
+#include "world_builder/features/oceanic_plate_models/grains/interface.h"
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate_models/composition/interface.cc
+++ b/source/features/oceanic_plate_models/composition/interface.cc
@@ -19,11 +19,8 @@
 
 #include "world_builder/features/oceanic_plate_models/composition/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
 
 namespace WorldBuilder
 {

--- a/source/features/oceanic_plate_models/composition/uniform.cc
+++ b/source/features/oceanic_plate_models/composition/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/oceanic_plate_models/composition/uniform.cc
+++ b/source/features/oceanic_plate_models/composition/uniform.cc
@@ -19,19 +19,20 @@
 
 #include "world_builder/features/oceanic_plate_models/composition/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate_models/grains/interface.cc
+++ b/source/features/oceanic_plate_models/grains/interface.cc
@@ -19,11 +19,10 @@
 
 #include "world_builder/features/oceanic_plate_models/grains/interface.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/types/object.h"
 #include "world_builder/types/string.h"
-
-#include <algorithm>
 
 namespace WorldBuilder
 {

--- a/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -19,22 +19,21 @@
 
 #include "world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
-
-#include <algorithm>
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -32,8 +32,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate_models/grains/uniform.cc
+++ b/source/features/oceanic_plate_models/grains/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/oceanic_plate_models/grains/uniform.cc
+++ b/source/features/oceanic_plate_models/grains/uniform.cc
@@ -19,20 +19,20 @@
 
 #include "world_builder/features/oceanic_plate_models/grains/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate_models/temperature/adiabatic.cc
+++ b/source/features/oceanic_plate_models/temperature/adiabatic.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate_models/temperature/adiabatic.cc
+++ b/source/features/oceanic_plate_models/temperature/adiabatic.cc
@@ -19,17 +19,17 @@
 
 #include "world_builder/features/oceanic_plate_models/temperature/adiabatic.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate_models/temperature/interface.cc
+++ b/source/features/oceanic_plate_models/temperature/interface.cc
@@ -25,11 +25,6 @@
 
 namespace WorldBuilder
 {
-  namespace Types
-  {
-    class Interface;
-  }  // namespace Types
-
   namespace Features
   {
     namespace OceanicPlateModels

--- a/source/features/oceanic_plate_models/temperature/interface.cc
+++ b/source/features/oceanic_plate_models/temperature/interface.cc
@@ -19,14 +19,17 @@
 
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
+#include "world_builder/types/string.h"
 
 namespace WorldBuilder
 {
+  namespace Types
+  {
+    class Interface;
+  }  // namespace Types
+
   namespace Features
   {
     namespace OceanicPlateModels

--- a/source/features/oceanic_plate_models/temperature/linear.cc
+++ b/source/features/oceanic_plate_models/temperature/linear.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/oceanic_plate_models/temperature/linear.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate_models/temperature/linear.cc
+++ b/source/features/oceanic_plate_models/temperature/linear.cc
@@ -29,8 +29,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate_models/temperature/plate_model.cc
+++ b/source/features/oceanic_plate_models/temperature/plate_model.cc
@@ -19,15 +19,14 @@
 
 #include "world_builder/features/oceanic_plate_models/temperature/plate_model.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/point.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder

--- a/source/features/oceanic_plate_models/temperature/uniform.cc
+++ b/source/features/oceanic_plate_models/temperature/uniform.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/oceanic_plate_models/temperature/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/oceanic_plate_models/temperature/uniform.cc
+++ b/source/features/oceanic_plate_models/temperature/uniform.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -20,11 +20,11 @@
 #include "world_builder/features/subducting_plate.h"
 
 
+#include "glm/glm.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/point.h"
 #include "world_builder/types/unsigned_int.h"
-#include "glm/glm.h"
 #include "world_builder/world.h"
 
 using namespace std;

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -19,19 +19,13 @@
 
 #include "world_builder/features/subducting_plate.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/nan.h"
-#include "world_builder/parameters.h"
+
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
 #include "world_builder/types/point.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
-#include "world_builder/utilities.h"
-
 #include "glm/glm.h"
+#include "world_builder/world.h"
 
 using namespace std;
 

--- a/source/features/subducting_plate_models/composition/interface.cc
+++ b/source/features/subducting_plate_models/composition/interface.cc
@@ -19,11 +19,8 @@
 
 #include "world_builder/features/subducting_plate_models/composition/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
 
 
 namespace WorldBuilder

--- a/source/features/subducting_plate_models/composition/uniform.cc
+++ b/source/features/subducting_plate_models/composition/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/subducting_plate_models/composition/uniform.cc
+++ b/source/features/subducting_plate_models/composition/uniform.cc
@@ -19,19 +19,20 @@
 
 #include "world_builder/features/subducting_plate_models/composition/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/grains/interface.cc
+++ b/source/features/subducting_plate_models/grains/interface.cc
@@ -19,11 +19,10 @@
 
 #include "world_builder/features/subducting_plate_models/grains/interface.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/types/object.h"
 #include "world_builder/types/string.h"
-
-#include <algorithm>
 
 namespace WorldBuilder
 {

--- a/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -19,22 +19,21 @@
 
 #include "world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h"
 
-#include "world_builder/assert.h"
+#include <algorithm>
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
-
-#include <algorithm>
+#include "world_builder/world.h"
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -32,8 +32,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/grains/uniform.cc
+++ b/source/features/subducting_plate_models/grains/uniform.cc
@@ -19,20 +19,20 @@
 
 #include "world_builder/features/subducting_plate_models/grains/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/grains/uniform.cc
+++ b/source/features/subducting_plate_models/grains/uniform.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/subducting_plate_models/temperature/adiabatic.cc
+++ b/source/features/subducting_plate_models/temperature/adiabatic.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/temperature/adiabatic.cc
+++ b/source/features/subducting_plate_models/temperature/adiabatic.cc
@@ -19,17 +19,17 @@
 
 #include "world_builder/features/subducting_plate_models/temperature/adiabatic.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/temperature/interface.cc
+++ b/source/features/subducting_plate_models/temperature/interface.cc
@@ -25,11 +25,6 @@
 
 namespace WorldBuilder
 {
-  namespace Types
-  {
-    class Interface;
-  }  // namespace Types
-
   namespace Features
   {
     namespace SubductingPlateModels

--- a/source/features/subducting_plate_models/temperature/interface.cc
+++ b/source/features/subducting_plate_models/temperature/interface.cc
@@ -19,14 +19,17 @@
 
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
-
 #include <algorithm>
+
+#include "world_builder/types/string.h"
 
 namespace WorldBuilder
 {
+  namespace Types
+  {
+    class Interface;
+  }  // namespace Types
+
   namespace Features
   {
     namespace SubductingPlateModels

--- a/source/features/subducting_plate_models/temperature/linear.cc
+++ b/source/features/subducting_plate_models/temperature/linear.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/subducting_plate_models/temperature/linear.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/temperature/linear.cc
+++ b/source/features/subducting_plate_models/temperature/linear.cc
@@ -29,8 +29,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/features/subducting_plate_models/temperature/plate_model.cc
@@ -30,8 +30,6 @@
 
 namespace WorldBuilder
 {
-  template <int dim> class Point;
-
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/features/subducting_plate_models/temperature/plate_model.cc
@@ -19,20 +19,19 @@
 
 #include "world_builder/features/subducting_plate_models/temperature/plate_model.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
-#include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/point.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
+#include "world_builder/world.h"
 
 
 namespace WorldBuilder
 {
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/subducting_plate_models/temperature/uniform.cc
+++ b/source/features/subducting_plate_models/temperature/uniform.cc
@@ -28,8 +28,6 @@
 
 namespace WorldBuilder
 {
-  class World;
-  template <int dim> class Point;
 
   using namespace Utilities;
 

--- a/source/features/subducting_plate_models/temperature/uniform.cc
+++ b/source/features/subducting_plate_models/temperature/uniform.cc
@@ -19,17 +19,18 @@
 
 #include "world_builder/features/subducting_plate_models/temperature/uniform.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/nan.h"
-#include "world_builder/parameters.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/string.h"
 #include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
 {
+  class World;
+  template <int dim> class Point;
+
   using namespace Utilities;
 
   namespace Features

--- a/source/features/utilities.cc
+++ b/source/features/utilities.cc
@@ -19,6 +19,7 @@
 
 #include "world_builder/features/utilities.h"
 
+
 namespace WorldBuilder
 {
   namespace Features

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -17,56 +17,25 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "world_builder/parameters.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/config.h"
-#include "world_builder/utilities.h"
+#include <fstream>
 
-#include "world_builder/types/array.h"
-#include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
-#include "world_builder/types/plugin_system.h"
-#include "world_builder/types/point.h"
-#include "world_builder/types/segment.h"
-#include "world_builder/types/string.h"
-#include "world_builder/types/unsigned_int.h"
-
-#include "world_builder/features/continental_plate_models/composition/interface.h"
-#include "world_builder/features/continental_plate_models/grains/interface.h"
-#include "world_builder/features/continental_plate_models/temperature/interface.h"
-#include "world_builder/features/mantle_layer_models/composition/interface.h"
-#include "world_builder/features/mantle_layer_models/grains/interface.h"
-#include "world_builder/features/mantle_layer_models/temperature/interface.h"
-#include "world_builder/features/oceanic_plate_models/composition/interface.h"
-#include "world_builder/features/oceanic_plate_models/grains/interface.h"
-#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
-#include "world_builder/features/subducting_plate_models/composition/interface.h"
-#include "world_builder/features/subducting_plate_models/grains/interface.h"
-#include "world_builder/features/subducting_plate_models/temperature/interface.h"
-
 #include "world_builder/features/fault.h"
-#include "world_builder/features/fault_models/composition/interface.h"
-#include "world_builder/features/fault_models/grains/interface.h"
-#include "world_builder/features/fault_models/temperature/interface.h"
 #include "world_builder/features/subducting_plate.h"
-#include "world_builder/features/subducting_plate_models/composition/interface.h"
-#include "world_builder/features/subducting_plate_models/grains/interface.h"
-#include "world_builder/features/subducting_plate_models/temperature/interface.h"
-
-
 #include "rapidjson/error/en.h"
 #include "rapidjson/istreamwrapper.h"
 #include "rapidjson/latexwriter.h"
-#include "rapidjson/pointer.h"
 #include "rapidjson/prettywriter.h"
-#include "rapidjson/stringbuffer.h"
-
-#include <fstream>
-#include <memory>
-#include <sstream>
-#include <tuple>
-#include <vector>
+#include "world_builder/features/continental_plate_models/composition/interface.h"
+#include "world_builder/features/continental_plate_models/grains/interface.h"
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
+#include "world_builder/features/oceanic_plate_models/composition/interface.h"
+#include "world_builder/features/oceanic_plate_models/grains/interface.h"
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
+#include "world_builder/features/mantle_layer_models/composition/interface.h"
+#include "world_builder/features/mantle_layer_models/grains/interface.h"
+#include "world_builder/features/mantle_layer_models/temperature/interface.h"
 
 using namespace rapidjson;
 

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -18,24 +18,26 @@
 */
 
 
-#include <fstream>
-
-#include "world_builder/types/object.h"
+#include "world_builder/features/continental_plate_models/composition/interface.h"
+#include "world_builder/features/continental_plate_models/grains/interface.h"
+#include "world_builder/features/continental_plate_models/temperature/interface.h"
 #include "world_builder/features/fault.h"
+#include "world_builder/features/mantle_layer_models/composition/interface.h"
+#include "world_builder/features/mantle_layer_models/grains/interface.h"
+#include "world_builder/features/mantle_layer_models/temperature/interface.h"
+#include "world_builder/features/oceanic_plate_models/composition/interface.h"
+#include "world_builder/features/oceanic_plate_models/grains/interface.h"
+#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
 #include "world_builder/features/subducting_plate.h"
+#include "world_builder/types/object.h"
+
 #include "rapidjson/error/en.h"
 #include "rapidjson/istreamwrapper.h"
 #include "rapidjson/latexwriter.h"
 #include "rapidjson/prettywriter.h"
-#include "world_builder/features/continental_plate_models/composition/interface.h"
-#include "world_builder/features/continental_plate_models/grains/interface.h"
-#include "world_builder/features/continental_plate_models/temperature/interface.h"
-#include "world_builder/features/oceanic_plate_models/composition/interface.h"
-#include "world_builder/features/oceanic_plate_models/grains/interface.h"
-#include "world_builder/features/oceanic_plate_models/temperature/interface.h"
-#include "world_builder/features/mantle_layer_models/composition/interface.h"
-#include "world_builder/features/mantle_layer_models/grains/interface.h"
-#include "world_builder/features/mantle_layer_models/temperature/interface.h"
+
+#include <fstream>
+#include <memory>
 
 using namespace rapidjson;
 

--- a/source/point.cc
+++ b/source/point.cc
@@ -19,10 +19,9 @@
 
 #include "world_builder/point.h"
 
-#include "world_builder/assert.h"
-
-#include <iostream>
 #include <limits>
+
+
 
 
 namespace WorldBuilder

--- a/source/point.cc
+++ b/source/point.cc
@@ -21,9 +21,6 @@
 
 #include <limits>
 
-
-
-
 namespace WorldBuilder
 {
   template<>

--- a/source/types/array.cc
+++ b/source/types/array.cc
@@ -18,7 +18,6 @@
 */
 #include "world_builder/types/array.h"
 
-#include "world_builder/assert.h"
 #include "world_builder/parameters.h"
 
 namespace WorldBuilder

--- a/source/types/bool.cc
+++ b/source/types/bool.cc
@@ -18,8 +18,7 @@
 */
 #include "world_builder/types/bool.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/utilities.h"
+#include "world_builder/parameters.h"
 
 namespace WorldBuilder
 {

--- a/source/types/double.cc
+++ b/source/types/double.cc
@@ -18,8 +18,7 @@
 */
 #include "world_builder/types/double.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/utilities.h"
+#include "world_builder/parameters.h"
 
 namespace WorldBuilder
 {

--- a/source/types/interface.cc
+++ b/source/types/interface.cc
@@ -19,10 +19,6 @@
 
 #include "world_builder/types/interface.h"
 
-#include "world_builder/assert.h"
-
-#include <algorithm>
-
 
 
 namespace WorldBuilder

--- a/source/types/object.cc
+++ b/source/types/object.cc
@@ -19,10 +19,8 @@
 
 #include "world_builder/types/object.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/parameters.h"
 
-#include <utility>
+#include "world_builder/parameters.h"
 
 namespace WorldBuilder
 {

--- a/source/types/plugin_system.cc
+++ b/source/types/plugin_system.cc
@@ -18,9 +18,7 @@
 */
 #include "world_builder/types/plugin_system.h"
 
-#include "world_builder/assert.h"
 
-#include <utility>
 
 namespace WorldBuilder
 {

--- a/source/types/point.cc
+++ b/source/types/point.cc
@@ -18,10 +18,8 @@
 */
 #include "world_builder/types/point.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/utilities.h"
 
-#include <utility>
+#include "world_builder/parameters.h"
 
 namespace WorldBuilder
 {

--- a/source/types/segment.cc
+++ b/source/types/segment.cc
@@ -18,18 +18,43 @@
 */
 #include "world_builder/types/segment.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/features/fault_models/composition/interface.h"
-#include "world_builder/features/fault_models/grains/interface.h"
-#include "world_builder/features/fault_models/temperature/interface.h"
-#include "world_builder/features/subducting_plate_models/composition/interface.h"
-#include "world_builder/features/subducting_plate_models/grains/interface.h"
-#include "world_builder/features/subducting_plate_models/temperature/interface.h"
-#include "world_builder/parameters.h"
-#include "world_builder/utilities.h"
 
 namespace WorldBuilder
 {
+  namespace Features
+  {
+    namespace FaultModels
+    {
+      namespace Composition
+      {
+        class Interface;
+      }  // namespace Composition
+      namespace Grains
+      {
+        class Interface;
+      }  // namespace Grains
+      namespace Temperature
+      {
+        class Interface;
+      }  // namespace Temperature
+    }  // namespace FaultModels
+    namespace SubductingPlateModels
+    {
+      namespace Composition
+      {
+        class Interface;
+      }  // namespace Composition
+      namespace Grains
+      {
+        class Interface;
+      }  // namespace Grains
+      namespace Temperature
+      {
+        class Interface;
+      }  // namespace Temperature
+    }  // namespace SubductingPlateModels
+  }  // namespace Features
+
   namespace Types
   {
     Segment::Segment(const double default_length_,

--- a/source/types/string.cc
+++ b/source/types/string.cc
@@ -18,10 +18,8 @@
 */
 #include "world_builder/types/string.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/parameters.h"
 
-#include <utility>
+#include "world_builder/parameters.h"
 
 namespace WorldBuilder
 {

--- a/source/types/unsigned_int.cc
+++ b/source/types/unsigned_int.cc
@@ -18,10 +18,7 @@
 */
 #include "world_builder/types/unsigned_int.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/utilities.h"
-
-#include "world_builder/nan.h"
+#include "world_builder/parameters.h"
 
 namespace WorldBuilder
 {

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -17,14 +17,10 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "world_builder/assert.h"
-#include "world_builder/coordinate_systems/interface.h"
-#include "world_builder/nan.h"
-#include "world_builder/utilities.h"
-
 #include <algorithm>
 #include <iomanip>
-#include <iostream>
+
+#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder
@@ -461,7 +457,7 @@ namespace WorldBuilder
           // fill it
           global_x_list.resize(point_list.size());
           for (size_t i = 0; i < point_list.size(); ++i)
-            global_x_list[i] = (double)i;
+            global_x_list[i] = static_cast<double>(i);
         }
       WBAssertThrow(global_x_list.size() == point_list.size(), "The given global_x_list doesn't have "
                     "the same size as the point list. This is required.");
@@ -571,7 +567,7 @@ namespace WorldBuilder
           double minimum_distance_to_reference_point = splines.cheap_relative_distance(check_point_surface_2d);
 
           // Compute the clostest point on the spline as a double.
-          for (size_t i_estimate = 0; i_estimate <= parts*(global_x_list[point_list.size()-1])+1; i_estimate++)
+          for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(global_x_list[point_list.size()-1])+1); i_estimate++)
             {
               splines[0] = x_spline(min_estimate_solution_temp);
               splines[1] = y_spline(min_estimate_solution_temp);
@@ -619,7 +615,7 @@ namespace WorldBuilder
           continue_computation = (solution > 0 && floor(solution) <= global_x_list[point_list.size()-2] && floor(solution)  >= 0);
 
           closest_point_on_line_2d = Point<2>(x_spline(solution),y_spline(solution),natural_coordinate_system);
-          i_section_min_distance = (size_t) floor(solution);
+          i_section_min_distance = static_cast<size_t>(floor(solution));
           fraction_CPL_P1P2 = solution-floor(solution);
         }
 

--- a/source/world.cc
+++ b/source/world.cc
@@ -19,33 +19,21 @@
 
 #include "world_builder/world.h"
 
-#include "world_builder/assert.h"
-#include "world_builder/config.h"
-#include "world_builder/coordinate_systems/interface.h"
-#include "world_builder/nan.h"
-#include "world_builder/parameters.h"
-#include "world_builder/point.h"
-#include "world_builder/types/interface.h"
-#include "world_builder/utilities.h"
 
+#include "world_builder/config.h"
+#include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/plugin_system.h"
 #include "world_builder/types/point.h"
-#include "world_builder/types/string.h"
-#include "world_builder/types/unsigned_int.h"
-
-#include "rapidjson/pointer.h"
 
 #ifdef WB_WITH_MPI
 #define OMPI_SKIP_MPICXX 1
 #include <mpi.h>
 #endif
 
-#include <sstream>
-#include <utility>
 
 namespace WorldBuilder
 {

--- a/source/wrapper_c.cc
+++ b/source/wrapper_c.cc
@@ -17,9 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "world_builder/wrapper_c.h"
 
-#include "world_builder/assert.h"
+
 #include "world_builder/world.h"
 
 extern "C" {

--- a/source/wrapper_c.cc
+++ b/source/wrapper_c.cc
@@ -17,7 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
+#include "world_builder/wrapper_c.h"
 
 #include "world_builder/world.h"
 

--- a/source/wrapper_cpp.cc
+++ b/source/wrapper_cpp.cc
@@ -17,12 +17,10 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "world_builder/world.h"
 
+#include "world_builder/world.h"
 #include "world_builder/wrapper_cpp.h"
 
-#include <iostream>
-#include <utility>
 using namespace WorldBuilder;
 namespace wrapper_cpp
 {

--- a/source/wrapper_cpp.cc
+++ b/source/wrapper_cpp.cc
@@ -17,9 +17,9 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "world_builder/wrapper_cpp.h"
 
 #include "world_builder/world.h"
-#include "world_builder/wrapper_cpp.h"
 
 using namespace WorldBuilder;
 namespace wrapper_cpp

--- a/tests/unit_tests/unit_test_wb_glm.cc
+++ b/tests/unit_tests/unit_test_wb_glm.cc
@@ -21,10 +21,11 @@
 
 
 #include <catch2.h>
+#include <array>
 
 #include "world_builder/utilities.h"
-
 #include "glm/glm.h"
+#include "world_builder/coordinate_system.h"
 
 using namespace WorldBuilder;
 

--- a/tests/unit_tests/unit_test_wb_glm.cc
+++ b/tests/unit_tests/unit_test_wb_glm.cc
@@ -20,12 +20,14 @@
 #define CATCH_CONFIG_MAIN
 
 
-#include <catch2.h>
-#include <array>
+#include "catch2.h"
 
-#include "world_builder/utilities.h"
 #include "glm/glm.h"
+
 #include "world_builder/coordinate_system.h"
+#include "world_builder/utilities.h"
+
+#include <array>
 
 using namespace WorldBuilder;
 

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -19,22 +19,26 @@
 
 #define CATCH_CONFIG_MAIN
 
+#include <catch2.h>
+#include <ext/alloc_traits.h>
+#include <stddef.h>
 #include <iostream>
 #include <memory>
-
-#include <catch2.h>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <iterator>
+#include <map>
+#include <random>
+#include <string>
+#include <vector>
 
 #include "world_builder/config.h"
 #include "world_builder/coordinate_systems/interface.h"
-
 #include "world_builder/features/continental_plate.h"
-#include "world_builder/features/fault_models/composition/uniform.h"
-#include "world_builder/features/fault_models/grains/interface.h"
-#include "world_builder/features/fault_models/temperature/uniform.h"
 #include "world_builder/features/interface.h"
-
 #include "world_builder/point.h"
-
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
 #include "world_builder/types/double.h"
@@ -44,14 +48,39 @@
 #include "world_builder/types/segment.h"
 #include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
-
 #include "world_builder/utilities.h"
+#include "world_builder/coordinate_system.h"
+#include "world_builder/grains.h"
+#include "world_builder/parameters.h"
+#include "world_builder/types/interface.h"
+#include "world_builder/world.h"
+
 extern "C" {
 #include "world_builder/wrapper_c.h"
 }
 #include "world_builder/wrapper_cpp.h"
 
-#include "glm/glm.h"
+namespace WorldBuilder
+{
+  namespace Features
+  {
+    namespace FaultModels
+    {
+      namespace Composition
+      {
+        class Interface;
+      }  // namespace Composition
+      namespace Grains
+      {
+        class Interface;
+      }  // namespace Grains
+      namespace Temperature
+      {
+        class Interface;
+      }  // namespace Temperature
+    }  // namespace FaultModels
+  }  // namespace Features
+}  // namespace WorldBuilder
 
 using namespace WorldBuilder;
 
@@ -7094,13 +7123,13 @@ TEST_CASE("Fast sin functions")
 {
   for (int i = -400; i < 400; i++)
     {
-      const double angle = (WorldBuilder::Utilities::const_pi/100.)*(double)i;
+      const double angle = (WorldBuilder::Utilities::const_pi/100.)*static_cast<double>(i);
       CHECK(fabs(FT::sin(angle)-std::sin(angle)) < 1.2e-5);
     }
 
   for (int i = -400; i < 400; i++)
     {
-      const double angle = (WorldBuilder::Utilities::const_pi/100.)*(double)i;
+      const double angle = (WorldBuilder::Utilities::const_pi/100.)*static_cast<double>(i);
       CHECK(fabs(FT::cos(angle)-std::cos(angle)) < 1.2e-5);
     }
 }

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -19,29 +19,20 @@
 
 #define CATCH_CONFIG_MAIN
 
-#include <catch2.h>
-#include <ext/alloc_traits.h>
-#include <stddef.h>
-#include <iostream>
-#include <memory>
-#include <algorithm>
-#include <array>
-#include <cmath>
-#include <iomanip>
-#include <iterator>
-#include <map>
-#include <random>
-#include <string>
-#include <vector>
+#include "catch2.h"
 
 #include "world_builder/config.h"
+#include "world_builder/coordinate_system.h"
 #include "world_builder/coordinate_systems/interface.h"
 #include "world_builder/features/continental_plate.h"
 #include "world_builder/features/interface.h"
+#include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 #include "world_builder/point.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
 #include "world_builder/types/double.h"
+#include "world_builder/types/interface.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/plugin_system.h"
 #include "world_builder/types/point.h"
@@ -49,16 +40,25 @@
 #include "world_builder/types/string.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/utilities.h"
-#include "world_builder/coordinate_system.h"
-#include "world_builder/grains.h"
-#include "world_builder/parameters.h"
-#include "world_builder/types/interface.h"
 #include "world_builder/world.h"
 
 extern "C" {
 #include "world_builder/wrapper_c.h"
 }
 #include "world_builder/wrapper_cpp.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <random>
+#include <stddef.h>
+#include <string>
+#include <vector>
 
 namespace WorldBuilder
 {

--- a/visualization/main.cc
+++ b/visualization/main.cc
@@ -28,9 +28,9 @@
 #include "world_builder/assert.h"
 #include "world_builder/coordinate_system.h"
 #include "world_builder/nan.h"
+#include "world_builder/point.h"
 #include "world_builder/utilities.h"
 #include "world_builder/world.h"
-#include "world_builder/point.h"
 
 #include "vtu11/vtu11.hpp"
 #undef max
@@ -44,11 +44,11 @@
 #include <array>
 #include <cmath>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <thread>
 #include <vector>
-#include <iterator>
 
 
 using namespace WorldBuilder;

--- a/visualization/main.cc
+++ b/visualization/main.cc
@@ -30,7 +30,7 @@
 #include "world_builder/nan.h"
 #include "world_builder/utilities.h"
 #include "world_builder/world.h"
-
+#include "world_builder/point.h"
 
 #include "vtu11/vtu11.hpp"
 #undef max
@@ -43,11 +43,12 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
-#include <exception>
-#include <fstream>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <thread>
+#include <vector>
+#include <iterator>
 
 
 using namespace WorldBuilder;
@@ -1386,38 +1387,38 @@ int main(int argc, char **argv)
         }
       std::cout << "[5/6] Preparing to write the paraview file: stage 2 of 6, converting the connectivity                              \r";
       std::cout.flush();
-      const double pow_2_dim = pow(2,dim);
+      const size_t pow_2_dim = dim == 2 ? 4 : 8;
       std::vector<vtu11::VtkIndexType> connectivity(n_cell*pow_2_dim);
       if (dim == 2)
         for (size_t i = 0; i < n_cell; ++i)
           {
-            connectivity[i*pow_2_dim] = grid_connectivity[i][0];
-            connectivity[i*pow_2_dim+1] = grid_connectivity[i][1];
-            connectivity[i*pow_2_dim+2] = grid_connectivity[i][2];
-            connectivity[i*pow_2_dim+3] = grid_connectivity[i][3];
+            connectivity[i*pow_2_dim] = static_cast<int>(grid_connectivity[i][0]);
+            connectivity[i*pow_2_dim+1] = static_cast<int>(grid_connectivity[i][1]);
+            connectivity[i*pow_2_dim+2] = static_cast<int>(grid_connectivity[i][2]);
+            connectivity[i*pow_2_dim+3] = static_cast<int>(grid_connectivity[i][3]);
           }
       else
         for (size_t i = 0; i < n_cell; ++i)
           {
 
-            connectivity[i*pow_2_dim] = grid_connectivity[i][0];
-            connectivity[i*pow_2_dim+1] = grid_connectivity[i][1];
-            connectivity[i*pow_2_dim+2] = grid_connectivity[i][2];
-            connectivity[i*pow_2_dim+3] = grid_connectivity[i][3];
-            connectivity[i*pow_2_dim+4] = grid_connectivity[i][4];
-            connectivity[i*pow_2_dim+5] = grid_connectivity[i][5];
-            connectivity[i*pow_2_dim+6] = grid_connectivity[i][6];
-            connectivity[i*pow_2_dim+7] = grid_connectivity[i][7];
+            connectivity[i*pow_2_dim] = static_cast<int>(grid_connectivity[i][0]);
+            connectivity[i*pow_2_dim+1] = static_cast<int>(grid_connectivity[i][1]);
+            connectivity[i*pow_2_dim+2] = static_cast<int>(grid_connectivity[i][2]);
+            connectivity[i*pow_2_dim+3] = static_cast<int>(grid_connectivity[i][3]);
+            connectivity[i*pow_2_dim+4] = static_cast<int>(grid_connectivity[i][4]);
+            connectivity[i*pow_2_dim+5] = static_cast<int>(grid_connectivity[i][5]);
+            connectivity[i*pow_2_dim+6] = static_cast<int>(grid_connectivity[i][6]);
+            connectivity[i*pow_2_dim+7] = static_cast<int>(grid_connectivity[i][7]);
           }
       std::cout << "[5/6] Preparing to write the paraview file: stage 3 of 6, creating the offsets                              \r";
       std::cout.flush();
       std::vector<vtu11::VtkIndexType> offsets(n_cell);
       if (dim == 2)
         for (size_t i = 0; i < n_cell; ++i)
-          offsets[i] = (i+1) * 4;
+          offsets[i] = static_cast<int>((i+1) * 4);
       else
         for (size_t i = 0; i < n_cell; ++i)
-          offsets[i] = (i+1) * 8;
+          offsets[i] = static_cast<int>((i+1) * 8);
 
       std::cout << "[5/6] Preparing to write the paraview file: stage 4 of 6, creating the Data set info                              \r";
       std::cout.flush();


### PR DESCRIPTION
This is a follow up for #293 and related to issue #294. Clean up header files with IWYU and custom script (which can be found here: https://stackoverflow.com/a/7135530) which goes through all the files and removes the includes one by one. This is has been a bit messy and a lot of checking and fixing by hand, but the final result is an improvement. So I am not going to include the codes I used to do this in the pull request for now. 