### PR TITLE
precompute natural coodinates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - The World Builder Visualizer will now use zlib compression for vtu files by default. If zlib is not available binary output will be used. \[Menno Fraters; 2021-06-26; [#282](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/282)\]
 - The return argument type of the distance_point_from_curved_planes function has been converted from a map to a struct, requiring a change in the plugin interfaces for 'fault_models' and 'subducting_plate_models', but significantly increasing the speed of the function and all functions that access its returned values. \[Rene Gassmoeller; 2021-06-27; [#289](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/289)\]
+- The plugin systems (temperature, composition and grains) and the distance_point_from_curved_planes function now all pass a precomputed NaturalCoordinate, besides just the cartesian position. It turns out that this can make a significant performance differce. \[Issue found and solution suggested by Wolfgang Bangerth, implemented and tested by Menno Fraters; 2021-07-03; [#300](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/300) and [#219](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/219)\]
 
 ## [0.4.0]
 ### Added

--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -85,6 +85,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -96,6 +97,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const unsigned int composition_number,
                            double composition) const override final;
@@ -109,6 +111,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
+               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -87,6 +87,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -98,6 +99,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const unsigned int composition_number,
                            double composition_value) const override final;
@@ -111,6 +113,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
+               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -87,6 +87,7 @@ namespace WorldBuilder
          */
         virtual
         double temperature(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const double gravity,
                            double temperature) const = 0;
@@ -96,6 +97,7 @@ namespace WorldBuilder
          */
         virtual
         double composition(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const unsigned int composition_number,
                            double value) const = 0;
@@ -106,6 +108,7 @@ namespace WorldBuilder
          */
         virtual
         WorldBuilder::grains grains(const Point<3> &position,
+                                    const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                                     const double depth,
                                     const unsigned int composition_number,
                                     WorldBuilder::grains value) const = 0;

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -86,6 +86,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -98,6 +99,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const unsigned int composition_number,
                            double composition) const override final;
@@ -112,6 +114,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
+               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -86,6 +86,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -98,6 +99,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const unsigned int composition_number,
                            double composition) const override final;
@@ -112,6 +114,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
+               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -89,6 +89,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -101,6 +102,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                            const double depth,
                            const unsigned int composition_number,
                            double composition_value) const override final;
@@ -114,6 +116,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
+               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -89,7 +89,7 @@ namespace WorldBuilder
          * Returns the coordinates in the given coordinate system, which may
          * not be Cartesian.
          */
-        const std::array<double,3> &get_coordinates();
+        const std::array<double,3> &get_coordinates() const;
 
         /**
          * The coordinate that represents the 'surface' directions in the
@@ -299,8 +299,10 @@ namespace WorldBuilder
     /**
      * Computes the distance of a point to a curved plane.
      * TODO: add more info on how this works/is implemented.
-     * \param point This is the cartesian point of which we want to know the
+     * \param check_point This is the cartesian point of which we want to know the
      * distance to the curved planes
+     * \param check_point_natural the check_point in the natural coordinates of the
+     * current coordinate system.
      * \param reference_point This is a 2d point in natural coordinates at the
      * surface which the curved planes dip towards. Natural coordinates are in
      * cartesian (x,y,z) in meters and in spherical radius in meters and longitude
@@ -342,7 +344,8 @@ namespace WorldBuilder
      * of the point from the plane and the distance of the point along the plane,
      * and the average angle of the closest segment/section.
      */
-    PointDistanceFromCurvedPlanes distance_point_from_curved_planes(const Point<3> &point,
+    PointDistanceFromCurvedPlanes distance_point_from_curved_planes(const Point<3> &check_point,
+                                                                    const NaturalCoordinate &check_point_natural,
                                                                     const Point<2> &reference_point,
                                                                     const std::vector<Point<2> > &point_list,
                                                                     const std::vector<std::vector<double> > &plane_segment_lengths,

--- a/source/features/continental_plate.cc
+++ b/source/features/continental_plate.cc
@@ -135,12 +135,11 @@ namespace WorldBuilder
 
     double
     ContinentalPlate::temperature(const Point<3> &position,
+                                  const  NaturalCoordinate &natural_coordinate,
                                   const double depth,
                                   const double gravity_norm,
                                   double temperature) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
       if (depth <= max_depth && depth >= min_depth &&
           Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                   world->parameters.coordinate_system->natural_coordinate_system())))
@@ -167,12 +166,11 @@ namespace WorldBuilder
 
     double
     ContinentalPlate::composition(const Point<3> &position,
+                                  const  NaturalCoordinate &natural_coordinate,
                                   const double depth,
                                   const unsigned int composition_number,
                                   double composition) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
 
       if (depth <= max_depth && depth >= min_depth &&
           Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
@@ -200,12 +198,11 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     ContinentalPlate::grains(const Point<3> &position,
+                             const  NaturalCoordinate &natural_coordinate,
                              const double depth,
                              const unsigned int composition_number,
                              WorldBuilder::grains grains) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
 
       if (depth <= max_depth && depth >= min_depth &&
           Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -329,13 +329,11 @@ namespace WorldBuilder
 
     double
     Fault::temperature(const Point<3> &position,
+                       const  NaturalCoordinate &natural_coordinate,
                        const double depth,
                        const double gravity_norm,
                        double temperature) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
-
       // The depth variable is the distance from the surface to the position, the depth
       // coordinate is the distance from the bottom of the model to the position and
       // the starting radius is the distance from the bottom of the model to the surface.
@@ -470,12 +468,11 @@ namespace WorldBuilder
 
     double
     Fault::composition(const Point<3> &position,
+                       const  NaturalCoordinate &natural_coordinate,
                        const double depth,
                        const unsigned int composition_number,
                        double composition) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
       // todo: explain
       const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
 
@@ -604,12 +601,11 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     Fault::grains(const Point<3> &position,
+                  const  NaturalCoordinate &natural_coordinate,
                   const double depth,
                   const unsigned int composition_number,
                   WorldBuilder::grains grains) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
       // todo: explain
       const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
 

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -354,6 +354,7 @@ namespace WorldBuilder
           // the fault to be centered around the line provided by the user.
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       natural_coordinate,
                                                                        reference_point,
                                                                        coordinates,
                                                                        fault_segment_lengths,
@@ -484,6 +485,7 @@ namespace WorldBuilder
           // the fault to be centered around the line provided by the user.
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       natural_coordinate,
                                                                        reference_point,
                                                                        coordinates,
                                                                        fault_segment_lengths,
@@ -617,6 +619,7 @@ namespace WorldBuilder
           // the fault to be centered around the line provided by the user.
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       natural_coordinate,
                                                                        reference_point,
                                                                        coordinates,
                                                                        fault_segment_lengths,

--- a/source/features/mantle_layer.cc
+++ b/source/features/mantle_layer.cc
@@ -128,13 +128,11 @@ namespace WorldBuilder
 
     double
     MantleLayer::temperature(const Point<3> &position,
+                             const  NaturalCoordinate &natural_coordinate,
                              const double depth,
                              const double gravity_norm,
                              double temperature) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
-
       if (depth <= max_depth && depth >= min_depth &&
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
@@ -161,13 +159,11 @@ namespace WorldBuilder
 
     double
     MantleLayer::composition(const Point<3> &position,
+                             const  NaturalCoordinate &natural_coordinate,
                              const double depth,
                              const unsigned int composition_number,
                              double composition) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
-
       if (depth <= max_depth && depth >= min_depth &&
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
@@ -196,13 +192,11 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     MantleLayer::grains(const Point<3> &position,
+                        const  NaturalCoordinate &natural_coordinate,
                         const double depth,
                         const unsigned int composition_number,
                         WorldBuilder::grains grains) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
-
       if (depth <= max_depth && depth >= min_depth &&
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))

--- a/source/features/oceanic_plate.cc
+++ b/source/features/oceanic_plate.cc
@@ -132,14 +132,11 @@ namespace WorldBuilder
 
     double
     OceanicPlate::temperature(const Point<3> &position,
+                              const  NaturalCoordinate &natural_coordinate,
                               const double depth,
                               const double gravity_norm,
                               double temperature) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
-
-
       if (depth <= max_depth && depth >= min_depth &&
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
@@ -166,13 +163,11 @@ namespace WorldBuilder
 
     double
     OceanicPlate::composition(const Point<3> &position,
+                              const  NaturalCoordinate &natural_coordinate,
                               const double depth,
                               const unsigned int composition_number,
                               double composition) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
-
       if (depth <= max_depth && depth >= min_depth &&
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
@@ -199,13 +194,11 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     OceanicPlate::grains(const Point<3> &position,
+                         const NaturalCoordinate &natural_coordinate,
                          const double depth,
                          const unsigned int composition_number,
                          WorldBuilder::grains grains) const
     {
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
-
       if (depth <= max_depth && depth >= min_depth &&
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -333,16 +333,11 @@ namespace WorldBuilder
 
     double
     SubductingPlate::temperature(const Point<3> &position,
+                                 const  NaturalCoordinate &natural_coordinate,
                                  const double depth,
                                  const double gravity_norm,
                                  double temperature) const
     {
-
-
-
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
-
       // The depth variable is the distance from the surface to the position, the depth
       // coordinate is the distance from the bottom of the model to the position and
       // the starting radius is the distance from the bottom of the model to the surface.
@@ -483,13 +478,11 @@ namespace WorldBuilder
 
     double
     SubductingPlate::composition(const Point<3> &position,
+                                 const  NaturalCoordinate &natural_coordinate,
                                  const double depth,
                                  const unsigned int composition_number,
                                  double composition) const
     {
-
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
       // todo: explain
       const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
 
@@ -615,13 +608,11 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     SubductingPlate::grains(const Point<3> &position,
+                            const  NaturalCoordinate &natural_coordinate,
                             const double depth,
                             const unsigned int composition_number,
                             WorldBuilder::grains grains) const
     {
-
-      WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                      *(world->parameters.coordinate_system));
       // todo: explain
       const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
 

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -365,6 +365,7 @@ namespace WorldBuilder
           // todo: explain
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       natural_coordinate,
                                                                        reference_point,
                                                                        coordinates,
                                                                        slab_segment_lengths,
@@ -492,6 +493,7 @@ namespace WorldBuilder
           // todo: explain
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       natural_coordinate,
                                                                        reference_point,
                                                                        coordinates,
                                                                        slab_segment_lengths,
@@ -622,6 +624,7 @@ namespace WorldBuilder
           // todo: explain
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
+                                                                       natural_coordinate,
                                                                        reference_point,
                                                                        coordinates,
                                                                        slab_segment_lengths,

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -222,7 +222,7 @@ namespace WorldBuilder
       coordinates = coordinate_system_.cartesian_to_natural_coordinates(position.get_array());
     }
 
-    const std::array<double,3> &NaturalCoordinate::get_coordinates()
+    const std::array<double,3> &NaturalCoordinate::get_coordinates() const
     {
       return coordinates;
     }
@@ -428,7 +428,8 @@ namespace WorldBuilder
     }
 
     PointDistanceFromCurvedPlanes
-    distance_point_from_curved_planes(const Point<3> &check_point, // cartesian point in spherical system
+    distance_point_from_curved_planes(const Point<3> &check_point, // cartesian point in cartesian and spherical system
+                                      const NaturalCoordinate &natural_coordinate, // cartesian point cartesian system, spherical point in spherical system
                                       const Point<2> &reference_point, // in (rad) spherical coordinates in spherical system
                                       const std::vector<Point<2> > &point_list, // in  (rad) spherical coordinates in spherical system
                                       const std::vector<std::vector<double> > &plane_segment_lengths,
@@ -470,13 +471,12 @@ namespace WorldBuilder
       const CoordinateSystem natural_coordinate_system = coordinate_system->natural_coordinate_system();
       const bool bool_cartesian = natural_coordinate_system == cartesian;
 
-      const Point<3> check_point_natural(coordinate_system->cartesian_to_natural_coordinates(check_point.get_array()),natural_coordinate_system);
-      const Point<3> check_point_surface(bool_cartesian ? check_point_natural[0] : start_radius,
-                                         check_point_natural[1],
-                                         bool_cartesian ? start_radius           : check_point_natural[2],
+      const std::array<double,3> &check_point_surface_2d_array = natural_coordinate.get_coordinates();
+      const Point<3> check_point_surface(bool_cartesian ? check_point_surface_2d_array[0] : start_radius,
+                                         check_point_surface_2d_array[1],
+                                         bool_cartesian ? start_radius : check_point_surface_2d_array[2],
                                          natural_coordinate_system);
-      const Point<2> check_point_surface_2d(bool_cartesian ? check_point_natural[0] : check_point_natural[1],
-                                            bool_cartesian ? check_point_natural[1] : check_point_natural[2],
+      const Point<2> check_point_surface_2d(natural_coordinate.get_surface_coordinates(),
                                             natural_coordinate_system);
 
       // The section which is checked.

--- a/source/world.cc
+++ b/source/world.cc
@@ -272,9 +272,11 @@ namespace WorldBuilder
                                    specific_heat) * depth);
 
 
+    WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(point,
+                                                                    *(this->parameters.coordinate_system));
     for (auto &&it : parameters.features)
       {
-        temperature = it->temperature(point,depth,gravity_norm,temperature);
+        temperature = it->temperature(point,natural_coordinate,depth,gravity_norm,temperature);
 
         WBAssert(!std::isnan(temperature), "Temparture is not a number: " << temperature
                  << ", based on a feature with the name " << it->get_name());
@@ -333,10 +335,13 @@ namespace WorldBuilder
   {
     // We receive the cartesian points from the user.
     Point<3> point(point_,cartesian);
+
+    WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(point,
+                                                                    *(this->parameters.coordinate_system));
     double composition = 0;
     for (auto &&it : parameters.features)
       {
-        composition = it->composition(point,depth,composition_number, composition);
+        composition = it->composition(point,natural_coordinate,depth,composition_number, composition);
 
         WBAssert(!std::isnan(composition), "Composition is not a number: " << composition
                  << ", based on a feature with the name " << it->get_name());
@@ -400,12 +405,14 @@ namespace WorldBuilder
   {
     // We receive the cartesian points from the user.
     Point<3> point(point_,cartesian);
+    WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(point,
+                                                                    *(this->parameters.coordinate_system));
     WorldBuilder::grains grains;
     grains.sizes.resize(number_of_grains,0);
     grains.rotation_matrices.resize(number_of_grains);
     for (const auto &feature : parameters.features)
       {
-        grains = feature->grains(point,depth,composition_number, grains);
+        grains = feature->grains(point,natural_coordinate,depth,composition_number, grains);
 
         /*WBAssert(!std::isnan(composition), "Composition is not a number: " << composition
                  << ", based on a feature with the name " << (*it)->get_name());

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -4638,6 +4638,9 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   //cartesian_system->declare_entries();
 
   Point<3> position(10,0,0,cartesian);
+
+  WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   Point<2> reference_point(0,0,cartesian);
 
   std::vector<Point<2> > coordinates;
@@ -4664,6 +4667,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4688,6 +4692,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4708,9 +4713,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   // center square test 3
   position[1] = 20;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4734,6 +4741,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4755,9 +4763,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   // center square test 5
   position[1] = -10;
   position[2] = -10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4778,9 +4788,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   // begin section square test 6
   position[0] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4802,9 +4814,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   // end section square test 7
   position[0] = 20;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4825,9 +4839,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   // before begin section square test 8
   position[0] = -10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4848,9 +4864,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   // beyond end section square test 9
   position[0] = 25;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4874,9 +4892,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 5;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4899,9 +4919,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 5;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4925,9 +4947,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = -5;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4951,9 +4975,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = -5;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -4976,7 +5002,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 25;
   position[1] = 0;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   coordinates.emplace_back(30,10,cartesian);
 
   slab_segment_lengths.resize(3);
@@ -4989,6 +5016,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5020,9 +5048,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 10-10*tan(22.5*dtr);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5045,9 +5075,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 25;
   position[1] = 0;
   position[2] = 10-10*tan((22.5*1.5)*dtr);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5070,9 +5102,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 30;
   position[1] = 0;
   position[2] = 10-10*tan(45*dtr);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5116,9 +5150,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = 10-100;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5141,9 +5177,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = 10-101;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5166,9 +5204,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = 10-200;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5193,9 +5233,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = 10-201;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5220,9 +5262,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 25;
   position[1] = 10;
   position[2] = 10-75;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5245,9 +5289,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 25;
   position[1] = 10;
   position[2] = 10-76;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5270,9 +5316,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 25;
   position[1] = 10;
   position[2] = 10-150;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5297,9 +5345,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 25;
   position[1] = 10;
   position[2] = 10-151;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5323,9 +5373,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 30;
   position[1] = 10;
   position[2] = 10-50;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5348,9 +5400,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 30;
   position[1] = 10;
   position[2] = 10-51;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5373,9 +5427,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 30;
   position[1] = 10;
   position[2] = 10-100;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5400,9 +5456,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 30;
   position[1] = 10;
   position[2] = 10-101;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5430,6 +5488,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   //cartesian_system->declare_entries();
 
   Point<3> position(10,0,0,cartesian);
+  WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   Point<2> reference_point(0,0,cartesian);
 
   std::vector<Point<2> > coordinates;
@@ -5482,13 +5542,15 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   Utilities::interpolation x_spline;
   Utilities::interpolation y_spline;
   Utilities::InterpolationType interpolation_type = Utilities::InterpolationType::None;
 
   WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5511,9 +5573,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 5;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5536,9 +5600,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = -5;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5562,9 +5628,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10 - 10 * sqrt(2)/2;
   position[2] = 10 * sqrt(2)/2;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5587,9 +5655,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10 - 10 * sqrt(2);
   position[2] = 10 * sqrt(2);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5612,9 +5682,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5642,9 +5714,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = -5;
   position[2] = -1;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5672,9 +5746,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 5;
   position[2] = 5;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5697,9 +5773,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10 - 5 * sqrt(2)/2;
   position[2] = 5 + 5 * sqrt(2)/2;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5737,9 +5815,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5762,9 +5842,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10 - 10 * sqrt(2)/2;
   position[2] = 10 * sqrt(2)/2;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5787,9 +5869,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10 - 10 * sqrt(2)/2;
   position[2] = -10 * sqrt(2)/2;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5813,9 +5897,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = -10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5852,9 +5938,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5877,9 +5965,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = -10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5902,9 +5992,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = -11;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5927,9 +6019,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = -9;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5952,9 +6046,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 20;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -5978,9 +6074,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 21;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6003,9 +6101,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 19;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6043,9 +6143,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6068,9 +6170,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = -10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6093,9 +6197,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 20;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6118,9 +6224,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10 + 1e-14 + 10 * sqrt(2)/2; // somehow it doesn't get the exact value here, so adding an epsiolon of 1e-14.
   position[2] = 10 * sqrt(2)/2;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6160,9 +6268,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6188,9 +6298,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6214,9 +6326,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6257,9 +6371,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6299,9 +6415,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 0;
   position[2] = 0;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6324,9 +6442,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = -10;
   position[2] = -10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6349,9 +6469,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10 - (20 - 10 * sqrt(2)/2);
   position[2] = -10 * sqrt(2)/2;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6376,9 +6498,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   double angle = 180+0.1;
   position[1] = 10 - (20 * std::cos(0 * Utilities::const_pi/180) + 10 * std::cos((angle) * Utilities::const_pi/180));
   position[2] = 0 * std::cos(0 * Utilities::const_pi/180) + 10 * std::sin((angle) * Utilities::const_pi/180);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6402,9 +6526,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10 - (20 - 10 * std::cos(0.001 * Utilities::const_pi/180));
   position[2] = - 10 * std::sin(0.001 * Utilities::const_pi/180);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6441,9 +6567,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10 - 10 * std::cos(45.000 * Utilities::const_pi/180);
   position[2] = 10 * std::sin(45.000 * Utilities::const_pi/180);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6467,9 +6595,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   angle = 45;
   position[1] = 10 - (10 * std::cos((angle) * Utilities::const_pi/180));
   position[2] = 10 * std::sin((angle) * Utilities::const_pi/180);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6493,9 +6623,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   angle = 180+45;
   position[1] = 10 - (20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::cos((angle) * Utilities::const_pi/180));
   position[2] = 20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::sin((angle) * Utilities::const_pi/180);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6520,9 +6652,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   angle = 180+46;
   position[1] = 10 - (20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::cos((angle) * Utilities::const_pi/180));
   position[2] = 20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::sin((angle) * Utilities::const_pi/180);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6548,9 +6682,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   angle = 180+46;
   position[1] = 10 - (20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::cos((angle) * Utilities::const_pi/180))+0.1;
   position[2] = 20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::sin((angle) * Utilities::const_pi/180);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6574,9 +6710,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   angle = 180+46;
   position[1] = 10 - (20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::cos((angle) * Utilities::const_pi/180))-0.1;
   position[2] = 20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::sin((angle) * Utilities::const_pi/180);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6600,9 +6738,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   angle = 180+90;
   position[1] = 10 - (20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::cos((angle) * Utilities::const_pi/180));
   position[2] = 20 * std::cos(45 * Utilities::const_pi/180) + 10 * std::sin((angle) * Utilities::const_pi/180);
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6627,9 +6767,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = 10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6653,9 +6795,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 10;
   position[1] = 10;
   position[2] = 10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6679,9 +6823,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 15;
   position[1] = 10;
   position[2] = 10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6705,9 +6851,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 20;
   position[1] = 10;
   position[2] = 10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6731,8 +6879,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 25;
   position[1] = 10;
   position[2] = 10;
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6758,9 +6909,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   position[0] = 30;
   position[1] = 10;
   position[2] = 10;
-
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *cartesian_system);
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6797,6 +6950,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   Point<3> position(10,0 * dtr,10 * dtr,spherical);
   position = Point<3>(world.parameters.coordinate_system->natural_to_cartesian_coordinates(position.get_array()),cartesian);
 
+  WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *(world.parameters.coordinate_system));
   Point<2> reference_point(0,0,spherical);
 
   std::vector<Point<2> > coordinates;
@@ -6823,6 +6978,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
 
   WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6846,8 +7002,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   position = Point<3>(10,10 * dtr,10 * dtr,spherical);
   position = Point<3>(world.parameters.coordinate_system->natural_to_cartesian_coordinates(position.get_array()),cartesian);
 
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *(world.parameters.coordinate_system));
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6875,8 +7034,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   position = Point<3>(10,0 * dtr,45 * dtr,spherical);
   position = Point<3>(world.parameters.coordinate_system->natural_to_cartesian_coordinates(position.get_array()),cartesian);
 
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *(world.parameters.coordinate_system));
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6899,8 +7061,11 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
 // spherical test 3
   position = Point<3>(5,0 * dtr,45 * dtr,spherical);
   position = Point<3>(world.parameters.coordinate_system->natural_to_cartesian_coordinates(position.get_array()),cartesian);
+  natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                  *(world.parameters.coordinate_system));
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6936,6 +7101,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
 
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6961,6 +7127,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
 
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,
@@ -6998,6 +7165,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
 
   distance_from_planes =
     Utilities::distance_point_from_curved_planes(position,
+                                                 natural_coordinate,
                                                  reference_point,
                                                  coordinates,
                                                  slab_segment_lengths,


### PR DESCRIPTION
Found in #219. Moves the computation of the natural coordinates outside the feature loop and pass it as a reference. This will also contain a commit later to pass the natural coordinates by reference to the distance from curved planes function.

Although it currently looks kinda inconsistent to have a value called point and one called natural_coordinate, I don't think it is a good idea to make them consistent in this pull request, and focus here on the functional change. 

edit: although I am open to changing the names in a last seperate commit here or in a new pull request.