### PR TITLE
Clang tidy headers fixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(WB_CHECK_CLANG_TIDY OFF CACHE BOOL "Whether or not to check the code with cl
 if(WB_CHECK_CLANG_TIDY)
   set(WB_CHECK_CLANG_TIDY_CHECKS "clang-analyzer-*,performance-*,modernize-a*,modernize-c*,modernize-c*,modernize-l*,modernize-m*,modernize-p*,modernize-r*\
 ,modernize-s*,modernize-un*,modernize-use-b*,modernize-use-d*,modernize-use-e*,modernize-use-n*,modernize-use-o*,modernize-use-tran*,modernize-use-u*\
-,misc-*,mpi-*,readability-a*,readability-c*,readability-d*,readability-e*,readability-i*,readability-mak*,readability-mi*,readability-n*,llvm-*\
+,misc-*,mpi-*,readability-c*,readability-d*,readability-e*,readability-i*,readability-mak*,readability-mi*,readability-n*,llvm-*\
 ,readability-q*,readability-r*,readability-s*,readability-u*"
   CACHE STRING "A list of items to check with clang-tidy")
   set(WB_CHECK_CLANG_TIDY_FIX OFF CACHE BOOL "Whether or not to try to automatically fix the clang-tidy issues when found.")

--- a/include/world_builder/assert.h
+++ b/include/world_builder/assert.h
@@ -58,6 +58,6 @@ namespace WorldBuilder
           throw std::runtime_error(smessage.str()); \
         } \
     } while (false)
-}
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/config.h
+++ b/include/world_builder/config.h
@@ -42,7 +42,7 @@ namespace WorldBuilder
   {
     static const std::string WORLD_BUILDER_SOURCE_DIR;
   };
-}
+} // namespace WorldBuilder
 
 
 #endif /* WORLD_BUILDER_CONFIG_H_ */

--- a/include/world_builder/coordinate_system.h
+++ b/include/world_builder/coordinate_system.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _aspect_world_builder_coordinate_sytems_h
-#define _aspect_world_builder_coordinate_sytems_h
+#ifndef WORLD_BUILDER_COORDINATE_SYSTEM_H
+#define WORLD_BUILDER_COORDINATE_SYSTEM_H
 
 namespace WorldBuilder
 {
@@ -61,7 +61,7 @@ namespace WorldBuilder
     continuous_angle_with_surface,
     none
   };
-}
+} // namespace WorldBuilder
 
 #endif
 

--- a/include/world_builder/coordinate_systems/cartesian.h
+++ b/include/world_builder/coordinate_systems/cartesian.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_coordinate_systems_cartesian_h
-#define _world_builder_coordinate_systems_cartesian_h
+#ifndef WORLD_BUILDER_COORDINATE_SYSTEMS_CARTESIAN_H
+#define WORLD_BUILDER_COORDINATE_SYSTEMS_CARTESIAN_H
 
 #include "world_builder/coordinate_systems/interface.h"
 
@@ -41,7 +41,7 @@ namespace WorldBuilder
      * doesn't do anything with the coordinates, but is needed to have a common
      * interface for all the geometry models.
      */
-    class Cartesian : public Interface
+    class Cartesian final : public Interface
     {
       public:
         /**
@@ -52,7 +52,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Cartesian();
+        ~Cartesian() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -105,7 +105,7 @@ namespace WorldBuilder
       private:
 
     };
-  }
-}
+  } // namespace CoordinateSystems
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_coordinate_systems_interface_h
-#define _world_builder_coordinate_systems_interface_h
+#ifndef WORLD_BUILDER_COORDINATE_SYSTEMS_INTERFACE_H
+#define WORLD_BUILDER_COORDINATE_SYSTEMS_INTERFACE_H
 
 #include "world_builder/coordinate_systems/interface.h"
 
@@ -111,7 +111,7 @@ namespace WorldBuilder
          * registration of the object factory.
          */
         static void registerType(const std::string &name,
-                                 void ( *)(Parameters &, const std::string &),
+                                 void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                  ObjectFactory *factory);
 
         /**
@@ -171,7 +171,7 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-  }
-}
+  } // namespace CoordinateSystems
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/coordinate_systems/spherical.h
+++ b/include/world_builder/coordinate_systems/spherical.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_coordinate_systems_spherical_h
-#define _world_builder_coordinate_systems_spherical_h
+#ifndef WORLD_BUILDER_COORDINATE_SYSTEMS_SPHERICAL_H
+#define WORLD_BUILDER_COORDINATE_SYSTEMS_SPHERICAL_H
 
 #include "world_builder/coordinate_systems/interface.h"
 
@@ -39,7 +39,7 @@ namespace WorldBuilder
      * doesn't do anything with the coordinates, but is needed to have a common
      * interface for all the geometry models.
      */
-    class Spherical : public Interface
+    class Spherical final : public Interface
     {
       public:
         /**
@@ -50,7 +50,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Spherical();
+        ~Spherical() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -113,7 +113,7 @@ namespace WorldBuilder
       private:
 
     };
-  }
-}
+  } // namespace CoordinateSystems
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_features_continental_plate_h
-#define _world_feature_features_continental_plate_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_H
 
 
 #include "world_builder/features/interface.h"
@@ -53,7 +53,7 @@ namespace WorldBuilder
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class ContinentalPlate : public Interface
+    class ContinentalPlate final: public Interface
     {
       public:
         /**
@@ -64,7 +64,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~ContinentalPlate();
+        ~ContinentalPlate() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -106,7 +106,7 @@ namespace WorldBuilder
          * olvine and/or enstatite) which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
+
         WorldBuilder::grains
         grains(const Point<3> &position,
                const double depth,
@@ -147,7 +147,7 @@ namespace WorldBuilder
     };
 
 
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/continental_plate_models/composition/interface.h
+++ b/include/world_builder/features/continental_plate_models/composition/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_continental_plate_composition_interface_h
-#define _world_builder_features_continental_plate_composition_interface_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_COMPOSITION_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_COMPOSITION_INTERFACE_H
 
 
 #include "world_builder/parameters.h"
@@ -84,7 +84,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -155,9 +155,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/continental_plate_models/composition/uniform.h
+++ b/include/world_builder/features/continental_plate_models/composition/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_continental_plate_composition_uniform_h
-#define _world_builder_features_continental_plate_composition_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_COMPOSITION_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_COMPOSITION_UNIFORM_H
 
 
 #include "world_builder/features/continental_plate_models/composition/interface.h"
@@ -38,7 +38,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final : public Interface
         {
           public:
             /**
@@ -49,7 +49,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -84,9 +84,9 @@ namespace WorldBuilder
             std::string operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/continental_plate_models/grains/interface.h
+++ b/include/world_builder/features/continental_plate_models/grains/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_continental_plate_grains_interface_h
-#define _world_builder_features_continental_plate_grains_interface_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_GRAINS_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_GRAINS_INTERFACE_H
 
 
 #include "world_builder/grains.h"
@@ -89,7 +89,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -160,9 +160,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_continental_plate_grains_random_uniform_distribution_h
-#define _world_builder_features_continental_plate_grains_random_uniform_distribution_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
 
 
 #include "world_builder/features/continental_plate_models/grains/interface.h"
@@ -39,7 +39,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class RandomUniformDistribution : public Interface
+        class RandomUniformDistribution final : public Interface
         {
           public:
             /**
@@ -50,7 +50,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~RandomUniformDistribution();
+            ~RandomUniformDistribution() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -85,7 +85,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position, const double depth,
                        const unsigned int composition_number,
                        WorldBuilder::grains grains,

--- a/include/world_builder/features/continental_plate_models/grains/uniform.h
+++ b/include/world_builder/features/continental_plate_models/grains/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_continental_plate_grains_uniform_h
-#define _world_builder_features_continental_plate_grains_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_GRAINS_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_GRAINS_UNIFORM_H
 
 
 #include "world_builder/features/continental_plate_models/grains/interface.h"
@@ -37,7 +37,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final : public Interface
         {
           public:
             /**
@@ -48,7 +48,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -83,7 +83,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position, const double depth,
                        const unsigned int composition_number,
                        WorldBuilder::grains grains,

--- a/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_continental_plate_temperature_adiabatic_h
-#define _world_builder_features_continental_plate_temperature_adiabatic_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_TEMPERATURE_ADIABATIC_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_TEMPERATURE_ADIABATIC_H
 
 
 #include "world_builder/features/continental_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Adiabatic : public Interface
+        class Adiabatic final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Adiabatic();
+            ~Adiabatic() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -100,9 +100,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/continental_plate_models/temperature/interface.h
+++ b/include/world_builder/features/continental_plate_models/temperature/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_continental_plate_temperature_interface_h
-#define _world_builder_features_continental_plate_temperature_interface_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_TEMPERATURE_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_TEMPERATURE_INTERFACE_H
 
 
 #include "world_builder/parameters.h"
@@ -87,7 +87,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -159,9 +159,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/continental_plate_models/temperature/linear.h
+++ b/include/world_builder/features/continental_plate_models/temperature/linear.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_continental_plate_temperature_linear_h
-#define _world_builder_features_continental_plate_temperature_linear_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_TEMPERATURE_LINEAR_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_TEMPERATURE_LINEAR_H
 
 
 #include "world_builder/features/continental_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Linear : public Interface
+        class Linear final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Linear();
+            ~Linear() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -86,9 +86,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/continental_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/continental_plate_models/temperature/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_continental_plate_temperature_uniform_h
-#define _world_builder_features_continental_plate_temperature_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_TEMPERATURE_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_TEMPERATURE_UNIFORM_H
 
 
 #include "world_builder/features/continental_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -85,9 +85,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_features_fault_h
-#define _world_feature_features_fault_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_H
+#define WORLD_BUILDER_FEATURES_FAULT_H
 
 
 #include "world_builder/features/fault_models/composition/interface.h"
@@ -56,7 +56,7 @@ namespace WorldBuilder
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class Fault : public Interface
+    class Fault final: public Interface
     {
       public:
         /**
@@ -67,7 +67,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Fault();
+        ~Fault() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -108,7 +108,7 @@ namespace WorldBuilder
          * olvine and/or enstatite) which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
+
         WorldBuilder::grains
         grains(const Point<3> &position,
                const double depth,
@@ -178,7 +178,7 @@ namespace WorldBuilder
 
 
     };
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/fault_models/composition/interface.h
+++ b/include/world_builder/features/fault_models/composition/interface.h
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_fault_composition_interface_h
-#define _world_builder_features_fault_composition_interface_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_MODELS_COMPOSITION_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_FAULT_MODELS_COMPOSITION_INTERFACE_H
 
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 #include "world_builder/utilities.h"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 namespace WorldBuilder
 {
@@ -91,7 +91,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -162,9 +162,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/fault_models/composition/uniform.h
+++ b/include/world_builder/features/fault_models/composition/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_fault_composition_uniform_h
-#define _world_builder_features_fault_composition_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_MODELS_COMPOSITION_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_FAULT_MODELS_COMPOSITION_UNIFORM_H
 
 
 #include "world_builder/features/fault_models/composition/interface.h"
@@ -39,7 +39,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -50,7 +50,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -86,9 +86,9 @@ namespace WorldBuilder
             std::string operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/fault_models/grains/interface.h
+++ b/include/world_builder/features/fault_models/grains/interface.h
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_fault_grains_interface_h
-#define _world_builder_features_fault_grains_interface_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_MODELS_GRAINS_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_FAULT_MODELS_GRAINS_INTERFACE_H
 
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 #include "world_builder/utilities.h"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 namespace WorldBuilder
 {
@@ -92,7 +92,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -163,9 +163,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_fault_grains_random_uniform_distribution_h
-#define _world_builder_features_fault_grains_random_uniform_distribution_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
+#define WORLD_BUILDER_FEATURES_FAULT_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
 
 
 #include "world_builder/features/fault_models/grains/interface.h"
@@ -38,7 +38,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class RandomUniformDistribution : public Interface
+        class RandomUniformDistribution final: public Interface
         {
           public:
             /**
@@ -49,7 +49,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~RandomUniformDistribution();
+            ~RandomUniformDistribution() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -84,7 +84,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position,
                        const double depth,
                        const unsigned int composition_number,

--- a/include/world_builder/features/fault_models/grains/uniform.h
+++ b/include/world_builder/features/fault_models/grains/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_fault_grains_uniform_h
-#define _world_builder_features_fault_grains_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_MODELS_GRAINS_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_FAULT_MODELS_GRAINS_UNIFORM_H
 
 
 #include "world_builder/features/fault_models/grains/interface.h"
@@ -38,7 +38,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -49,7 +49,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -84,7 +84,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position,
                        const double depth,
                        const unsigned int composition_number,

--- a/include/world_builder/features/fault_models/temperature/adiabatic.h
+++ b/include/world_builder/features/fault_models/temperature/adiabatic.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_fault_temperature_adiabatic_h
-#define _world_builder_features_fault_temperature_adiabatic_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_MODELS_TEMPERATURE_ADIABATIC_H
+#define WORLD_BUILDER_FEATURES_FAULT_MODELS_TEMPERATURE_ADIABATIC_H
 
 
 #include "world_builder/features/fault_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Adiabatic : public Interface
+        class Adiabatic final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Adiabatic();
+            ~Adiabatic() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -101,9 +101,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/fault_models/temperature/interface.h
+++ b/include/world_builder/features/fault_models/temperature/interface.h
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_fault_temperature_interface_h
-#define _world_builder_features_fault_temperature_interface_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_MODELS_TEMPERATURE_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_FAULT_MODELS_TEMPERATURE_INTERFACE_H
 
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 #include "world_builder/utilities.h"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 namespace WorldBuilder
 {
@@ -91,7 +91,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -163,9 +163,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/fault_models/temperature/linear.h
+++ b/include/world_builder/features/fault_models/temperature/linear.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_fault_temperature_linear_h
-#define _world_builder_features_fault_temperature_linear_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_MODELS_TEMPERATURE_LINEAR_H
+#define WORLD_BUILDER_FEATURES_FAULT_MODELS_TEMPERATURE_LINEAR_H
 
 
 #include "world_builder/features/fault_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Linear : public Interface
+        class Linear final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Linear();
+            ~Linear() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -87,9 +87,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/fault_models/temperature/uniform.h
+++ b/include/world_builder/features/fault_models/temperature/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_fault_temperature_uniform_h
-#define _world_builder_features_fault_temperature_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_FAULT_MODELS_TEMPERATURE_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_FAULT_MODELS_TEMPERATURE_UNIFORM_H
 
 
 #include "world_builder/features/fault_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -86,9 +86,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace FaultModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_interface_h
-#define _world_builder_features_interface_h
+#ifndef WORLD_BUILDER_FEATURES_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_INTERFACE_H
 
 
 #include "world_builder/grains.h"
@@ -116,10 +116,10 @@ namespace WorldBuilder
          * registration of the object factory.
          */
         static void registerType(const std::string &name,
-                                 void ( *)(Parameters &, const std::string &, const std::vector<std::string> &required_entries),
+                                 void ( * /*declare_entries*/)(Parameters &, const std::string &, const std::vector<std::string> &required_entries),
                                  ObjectFactory *factory);
 
-        const std::string get_name() const
+        std::string get_name() const
         {
           return name;
         };
@@ -232,7 +232,7 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_features_mantle_layer_h
-#define _world_feature_features_mantle_layer_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_H
 
 
 #include "world_builder/features/interface.h"
@@ -53,7 +53,7 @@ namespace WorldBuilder
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class MantleLayer : public Interface
+    class MantleLayer final: public Interface
     {
       public:
         /**
@@ -64,7 +64,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~MantleLayer();
+        ~MantleLayer() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -109,7 +109,7 @@ namespace WorldBuilder
          * olvine and/or enstatite) which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
+
         WorldBuilder::grains
         grains(const Point<3> &position,
                const double depth,
@@ -149,7 +149,7 @@ namespace WorldBuilder
     };
 
 
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/mantle_layer_models/composition/interface.h
+++ b/include/world_builder/features/mantle_layer_models/composition/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_mantle_layer_composition_interface_h
-#define _world_builder_features_mantle_layer_composition_interface_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_COMPOSITION_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_COMPOSITION_INTERFACE_H
 
 
 #include "world_builder/parameters.h"
@@ -87,7 +87,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -158,9 +158,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/mantle_layer_models/composition/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/composition/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_mantle_layer_composition_uniform_h
-#define _world_builder_features_mantle_layer_composition_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_COMPOSITION_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_COMPOSITION_UNIFORM_H
 
 
 #include "world_builder/features/mantle_layer_models/composition/interface.h"
@@ -39,7 +39,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -50,7 +50,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -85,9 +85,9 @@ namespace WorldBuilder
             std::string operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/mantle_layer_models/grains/interface.h
+++ b/include/world_builder/features/mantle_layer_models/grains/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_mantle_layer_grains_interface_h
-#define _world_builder_features_mantle_layer_grains_interface_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_GRAINS_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_GRAINS_INTERFACE_H
 
 
 #include "world_builder/grains.h"
@@ -89,7 +89,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -160,9 +160,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_mantle_layer_grains_random_uniform_distribution_h
-#define _world_builder_features_mantle_layer_grains_random_uniform_distribution_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
 
 
 #include "world_builder/features/mantle_layer_models/grains/interface.h"
@@ -38,7 +38,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class RandomUniformDistribution : public Interface
+        class RandomUniformDistribution final: public Interface
         {
           public:
             /**
@@ -49,7 +49,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~RandomUniformDistribution();
+            ~RandomUniformDistribution() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -84,7 +84,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position, const double depth,
                        const unsigned int composition_number,
                        WorldBuilder::grains grains,

--- a/include/world_builder/features/mantle_layer_models/grains/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/grains/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_mantle_layer_grains_uniform_h
-#define _world_builder_features_mantle_layer_grains_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_GRAINS_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_GRAINS_UNIFORM_H
 
 
 #include "world_builder/features/mantle_layer_models/grains/interface.h"
@@ -38,7 +38,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -49,7 +49,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -84,7 +84,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position, const double depth,
                        const unsigned int composition_number,
                        WorldBuilder::grains grains,
@@ -102,7 +102,7 @@ namespace WorldBuilder
             std::vector<double> grain_sizes;
         };
       } // namespace Grains
-    }   // namespace MantlelayerModels
+    } // namespace MantleLayerModels
   }     // namespace Features
 } // namespace WorldBuilder
 

--- a/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_mantle_layer_temperature_adiabatic_h
-#define _world_builder_features_mantle_layer_temperature_adiabatic_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_TEMPERATURE_ADIABATIC_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_TEMPERATURE_ADIABATIC_H
 
 
 #include "world_builder/features/mantle_layer_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Adiabatic : public Interface
+        class Adiabatic final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Adiabatic();
+            ~Adiabatic() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -100,9 +100,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/mantle_layer_models/temperature/interface.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_mantle_layer_temperature_interface_h
-#define _world_builder_features_mantle_layer_temperature_interface_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_TEMPERATURE_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_TEMPERATURE_INTERFACE_H
 
 
 #include "world_builder/parameters.h"
@@ -87,7 +87,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -159,9 +159,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/mantle_layer_models/temperature/linear.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/linear.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_mantle_layer_temperature_linear_h
-#define _world_builder_features_mantle_layer_temperature_linear_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_TEMPERATURE_LINEAR_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_TEMPERATURE_LINEAR_H
 
 
 #include "world_builder/features/mantle_layer_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Linear : public Interface
+        class Linear final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Linear();
+            ~Linear() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -86,9 +86,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/mantle_layer_models/temperature/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_mantle_layer_temperature_uniform_h
-#define _world_builder_features_mantle_layer_temperature_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_TEMPERATURE_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_MODELS_TEMPERATURE_UNIFORM_H
 
 
 #include "world_builder/features/mantle_layer_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -85,9 +85,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace MantleLayerModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_features_oceanic_plate_h
-#define _world_feature_features_oceanic_plate_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_H
 
 
 #include "world_builder/features/interface.h"
@@ -53,7 +53,7 @@ namespace WorldBuilder
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class OceanicPlate : public Interface
+    class OceanicPlate final: public Interface
     {
       public:
         /**
@@ -64,7 +64,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~OceanicPlate();
+        ~OceanicPlate() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -109,7 +109,7 @@ namespace WorldBuilder
          * olvine and/or enstatite) which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
+
         WorldBuilder::grains
         grains(const Point<3> &position,
                const double depth,
@@ -146,7 +146,7 @@ namespace WorldBuilder
         double min_depth;
         double max_depth;
     };
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/oceanic_plate_models/composition/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_composition_interface_h
-#define _world_builder_features_oceanic_plate_composition_interface_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_COMPOSITION_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_COMPOSITION_INTERFACE_H
 
 
 #include "world_builder/parameters.h"
@@ -87,7 +87,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -158,9 +158,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/oceanic_plate_models/composition/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_composition_uniform_h
-#define _world_builder_features_oceanic_plate_composition_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_COMPOSITION_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_COMPOSITION_UNIFORM_H
 
 
 #include "world_builder/features/oceanic_plate_models/composition/interface.h"
@@ -39,7 +39,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -50,7 +50,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -85,9 +85,9 @@ namespace WorldBuilder
             std::string operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/oceanic_plate_models/grains/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_grains_interface_h
-#define _world_builder_features_oceanic_plate_grains_interface_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_GRAINS_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_GRAINS_INTERFACE_H
 
 
 #include "world_builder/grains.h"
@@ -85,7 +85,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -156,9 +156,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_grains_random_uniform_distribution_h
-#define _world_builder_features_oceanic_plate_grains_random_uniform_distribution_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
 
 
 #include "world_builder/features/oceanic_plate_models/grains/interface.h"
@@ -38,7 +38,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class RandomUniformDistribution : public Interface
+        class RandomUniformDistribution final: public Interface
         {
           public:
             /**
@@ -49,7 +49,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~RandomUniformDistribution();
+            ~RandomUniformDistribution() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -84,7 +84,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position, const double depth,
                        const unsigned int composition_number,
                        WorldBuilder::grains grains,

--- a/include/world_builder/features/oceanic_plate_models/grains/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_grains_uniform_h
-#define _world_builder_features_oceanic_plate_grains_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_GRAINS_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_GRAINS_UNIFORM_H
 
 
 #include "world_builder/features/oceanic_plate_models/grains/interface.h"
@@ -38,7 +38,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -49,7 +49,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -84,7 +84,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position, const double depth,
                        const unsigned int composition_number,
                        WorldBuilder::grains grains,

--- a/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_temperature_adiabatic_h
-#define _world_builder_features_oceanic_plate_temperature_adiabatic_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_ADIABATIC_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_ADIABATIC_H
 
 
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Adiabatic : public Interface
+        class Adiabatic final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Adiabatic();
+            ~Adiabatic() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -100,9 +100,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/oceanic_plate_models/temperature/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_temperature_interface_h
-#define _world_builder_features_oceanic_plate_temperature_interface_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_INTERFACE_H
 
 
 #include "world_builder/parameters.h"
@@ -87,7 +87,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -159,9 +159,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/oceanic_plate_models/temperature/linear.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/linear.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_temperature_linear_h
-#define _world_builder_features_oceanic_plate_temperature_linear_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_LINEAR_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_LINEAR_H
 
 
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Linear : public Interface
+        class Linear final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Linear();
+            ~Linear() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -86,9 +86,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_temperature_plate_model_h
-#define _world_builder_features_oceanic_plate_temperature_plate_model_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_PLATE_MODEL_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_PLATE_MODEL_H
 
 
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
@@ -42,7 +42,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class PlateModel : public Interface
+        class PlateModel final: public Interface
         {
           public:
             /**
@@ -53,7 +53,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~PlateModel();
+            ~PlateModel() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -90,9 +90,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_oceanic_plate_temperature_uniform_h
-#define _world_builder_features_oceanic_plate_temperature_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_MODELS_TEMPERATURE_UNIFORM_H
 
 
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -85,9 +85,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace OceanicPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_features_subducting_plate_h
-#define _world_feature_features_subducting_plate_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_H
 
 
 #include "world_builder/features/subducting_plate_models/composition/interface.h"
@@ -56,7 +56,7 @@ namespace WorldBuilder
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class SubductingPlate : public Interface
+    class SubductingPlate final: public Interface
     {
       public:
         /**
@@ -67,7 +67,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~SubductingPlate();
+        ~SubductingPlate() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -111,7 +111,7 @@ namespace WorldBuilder
          * olvine and/or enstatite) which is being requested and the current value
          * of that composition at this location and depth.
          */
-        virtual
+
         WorldBuilder::grains
         grains(const Point<3> &position,
                const double depth,
@@ -180,7 +180,7 @@ namespace WorldBuilder
         double maximum_slab_thickness;
 
     };
-  }
-}
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/subducting_plate_models/composition/interface.h
+++ b/include/world_builder/features/subducting_plate_models/composition/interface.h
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_composition_interface_h
-#define _world_builder_features_subducting_plate_composition_interface_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_COMPOSITION_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_COMPOSITION_INTERFACE_H
 
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 #include "world_builder/utilities.h"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 namespace WorldBuilder
 {
@@ -91,7 +91,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -162,9 +162,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/subducting_plate_models/composition/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/composition/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_composition_uniform_h
-#define _world_builder_features_subducting_plate_composition_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_COMPOSITION_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_COMPOSITION_UNIFORM_H
 
 
 #include "world_builder/features/subducting_plate_models/composition/interface.h"
@@ -39,7 +39,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -50,7 +50,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -86,9 +86,9 @@ namespace WorldBuilder
             std::string operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Composition
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/subducting_plate_models/grains/interface.h
+++ b/include/world_builder/features/subducting_plate_models/grains/interface.h
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_grains_interface_h
-#define _world_builder_features_subducting_plate_grains_interface_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_GRAINS_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_GRAINS_INTERFACE_H
 
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 #include "world_builder/utilities.h"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 namespace WorldBuilder
 {
@@ -92,7 +92,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -163,9 +163,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Grains
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_grains_random_uniform_distribution_h
-#define _world_builder_features_subducting_plate_grains_random_uniform_distribution_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_GRAINS_RANDOM_UNIFORM_DISTRIBUTION_H
 
 
 #include "world_builder/features/subducting_plate_models/grains/interface.h"
@@ -38,7 +38,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class RandomUniformDistribution : public Interface
+        class RandomUniformDistribution final: public Interface
         {
           public:
             /**
@@ -49,7 +49,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~RandomUniformDistribution();
+            ~RandomUniformDistribution() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -84,7 +84,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position,
                        const double depth,
                        const unsigned int composition_number,

--- a/include/world_builder/features/subducting_plate_models/grains/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/grains/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_grains_uniform_h
-#define _world_builder_features_subducting_plate_grains_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_GRAINS_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_GRAINS_UNIFORM_H
 
 
 #include "world_builder/features/subducting_plate_models/grains/interface.h"
@@ -38,7 +38,7 @@ namespace WorldBuilder
          * what the returned temperature or grains of the temperature and grains
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -49,7 +49,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters
@@ -84,7 +84,7 @@ namespace WorldBuilder
              * Returns a grains based on the given position, composition (e.g.
              * olivine and/or enstatite)depth in the model, gravity and current grains.
              */
-            virtual WorldBuilder::grains
+            WorldBuilder::grains
             get_grains(const Point<3> &position,
                        const double depth,
                        const unsigned int composition_number,
@@ -104,7 +104,7 @@ namespace WorldBuilder
             std::vector<double> grain_sizes;
         };
       } // namespace Grains
-    }   // namespace FaultModels
+    } // namespace SubductingPlateModels
   }     // namespace Features
 } // namespace WorldBuilder
 

--- a/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_temperature_adiabatic_h
-#define _world_builder_features_subducting_plate_temperature_adiabatic_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_ADIABATIC_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_ADIABATIC_H
 
 
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Adiabatic : public Interface
+        class Adiabatic final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Adiabatic();
+            ~Adiabatic() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -101,9 +101,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/subducting_plate_models/temperature/interface.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/interface.h
@@ -17,15 +17,15 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_temperature_interface_h
-#define _world_builder_features_subducting_plate_temperature_interface_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_INTERFACE_H
 
-#include "world_builder/parameters.h"
 #include "world_builder/grains.h"
+#include "world_builder/parameters.h"
 #include "world_builder/utilities.h"
 
-#include <vector>
 #include <map>
+#include <vector>
 
 namespace WorldBuilder
 {
@@ -91,7 +91,7 @@ namespace WorldBuilder
              * registration of the object factory.
              */
             static void registerType(const std::string &name,
-                                     void ( *)(Parameters &, const std::string &),
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
                                      ObjectFactory *factory);
 
 
@@ -163,9 +163,9 @@ namespace WorldBuilder
   }; \
   static klass##Factory global_##klass##Factory;
 
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/subducting_plate_models/temperature/linear.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/linear.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_temperature_linear_h
-#define _world_builder_features_subducting_plate_temperature_linear_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_LINEAR_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_LINEAR_H
 
 
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Linear : public Interface
+        class Linear final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Linear();
+            ~Linear() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -87,9 +87,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_temperature_plate_model_h
-#define _world_builder_features_subducting_plate_temperature_plate_model_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_PLATE_MODEL_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_PLATE_MODEL_H
 
 
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class PlateModel : public Interface
+        class PlateModel final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~PlateModel();
+            ~PlateModel() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -93,9 +93,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/subducting_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/uniform.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_features_subducting_plate_temperature_uniform_h
-#define _world_builder_features_subducting_plate_temperature_uniform_h
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_TEMPERATURE_UNIFORM_H
 
 
 #include "world_builder/features/subducting_plate_models/temperature/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
          * the returned temperature or composition of the temperature and composition
          * functions of this class will be.
          */
-        class Uniform : public Interface
+        class Uniform final: public Interface
         {
           public:
             /**
@@ -51,7 +51,7 @@ namespace WorldBuilder
             /**
              * Destructor
              */
-            ~Uniform();
+            ~Uniform() override final;
 
             /**
              * declare and read in the world builder file into the parameters class
@@ -86,9 +86,9 @@ namespace WorldBuilder
             Utilities::Operations operation;
 
         };
-      }
-    }
-  }
-}
+      } // namespace Temperature
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/features/utilities.h
+++ b/include/world_builder/features/utilities.h
@@ -18,8 +18,8 @@
 */
 
 
-#ifndef _world_builder_features_utilities_h
-#define _world_builder_features_utilities_h
+#ifndef WORLD_BUILDER_FEATURES_UTILITIES_H
+#define WORLD_BUILDER_FEATURES_UTILITIES_H
 
 #include <limits>
 
@@ -70,8 +70,8 @@ namespace WorldBuilder
 
         return std::numeric_limits<double>::signaling_NaN();
       }
-    }
-  }
-}
+    } // namespace Utilities
+  } // namespace Features
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/grains.h
+++ b/include/world_builder/grains.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_grains_h
-#define _world_builder_grains_h
+#ifndef WORLD_BUILDER_GRAINS_H
+#define WORLD_BUILDER_GRAINS_H
 
 #include <array>
 #include <vector>
@@ -40,6 +40,6 @@ namespace WorldBuilder
     // todo: convention.
     std::vector<std::array<std::array<double,3>,3> > rotation_matrices;
   };
-}
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/nan.h
+++ b/include/world_builder/nan.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_nan_h
-#define _world_nan_h
+#ifndef WORLD_BUILDER_NAN_H
+#define WORLD_BUILDER_NAN_H
 
 #include <limits>
 
@@ -44,7 +44,7 @@ namespace WorldBuilder
      * A unsigned int signaling NaN
      */
     const unsigned int ISNAN = std::numeric_limits<unsigned int>::signaling_NaN();
-  }
-}
+  } // namespace NaN
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_parameters_h
-#define _world_builder_parameters_h
+#ifndef WORLD_BUILDER_PARAMETERS_H
+#define WORLD_BUILDER_PARAMETERS_H
 
 #include <map>
 #include <memory>
@@ -40,17 +40,17 @@ namespace WorldBuilder
     class Array;
     class Bool;
     class UnsignedInt;
-  }
+  } // namespace Types
 
   namespace Features
   {
     class Interface;
-  }
+  } // namespace Features
 
   namespace CoordinateSystems
   {
     class Interface;
-  }
+  } // namespace CoordinateSystems
 
   class World;
 
@@ -143,7 +143,7 @@ namespace WorldBuilder
        */
       template<class T>
       bool
-      get_shared_pointers(const std::string &name, std::vector<std::shared_ptr<T> > &);
+      get_shared_pointers(const std::string &name, std::vector<std::shared_ptr<T> > & /*vector*/);
 
       /**
        * Checks for the existance of an entry in the parameter file.
@@ -296,5 +296,5 @@ namespace WorldBuilder
        */
       std::string get_relative_path_without_arrays() const;
   };
-}
+} // namespace WorldBuilder
 #endif

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_point_h
-#define _world_builder_point_h
+#ifndef WORLD_BUILDER_POINT_H
+#define WORLD_BUILDER_POINT_H
 #define _USE_MATH_DEFINES
 #include <array>
 #include <cmath>
@@ -267,8 +267,7 @@ namespace WorldBuilder
 
       if (angle >= 0)
         return fast_sin_d(angle);
-      else
-        return -fast_sin_d(-angle);
+      return -fast_sin_d(-angle);
     }
 
     /**
@@ -278,7 +277,7 @@ namespace WorldBuilder
     {
       return FT::sin((const_pi*0.5)-angle);
     }
-  }
+  } // namespace FT
 
 
   template<int dim>
@@ -286,5 +285,5 @@ namespace WorldBuilder
 
   template<int dim>
   Point<dim> operator/(const double scalar, const Point<dim> &point);
-}
+} // namespace WorldBuilder
 #endif

--- a/include/world_builder/types/array.h
+++ b/include/world_builder/types/array.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_types_array_h
-#define _world_feature_types_array_h
+#ifndef WORLD_BUILDER_TYPES_ARRAY_H
+#define WORLD_BUILDER_TYPES_ARRAY_H
 
 
 #include "world_builder/types/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
     * by index, and a list holds the values strictly ordered, only accessible
     * an iterator. An other difference it that lists have a name.
      */
-    class Array : public Interface
+    class Array final: public Interface
     {
       public:
         /**
@@ -60,7 +60,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Array();
+        ~Array() override final;
 
         /**
          * Todo
@@ -113,7 +113,7 @@ namespace WorldBuilder
           return new Array(*this);
         };
     };
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/types/bool.h
+++ b/include/world_builder/types/bool.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_types_bool_h
-#define _world_feature_types_bool_h
+#ifndef WORLD_BUILDER_TYPES_BOOL_H
+#define WORLD_BUILDER_TYPES_BOOL_H
 
 
 #include "world_builder/types/interface.h"
@@ -34,7 +34,7 @@ namespace WorldBuilder
     /**
      * This class represents a bool value with documentation
      */
-    class Bool : public Interface
+    class Bool final: public Interface
     {
       public:
         /**
@@ -50,7 +50,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Bool();
+        ~Bool() override final;
 
 
         /**
@@ -71,7 +71,7 @@ namespace WorldBuilder
       private:
 
     };
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/types/double.h
+++ b/include/world_builder/types/double.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_types_double_h
-#define _world_feature_types_double_h
+#ifndef WORLD_BUILDER_TYPES_DOUBLE_H
+#define WORLD_BUILDER_TYPES_DOUBLE_H
 
 
 #include "world_builder/types/interface.h"
@@ -34,7 +34,7 @@ namespace WorldBuilder
     /**
      * This class represents a double value with documentation
      */
-    class Double : public Interface
+    class Double final: public Interface
     {
       public:
         /**
@@ -50,7 +50,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Double();
+        ~Double() override final;
 
         /**
          * Todo
@@ -70,7 +70,7 @@ namespace WorldBuilder
       private:
 
     };
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/types/interface.h
+++ b/include/world_builder/types/interface.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_types_interface_h
-#define _world_builder_types_interface_h
+#ifndef WORLD_BUILDER_TYPES_INTERFACE_H
+#define WORLD_BUILDER_TYPES_INTERFACE_H
 
 #include "rapidjson/pointer.h"
 
@@ -79,13 +79,13 @@ namespace WorldBuilder
 
 
       protected:
-        type type_name;
+        type type_name {type::None};
 
 
         virtual
         Interface *clone_impl() const = 0;
     };
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/types/object.h
+++ b/include/world_builder/types/object.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_types_object_h
-#define _world_feature_types_object_h
+#ifndef WORLD_BUILDER_TYPES_OBJECT_H
+#define WORLD_BUILDER_TYPES_OBJECT_H
 
 #include <vector>
 
@@ -41,7 +41,7 @@ namespace WorldBuilder
     * by index, and a list holds the values strictly ordered, only accessible
     * an iterator. An other difference it that lists have a name.
      */
-    class Object : public Interface
+    class Object final: public Interface
     {
       public:
         /**
@@ -58,7 +58,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Object();
+        ~Object() final;
 
         /**
          * Todo
@@ -81,7 +81,7 @@ namespace WorldBuilder
         };
 
     };
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/types/plugin_system.h
+++ b/include/world_builder/types/plugin_system.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_types_plugin_system_h
-#define _world_feature_types_plugin_system_h
+#ifndef WORLD_BUILDER_TYPES_PLUGIN_SYSTEM_H
+#define WORLD_BUILDER_TYPES_PLUGIN_SYSTEM_H
 
 
 #include "world_builder/features/interface.h"
@@ -35,7 +35,7 @@ namespace WorldBuilder
      * This class represents a plate tectonic feature class, such as the
      * continental plate class, oceanic plate class and subduction zone class.
      */
-    class PluginSystem : public Interface
+    class PluginSystem final: public Interface
     {
       public:
         /**
@@ -55,7 +55,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~PluginSystem();
+        ~PluginSystem() override final;
 
         /**
          * Todo
@@ -79,7 +79,7 @@ namespace WorldBuilder
       private:
 
     };
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/types/point.h
+++ b/include/world_builder/types/point.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_types_point_h
-#define _world_feature_types_point_h
+#ifndef WORLD_BUILDER_TYPES_POINT_H
+#define WORLD_BUILDER_TYPES_POINT_H
 
 
 #include "world_builder/point.h"
@@ -39,7 +39,7 @@ namespace WorldBuilder
      * functions of this class will be.
      */
     template <int dim>
-    class Point : public Interface
+    class Point final: public Interface
     {
       public:
 
@@ -66,7 +66,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Point();
+        ~Point() override final;
 
         /**
          * Todo
@@ -126,7 +126,7 @@ namespace WorldBuilder
 
     template<int dim>
     WorldBuilder::Point<dim> operator*(const double scalar, const Point<dim> &point);
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/types/segment.h
+++ b/include/world_builder/types/segment.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_types_segment_h
-#define _world_feature_types_segment_h
+#ifndef WORLD_BUILDER_TYPES_SEGMENT_H
+#define WORLD_BUILDER_TYPES_SEGMENT_H
 
 
 #include "world_builder/types/plugin_system.h"
@@ -65,7 +65,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Segment();
+        ~Segment() override;
 
         /**
          * Todo
@@ -94,7 +94,7 @@ namespace WorldBuilder
       private:
 
     };
-  }
+  } // namespace Types
 
   namespace Objects
   {
@@ -103,7 +103,7 @@ namespace WorldBuilder
       * This class represents an actual segment
       */
     template <class A, class B, class C>
-    class Segment : public Types::Interface
+    class Segment final: public Types::Interface
     {
       public:
 
@@ -114,9 +114,9 @@ namespace WorldBuilder
                 const WorldBuilder::Point<2> &default_thickness,
                 const WorldBuilder::Point<2> &default_top_truncation,
                 const WorldBuilder::Point<2> &default_angle,
-                const std::vector<std::shared_ptr<A> > &temperature_systems,
-                const std::vector<std::shared_ptr<B> > &composition_systems,
-                const std::vector<std::shared_ptr<C> > &grains_systems);
+                std::vector<std::shared_ptr<A> > temperature_systems,
+                std::vector<std::shared_ptr<B> > composition_systems,
+                std::vector<std::shared_ptr<C> > grains_systems);
 
         /**
          * Copy constructor
@@ -126,7 +126,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~Segment();
+        ~Segment() override final;
 
         /**
          * Todo
@@ -153,7 +153,7 @@ namespace WorldBuilder
       private:
 
     };
-  }
-}
+  } // namespace Objects
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/types/string.h
+++ b/include/world_builder/types/string.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_types_string_h
-#define _world_feature_types_string_h
+#ifndef WORLD_BUILDER_TYPES_STRING_H
+#define WORLD_BUILDER_TYPES_STRING_H
 
 #include <vector>
 
@@ -38,7 +38,7 @@ namespace WorldBuilder
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class String : public Interface
+    class String final: public Interface
     {
       public:
         /**
@@ -75,7 +75,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~String();
+        ~String() final;
 
         /**
          * Todo
@@ -97,7 +97,7 @@ namespace WorldBuilder
           return new String(*this);
         };
     };
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/types/unsigned_int.h
+++ b/include/world_builder/types/unsigned_int.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_feature_types_unsigned_int_h
-#define _world_feature_types_unsigned_int_h
+#ifndef WORLD_BUILDER_TYPES_UNSIGNED_INT_H
+#define WORLD_BUILDER_TYPES_UNSIGNED_INT_H
 
 
 #include "world_builder/types/interface.h"
@@ -34,7 +34,7 @@ namespace WorldBuilder
     /**
      * This class represents a bool value with documentation
      */
-    class UnsignedInt : public Interface
+    class UnsignedInt final: public Interface
     {
       public:
         /**
@@ -50,7 +50,7 @@ namespace WorldBuilder
         /**
          * Destructor
          */
-        ~UnsignedInt();
+        ~UnsignedInt() override final;
 
 
         /**
@@ -60,7 +60,7 @@ namespace WorldBuilder
                           const std::string &name,
                           const std::string &documentation) const override final;
 
-        unsigned int value;
+        unsigned int value {0};
         unsigned int default_value;
 
       protected:
@@ -74,7 +74,7 @@ namespace WorldBuilder
       private:
 
     };
-  }
-}
+  } // namespace Types
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_utilities_h
-#define _world_builder_utilities_h
+#ifndef WORLD_BUILDER_UTILITIES_H
+#define WORLD_BUILDER_UTILITIES_H
 
 
 #include "world_builder/coordinate_systems/interface.h"
@@ -30,7 +30,7 @@ namespace WorldBuilder
   namespace CoordinateSystems
   {
     class Interface;
-  }
+  } // namespace CoordinateSystems
   namespace Utilities
   {
 
@@ -163,7 +163,7 @@ namespace WorldBuilder
      * and returns the corresponding value.
      */
     CoordinateSystem
-    string_to_coordinate_system (const std::string &);
+    string_to_coordinate_system (const std::string & /*coordinate_system*/);
 
 
     /**
@@ -374,8 +374,8 @@ namespace WorldBuilder
      */
     std::array<std::array<double,3>,3>
     euler_angles_to_rotation_matrix(double phi1, double theta, double phi2);
-  }
-}
+  } // namespace Utilities
+} // namespace WorldBuilder
 
 
 #endif

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_world_h
-#define _world_builder_world_h
+#ifndef WORLD_BUILDER_WORLD_H
+#define WORLD_BUILDER_WORLD_H
 
 #include "world_builder/grains.h"
 #include "world_builder/parameters.h"
@@ -32,7 +32,7 @@ namespace WorldBuilder
   namespace Features
   {
     class Interface;
-  }
+  } // namespace Features
 
   class World
   {
@@ -207,6 +207,6 @@ namespace WorldBuilder
 
 
   };
-}
+} // namespace WorldBuilder
 
 #endif

--- a/include/world_builder/wrapper_c.h
+++ b/include/world_builder/wrapper_c.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_wrapper_c_h
-#define _world_builder_wrapper_c_h
+#ifndef WORLD_BUILDER_WRAPPER_C_H
+#define WORLD_BUILDER_WRAPPER_C_H
 
 #include <stdbool.h>
 

--- a/include/world_builder/wrapper_cpp.h
+++ b/include/world_builder/wrapper_cpp.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _world_builder_wrapper_cpp_h
-#define _world_builder_wrapper_cpp_h
+#ifndef WORLD_BUILDER_WRAPPER_CPP_H
+#define WORLD_BUILDER_WRAPPER_CPP_H
 
 #include <string>
 
@@ -73,5 +73,5 @@ namespace wrapper_cpp
 
 
   };
-}
+} // namespace wrapper_cpp
 #endif

--- a/source/types/interface.cc
+++ b/source/types/interface.cc
@@ -26,9 +26,9 @@ namespace WorldBuilder
   namespace Types
   {
     Interface::Interface()
-      :
-      type_name(type::None)
-    {}
+
+
+      = default;
 
     Interface::~Interface ()
       = default;

--- a/source/types/segment.cc
+++ b/source/types/segment.cc
@@ -16,6 +16,8 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+#include <utility>
+
 #include "world_builder/types/segment.h"
 
 
@@ -174,18 +176,18 @@ namespace WorldBuilder
                             const WorldBuilder::Point<2> &default_thickness_,
                             const WorldBuilder::Point<2> &default_top_truncation_,
                             const WorldBuilder::Point<2> &default_angle_,
-                            const std::vector<std::shared_ptr<A> > &temperature_systems_,
-                            const std::vector<std::shared_ptr<B> > &composition_systems_,
-                            const std::vector<std::shared_ptr<C> > &grains_systems_)
+                            const std::vector<std::shared_ptr<A> > temperature_systems_,
+                            const std::vector<std::shared_ptr<B> > composition_systems_,
+                            const std::vector<std::shared_ptr<C> > grains_systems_)
       :
       value_length(default_length_),
       default_length(default_length_),
       value_thickness(default_thickness_),
       value_top_truncation(default_top_truncation_),
       value_angle(default_angle_),
-      temperature_systems(temperature_systems_),
-      composition_systems(composition_systems_),
-      grains_systems(grains_systems_)
+      temperature_systems(std::move(temperature_systems_)),
+      composition_systems(std::move(composition_systems_)),
+      grains_systems(std::move(grains_systems_))
     {
       this->type_name = Types::type::Segment;
 

--- a/source/types/unsigned_int.cc
+++ b/source/types/unsigned_int.cc
@@ -26,7 +26,7 @@ namespace WorldBuilder
   {
     UnsignedInt::UnsignedInt(unsigned int default_value_)
       :
-      value(0),
+
       default_value(default_value_)
     {
       this->type_name = Types::type::UnsignedInt;

--- a/tests/catch2.h
+++ b/tests/catch2.h
@@ -5517,7 +5517,7 @@ namespace Catch
 
     public:
     // !TBD We need to do this another way!
-    bool aborting() const final;
+    bool aborting() const override final;
 
     private:
 


### PR DESCRIPTION
This pull request changes two things: 

1. remove `readability-avoid-const-params-in-decls` from the list, because I think that actually decrease readability, and 
2. Apply fixes from warnings when clang-tidy is applied to the world builder headers. This includes the manual fixes to make functions final.