### PR TITLE
WIP: Remove non contiuous option from distance point from curved planes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,10 @@ if (NOT MSVC AND NOT APPLE)
           SET(WB_COMPILER_OPTIONS_PRIVATE ${WB_COMPILER_OPTIONS_PRIVATE} $<$<COMPILE_LANGUAGE:CXX>:-Wno-placement-new>)
         endif()
 
+        IF ( CMAKE_BUILD_TYPE STREQUAL Release )
+          SET(WB_COMPILER_OPTIONS_PRIVATE ${WB_COMPILER_OPTIONS_PRIVATE} $<$<COMPILE_LANGUAGE:CXX>:-march=native -ffast-math>)
+        endif()
+
         # untill 4.9.0 Wshadow is too strict: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57709,
         # but still some issues in 4.9.0, so only add it after 5.0.0.
         if(CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0.0)

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -260,7 +260,10 @@ namespace WorldBuilder
        * function without asin and sqrt is returned.
        */
       double
-      cheap_relative_distance(const Point<dim> &two) const;
+      cheap_relative_distance_spherical(const Point<dim> &two) const;
+
+      double
+      cheap_relative_distance_cartesian(const Point<dim> &two) const;
 
       /**
        * return the internal array which stores the point data.

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -369,10 +369,10 @@ namespace WorldBuilder
      */
     inline double fast_sin_d(const double angle)
     {
-        WBAssert(angle >= 0 && angle <= const_pi, 
-        "You are tring to use the fast sin function in an invalid range. "
-        "The fast sin function can only be used for values between 0 and pi. "
-        "The provided angle is " << angle);
+      WBAssert(angle >= 0 && angle <= const_pi,
+               "You are tring to use the fast sin function in an invalid range. "
+               "The fast sin function can only be used for values between 0 and pi. "
+               "The provided angle is " << angle);
       constexpr double A = 4.0/(const_pi *const_pi);
       constexpr double oneminPmin = 1.-0.1952403377008734-0.01915214119105392;
 
@@ -385,36 +385,36 @@ namespace WorldBuilder
      * Implemented by calling fast_sin_d with a mirrored x if needed to
      * forfill the constrained of fast_sin_d to only have values between
      * zero and pi.
-     * 
+     *
      * new: only valid between -180 and 180 degrees
      */
     inline double sin(const double angle)
     {
-      WBAssert(angle >= -const_pi && angle <= const_pi, 
-        "You are tring to use the fast sin function in an invalid range. "
-        "The fast sin function can only be used for values between -pi and pi. "
-        "The provided angle is " << angle);
+      WBAssert(angle >= -const_pi && angle <= const_pi,
+               "You are tring to use the fast sin function in an invalid range. "
+               "The fast sin function can only be used for values between -pi and pi. "
+               "The provided angle is " << angle);
       //const double angle = (raw_angle > -const_pi && raw_angle < const_pi)
       //                     ?
       //                     raw_angle
       //                     :
       //                     FT::fmod(raw_angle + std::copysign(const_pi,raw_angle), const_pi * 2.0) - std::copysign(const_pi,raw_angle);
-      if(angle >= 0.)
+      if (angle >= 0.)
         return fast_sin_d(angle);
       return -fast_sin_d(-angle);
     }
 
     /**
      * Fast but less accurate cos function for any angle.
-     * 
+     *
      * new: only valid between -90 and 270 degrees
      */
     inline double cos(const double angle)
-    {      
-      WBAssert(angle >= -0.5*const_pi && angle <= 1.5*const_pi, 
-        "You are tring to use the fast cos function in an invalid range. "
-        "The fast sin function can only be used for values between -pi and pi. "
-        "The provided angle is " << angle);
+    {
+      WBAssert(angle >= -0.5*const_pi && angle <= 1.5*const_pi,
+               "You are tring to use the fast cos function in an invalid range. "
+               "The fast sin function can only be used for values between -pi and pi. "
+               "The provided angle is " << angle);
 
       return FT::sin((const_pi*0.5)-angle);
     }

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -373,7 +373,7 @@ namespace WorldBuilder
     inline double fast_sin_d(const double angle)
     {
       WBAssert(angle >= 0 && angle <= const_pi,
-               "You are tring to use the fast sin function in an invalid range. "
+               "You are trying to use the fast sin function in an invalid range. "
                "The fast sin function can only be used for values between 0 and pi. "
                "The provided angle is " << angle);
       constexpr double A = 4.0/(const_pi *const_pi);
@@ -394,7 +394,7 @@ namespace WorldBuilder
     inline double sin(const double angle)
     {
       WBAssert(angle >= -const_pi && angle <= const_pi,
-               "You are tring to use the fast sin function in an invalid range. "
+               "You are trying to use the fast sin function in an invalid range. "
                "The fast sin function can only be used for values between -pi and pi. "
                "The provided angle is " << angle);
       //const double angle = (raw_angle > -const_pi && raw_angle < const_pi)
@@ -415,7 +415,7 @@ namespace WorldBuilder
     inline double cos(const double angle)
     {
       WBAssert(angle >= -0.5*const_pi && angle <= 1.5*const_pi,
-               "You are tring to use the fast cos function in an invalid range. "
+               "You are trying to use the fast cos function in an invalid range. "
                "The fast sin function can only be used for values between -pi and pi. "
                "The provided angle is " << angle);
 

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -369,6 +369,10 @@ namespace WorldBuilder
      */
     inline double fast_sin_d(const double angle)
     {
+        WBAssert(angle >= 0 && angle <= const_pi, 
+        "You are tring to use the fast sin function in an invalid range. "
+        "The fast sin function can only be used for values between 0 and pi. "
+        "The provided angle is " << angle);
       constexpr double A = 4.0/(const_pi *const_pi);
       constexpr double oneminPmin = 1.-0.1952403377008734-0.01915214119105392;
 
@@ -381,25 +385,37 @@ namespace WorldBuilder
      * Implemented by calling fast_sin_d with a mirrored x if needed to
      * forfill the constrained of fast_sin_d to only have values between
      * zero and pi.
+     * 
+     * new: only valid between -180 and 180 degrees
      */
-    inline double sin(const double raw_angle)
+    inline double sin(const double angle)
     {
-      const double angle = (raw_angle > -const_pi && raw_angle < const_pi)
-                           ?
-                           raw_angle
-                           :
-                           FT::fmod(raw_angle + std::copysign(const_pi,raw_angle), const_pi * 2.0) - std::copysign(const_pi,raw_angle);
-
-      if (angle >= 0)
+      WBAssert(angle >= -const_pi && angle <= const_pi, 
+        "You are tring to use the fast sin function in an invalid range. "
+        "The fast sin function can only be used for values between -pi and pi. "
+        "The provided angle is " << angle);
+      //const double angle = (raw_angle > -const_pi && raw_angle < const_pi)
+      //                     ?
+      //                     raw_angle
+      //                     :
+      //                     FT::fmod(raw_angle + std::copysign(const_pi,raw_angle), const_pi * 2.0) - std::copysign(const_pi,raw_angle);
+      if(angle >= 0.)
         return fast_sin_d(angle);
       return -fast_sin_d(-angle);
     }
 
     /**
      * Fast but less accurate cos function for any angle.
+     * 
+     * new: only valid between -90 and 270 degrees
      */
     inline double cos(const double angle)
-    {
+    {      
+      WBAssert(angle >= -0.5*const_pi && angle <= 1.5*const_pi, 
+        "You are tring to use the fast cos function in an invalid range. "
+        "The fast sin function can only be used for values between -pi and pi. "
+        "The provided angle is " << angle);
+
       return FT::sin((const_pi*0.5)-angle);
     }
   } // namespace FT

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -234,7 +234,8 @@ namespace WorldBuilder
         /**
          * x coordinates of points
          */
-        std::vector<double> m_x;
+        //std::vector<double> m_x;
+        size_t mx_size_min;
 
         /**
          * interpolation parameters

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -237,10 +237,9 @@ namespace WorldBuilder
         }
 
         inline
-        double operator() (const double x,const size_t idx) const
+        double operator() (const double x,const size_t idx,const double h) const
         {
-          const double h = x-idx;
-          return (((x >= 0 && x <= mx_size_min ? m_a[idx]*h : 0) + m_b[idx])*h + m_c[idx])*h + m_y[idx];
+          return ((m_a[idx]*h + m_b[idx])*h + m_c[idx])*h + m_y[idx];
         }
 
       private:

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -228,7 +228,13 @@ namespace WorldBuilder
         /**
          * Evaluate at point @p x.
          */
-        double operator() (const double x) const;
+        inline
+        double operator() (const double x) const
+    {
+      const size_t idx = std::min((size_t)std::max( (int)x, (int)0),mx_size_min);
+      const double h = x-idx;
+      return (((x >= 0 && x <= mx_size_min ? m_a[idx]*h : 0) + m_b[idx])*h + m_c[idx])*h + m_y[idx];
+    }
 
       private:
         /**

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -368,7 +368,8 @@ namespace WorldBuilder
                                                                     const bool only_positive,
                                                                     const InterpolationType interpolation_type,
                                                                     const interpolation &x_spline,
-                                                                    const interpolation &y_spline);
+                                                                    const interpolation &y_spline,
+                                                                    const double max_surface_distance);
 
 
 

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -230,11 +230,11 @@ namespace WorldBuilder
          */
         inline
         double operator() (const double x) const
-    {
-      const size_t idx = std::min((size_t)std::max( (int)x, (int)0),mx_size_min);
-      const double h = x-idx;
-      return (((x >= 0 && x <= mx_size_min ? m_a[idx]*h : 0) + m_b[idx])*h + m_c[idx])*h + m_y[idx];
-    }
+        {
+          const size_t idx = std::min((size_t)std::max( (int)x, (int)0),mx_size_min);
+          const double h = x-idx;
+          return (((x >= 0 && x <= mx_size_min ? m_a[idx]*h : 0) + m_b[idx])*h + m_c[idx])*h + m_y[idx];
+        }
 
       private:
         /**

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -369,7 +369,7 @@ namespace WorldBuilder
                                                                     const InterpolationType interpolation_type,
                                                                     const interpolation &x_spline,
                                                                     const interpolation &y_spline,
-                                                                    const double max_surface_distance);
+                                                                    const double max_surface_distance = INFINITY);
 
 
 

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -236,6 +236,13 @@ namespace WorldBuilder
           return (((x >= 0 && x <= mx_size_min ? m_a[idx]*h : 0) + m_b[idx])*h + m_c[idx])*h + m_y[idx];
         }
 
+        inline
+        double operator() (const double x,const size_t idx) const
+        {
+          const double h = x-idx;
+          return (((x >= 0 && x <= mx_size_min ? m_a[idx]*h : 0) + m_b[idx])*h + m_c[idx])*h + m_y[idx];
+        }
+
       private:
         /**
          * x coordinates of points

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -356,8 +356,7 @@ namespace WorldBuilder
                                                                     const bool only_positive,
                                                                     const InterpolationType interpolation_type,
                                                                     const interpolation &x_spline,
-                                                                    const interpolation &y_spline,
-                                                                    std::vector<double> global_x_list = {});
+                                                                    const interpolation &y_spline);
 
 
 

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -19,6 +19,7 @@
 
 #include "world_builder/features/fault.h"
 
+#include <iostream>
 
 #include "glm/glm.h"
 #include "world_builder/types/array.h"
@@ -316,14 +317,17 @@ namespace WorldBuilder
               local_total_fault_length += segment_vector[i][j].value_length;
 
               fault_segment_thickness[i][j] = segment_vector[i][j].value_thickness;
+              maximum_fault_thickness = std::max(maximum_fault_thickness, fault_segment_thickness[i][j][0]);
+              maximum_fault_thickness = std::max(maximum_fault_thickness, fault_segment_thickness[i][j][1]);
               fault_segment_top_truncation[i][j] = segment_vector[i][j].value_top_truncation;
 
               fault_segment_angles[i][j] = segment_vector[i][j].value_angle * (const_pi/180);
             }
-          maximum_fault_thickness = std::max(maximum_fault_thickness, local_total_fault_length);
+
           total_fault_length[i] = local_total_fault_length;
           maximum_total_fault_length = std::max(maximum_total_fault_length, local_total_fault_length);
         }
+      //std::cout << "maximum_total_fault_length = " << maximum_total_fault_length << ", maximum_fault_thickness = " << maximum_fault_thickness <<std::endl;
     }
 
 
@@ -349,6 +353,9 @@ namespace WorldBuilder
       // todo: explain and check -starting_depth
       if (depth <= maximum_depth && depth >= starting_depth && depth <= maximum_total_fault_length + maximum_fault_thickness)
         {
+          //std::cout << "maximum_total_fault_length = " << maximum_total_fault_length << ", maximum_fault_thickness = " << maximum_fault_thickness
+          //<< ", maximum_total_fault_length + maximum_fault_thickness = " << maximum_total_fault_length + maximum_fault_thickness
+          //<< ", 2.0*(maximum_total_fault_length + maximum_fault_thickness) = " << 2.0*(maximum_total_fault_length + maximum_fault_thickness) << std::endl;
           // todo: explain
           // This function only returns positive values, because we want
           // the fault to be centered around the line provided by the user.
@@ -364,7 +371,8 @@ namespace WorldBuilder
                                                                        true,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline);
+                                                                       this->y_spline,
+                                                                       2.0*(maximum_total_fault_length + maximum_fault_thickness));
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
@@ -494,7 +502,8 @@ namespace WorldBuilder
                                                                        true,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline);
+                                                                       this->y_spline,
+                                                                       2.0*(maximum_total_fault_length + maximum_fault_thickness));
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
@@ -627,7 +636,8 @@ namespace WorldBuilder
                                                                        true,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline);
+                                                                       this->y_spline,
+                                                                       2.0*(maximum_total_fault_length + maximum_fault_thickness));
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -364,13 +364,12 @@ namespace WorldBuilder
                                                                        true,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
@@ -495,13 +494,12 @@ namespace WorldBuilder
                                                                        true,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment;
           //const size_t next_segment = current_segment + 1;
@@ -629,13 +627,12 @@ namespace WorldBuilder
                                                                        true,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment;
           //const size_t next_segment = current_segment + 1;

--- a/source/features/interface.cc
+++ b/source/features/interface.cc
@@ -144,66 +144,29 @@ namespace WorldBuilder
           one_dimensional_coordinates_local[j] = static_cast<double>(j);
         }
 
-      //if (interpolation_type != WorldBuilder::Utilities::InterpolationType::None)
+      double maximum_distance_between_coordinates = this->world->maximum_distance_between_coordinates *
+                                                    (coordinate_system == CoordinateSystem::spherical ? const_pi / 180.0 : 1.0);
+
+
+      // I don't think this is usefull for continuous monotone spline, although it might
+      // help in a spherical case like for the linear case.
+      std::vector<double> x_list(original_number_of_coordinates,0.0);
+      std::vector<double> y_list(original_number_of_coordinates,0.0);
+      std::vector<Point<2> > coordinate_list_local = coordinates;
+      for (size_t j=0; j<original_number_of_coordinates; ++j)
         {
-          //WBAssert(interpolation_type == WorldBuilder::Utilities::InterpolationType::Linear ||
-          //         interpolation_type == WorldBuilder::Utilities::InterpolationType::MonotoneSpline ||
-          //         interpolation_type == WorldBuilder::Utilities::InterpolationType::ContinuousMonotoneSpline,
-          //         "For interpolation, linear and monotone spline are the only allowed values. "
-          //         << "You provided " << interpolation_type_string << ".");
-
-          double maximum_distance_between_coordinates = this->world->maximum_distance_between_coordinates *
-                                                        (coordinate_system == CoordinateSystem::spherical ? const_pi / 180.0 : 1.0);
-
-
-          // I don't think this is usefull for continuous monotone spline, although it might
-          // help in a spherical case like for the linear case.
-          std::vector<double> x_list(original_number_of_coordinates,0.0);
-          std::vector<double> y_list(original_number_of_coordinates,0.0);
-          std::vector<Point<2> > coordinate_list_local = coordinates;
-          for (size_t j=0; j<original_number_of_coordinates; ++j)
-            {
-              x_list[j] = coordinates[j][0];
-              y_list[j] = coordinates[j][1];
-            }
-
-          x_spline.set_points(one_dimensional_coordinates_local,
-                              x_list,
-                              interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear &&
-                              interpolation_type != WorldBuilder::Utilities::InterpolationType::None);
-          y_spline.set_points(one_dimensional_coordinates_local,
-                              y_list,
-                              interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear &&
-                              interpolation_type != WorldBuilder::Utilities::InterpolationType::None);
-
-          if (maximum_distance_between_coordinates > 0)
-            {
-              size_t additional_parts = 0;
-              for (size_t i_plane=0; i_plane<original_number_of_coordinates-1; ++i_plane)
-                {
-                  const Point<2> P1 (x_spline(one_dimensional_coordinates_local[i_plane + additional_parts]),
-                                     y_spline(one_dimensional_coordinates_local[i_plane + additional_parts]),
-                                     coordinate_system);
-
-                  const Point<2> P2 (x_spline(one_dimensional_coordinates_local[i_plane + additional_parts + 1]),
-                                     y_spline(one_dimensional_coordinates_local[i_plane  + additional_parts+ 1]),
-                                     coordinate_system);
-
-                  const double length = (P1 - P2).norm();
-                  const size_t parts = static_cast<size_t>(std::ceil(length / maximum_distance_between_coordinates));
-                  for (size_t j = 1; j < parts; j++)
-                    {
-                      const double x_position3 = static_cast<double>(i_plane) + static_cast<double>(j)/static_cast<double>(parts);
-                      const Point<2> P3(x_spline(x_position3), y_spline(x_position3), coordinate_system);
-                      one_dimensional_coordinates_local.insert(one_dimensional_coordinates_local.begin() + static_cast<std::vector<double>::difference_type>(additional_parts + i_plane + 1), x_position3);
-                      coordinate_list_local.insert(coordinate_list_local.begin() + static_cast<std::vector<double>::difference_type>(additional_parts + i_plane + 1), P3);
-                      additional_parts++;
-                    }
-                }
-              coordinates = coordinate_list_local;
-            }
+          x_list[j] = coordinates[j][0];
+          y_list[j] = coordinates[j][1];
         }
-      one_dimensional_coordinates = one_dimensional_coordinates_local;
+
+      x_spline.set_points(one_dimensional_coordinates_local,
+                          x_list,
+                          interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear &&
+                          interpolation_type != WorldBuilder::Utilities::InterpolationType::None);
+      y_spline.set_points(one_dimensional_coordinates_local,
+                          y_list,
+                          interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear &&
+                          interpolation_type != WorldBuilder::Utilities::InterpolationType::None);
     }
 
 

--- a/source/features/interface.cc
+++ b/source/features/interface.cc
@@ -144,13 +144,13 @@ namespace WorldBuilder
           one_dimensional_coordinates_local[j] = static_cast<double>(j);
         }
 
-      if (interpolation_type != WorldBuilder::Utilities::InterpolationType::None)
+      //if (interpolation_type != WorldBuilder::Utilities::InterpolationType::None)
         {
-          WBAssert(interpolation_type == WorldBuilder::Utilities::InterpolationType::Linear ||
-                   interpolation_type == WorldBuilder::Utilities::InterpolationType::MonotoneSpline ||
-                   interpolation_type == WorldBuilder::Utilities::InterpolationType::ContinuousMonotoneSpline,
-                   "For interpolation, linear and monotone spline are the only allowed values. "
-                   << "You provided " << interpolation_type_string << ".");
+          //WBAssert(interpolation_type == WorldBuilder::Utilities::InterpolationType::Linear ||
+          //         interpolation_type == WorldBuilder::Utilities::InterpolationType::MonotoneSpline ||
+          //         interpolation_type == WorldBuilder::Utilities::InterpolationType::ContinuousMonotoneSpline,
+          //         "For interpolation, linear and monotone spline are the only allowed values. "
+          //         << "You provided " << interpolation_type_string << ".");
 
           double maximum_distance_between_coordinates = this->world->maximum_distance_between_coordinates *
                                                         (coordinate_system == CoordinateSystem::spherical ? const_pi / 180.0 : 1.0);
@@ -169,10 +169,12 @@ namespace WorldBuilder
 
           x_spline.set_points(one_dimensional_coordinates_local,
                               x_list,
-                              interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear);
+                              interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear &&
+                              interpolation_type != WorldBuilder::Utilities::InterpolationType::None);
           y_spline.set_points(one_dimensional_coordinates_local,
                               y_list,
-                              interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear);
+                              interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear &&
+                              interpolation_type != WorldBuilder::Utilities::InterpolationType::None);
 
           if (maximum_distance_between_coordinates > 0)
             {

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -320,11 +320,12 @@ namespace WorldBuilder
               local_total_slab_length += segment_vector[i][j].value_length;
 
               slab_segment_thickness[i][j] = segment_vector[i][j].value_thickness;
+              maximum_slab_thickness = std::max(maximum_slab_thickness, slab_segment_thickness[i][j][0]);
+              maximum_slab_thickness = std::max(maximum_slab_thickness, slab_segment_thickness[i][j][1]);
               slab_segment_top_truncation[i][j] = segment_vector[i][j].value_top_truncation;
 
               slab_segment_angles[i][j] = segment_vector[i][j].value_angle * (const_pi/180);
             }
-          maximum_slab_thickness = std::max(maximum_slab_thickness, local_total_slab_length);
           total_slab_length[i] = local_total_slab_length;
           maximum_total_slab_length = std::max(maximum_total_slab_length, local_total_slab_length);
         }

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -375,7 +375,8 @@ namespace WorldBuilder
                                                                        false,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline);
+                                                                       this->y_spline,
+                                                                       2.0*(maximum_total_slab_length + maximum_slab_thickness));
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
@@ -502,7 +503,8 @@ namespace WorldBuilder
                                                                        false,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline);
+                                                                       this->y_spline,
+                                                                       2.0*(maximum_total_slab_length + maximum_slab_thickness));
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
@@ -632,7 +634,8 @@ namespace WorldBuilder
                                                                        false,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline);
+                                                                       this->y_spline,
+                                                                       2.0*(maximum_total_slab_length + maximum_slab_thickness));
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -375,13 +375,12 @@ namespace WorldBuilder
                                                                        false,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
@@ -503,13 +502,12 @@ namespace WorldBuilder
                                                                        false,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
@@ -634,13 +632,12 @@ namespace WorldBuilder
                                                                        false,
                                                                        interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;

--- a/source/point.cc
+++ b/source/point.cc
@@ -87,19 +87,20 @@ namespace WorldBuilder
 
   template<int dim>
   double
-  Point<dim>::cheap_relative_distance(const Point<dim> &two) const
+  Point<dim>::cheap_relative_distance_spherical(const Point<dim> &two) const
   {
-    if (this->coordinate_system == spherical)
-      {
-        // spherical
-        const double d_longitude = two[0] - this->point[0];
-        const double d_lattitude = two[1] - this->point[1];
-        const double sin_d_lat = FT::sin(d_lattitude * 0.5);
-        const double sin_d_long = FT::sin(d_longitude * 0.5);
-        return (sin_d_lat * sin_d_lat) + (sin_d_long*sin_d_long) * FT::cos(this->point[1]) * FT::cos(two[1]);
-      }
+    const double d_longitude = two[0] - this->point[0];
+    const double d_lattitude = two[1] - this->point[1];
+    const double sin_d_lat = FT::sin(d_lattitude * 0.5);
+    const double sin_d_long = FT::sin(d_longitude * 0.5);
+    return (sin_d_lat * sin_d_lat) + (sin_d_long*sin_d_long) * FT::cos(this->point[1]) * FT::cos(two[1]);
+  }
 
-    // cartesian
+
+  template<int dim>
+  double
+  Point<dim>::cheap_relative_distance_cartesian(const Point<dim> &two) const
+  {
     const double x_distance_to_reference_point = point[0]-two[0];
     const double y_distance_to_reference_point = point[1]-two[1];
     return (x_distance_to_reference_point*x_distance_to_reference_point) + (y_distance_to_reference_point*y_distance_to_reference_point);

--- a/source/point.cc
+++ b/source/point.cc
@@ -20,6 +20,7 @@
 #include "world_builder/point.h"
 
 #include <limits>
+#include <iostream>
 
 namespace WorldBuilder
 {

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -519,7 +519,7 @@ namespace WorldBuilder
       Point<2> splines(0.,
                        0.,
                        natural_coordinate_system);
-      double minimum_distance_to_reference_point = splines.cheap_relative_distance(check_point_surface_2d);
+      double minimum_distance_to_reference_point = INFINITY;
 
       // Compute the clostest point on the spline as a double.
       for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -460,18 +460,19 @@ namespace WorldBuilder
 
       std::array<double,3> check_point_surface_2d_array = natural_coordinate.get_coordinates();
       // make sure the values are between -pi and pi
-      if(!bool_cartesian){
-        check_point_surface_2d_array[1] = (check_point_surface_2d_array[1]  > -const_pi && check_point_surface_2d_array[1]  < const_pi)
-                           ?
-                           check_point_surface_2d_array[1] 
-                           :
-                           FT::fmod(check_point_surface_2d_array[1]  + std::copysign(const_pi,check_point_surface_2d_array[1] ), const_pi * 2.0) - std::copysign(const_pi,check_point_surface_2d_array[1] );
-        check_point_surface_2d_array[2] = (check_point_surface_2d_array[2]  > -const_pi && check_point_surface_2d_array[2]  < const_pi)
-                           ?
-                           check_point_surface_2d_array[2] 
-                           :
-                           FT::fmod(check_point_surface_2d_array[2]  + std::copysign(const_pi,check_point_surface_2d_array[2] ), const_pi * 2.0) - std::copysign(const_pi,check_point_surface_2d_array[2] );
-      }
+      if (!bool_cartesian)
+        {
+          check_point_surface_2d_array[1] = (check_point_surface_2d_array[1]  > -const_pi && check_point_surface_2d_array[1]  < const_pi)
+                                            ?
+                                            check_point_surface_2d_array[1]
+                                            :
+                                            FT::fmod(check_point_surface_2d_array[1]  + std::copysign(const_pi,check_point_surface_2d_array[1] ), const_pi * 2.0) - std::copysign(const_pi,check_point_surface_2d_array[1] );
+          check_point_surface_2d_array[2] = (check_point_surface_2d_array[2]  > -const_pi && check_point_surface_2d_array[2]  < const_pi)
+                                            ?
+                                            check_point_surface_2d_array[2]
+                                            :
+                                            FT::fmod(check_point_surface_2d_array[2]  + std::copysign(const_pi,check_point_surface_2d_array[2] ), const_pi * 2.0) - std::copysign(const_pi,check_point_surface_2d_array[2] );
+        }
       const Point<3> check_point_surface(bool_cartesian ? check_point_surface_2d_array[0] : start_radius,
                                          check_point_surface_2d_array[1],
                                          bool_cartesian ? start_radius : check_point_surface_2d_array[2],
@@ -509,7 +510,7 @@ namespace WorldBuilder
 
 
       // get an estimate for the closest point between P1 and P2.
-      const double parts = 3;
+      const double parts = interpolation_type == InterpolationType::None || interpolation_type == InterpolationType::Linear ? 1 : 3;
       double min_estimate_solution = 0;
       double min_estimate_solution_temp = min_estimate_solution;
       Point<2> splines(x_spline(min_estimate_solution),y_spline(min_estimate_solution), natural_coordinate_system);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1131,13 +1131,14 @@ namespace WorldBuilder
     {
       WBAssert(!x.empty(), "Internal error: The x in the set points function is zero.");
       assert(x.size() == y.size());
-      m_x = x;
+      //m_x = x;
+      mx_size_min = x.size()-1;
       m_y = y;
       const size_t n = x.size();
-      for (size_t i = 0; i < n-1; i++)
-        {
-          assert(m_x[i] < m_x[i+1]);
-        }
+      //for (size_t i = 0; i < n-1; i++)
+      //  {
+      //    assert(m_x[i] < m_x[i+1]);
+      //  }
 
       if (monotone_spline)
         {
@@ -1203,7 +1204,7 @@ namespace WorldBuilder
             {
               m_a[i] = 0.0;
               m_b[i] = 0.0;
-              m_c[i] = (m_y[i+1]-m_y[i])/(m_x[i+1]-m_x[i]);
+              m_c[i] = (m_y[i+1]-m_y[i]);
             }
         }
 
@@ -1220,20 +1221,20 @@ namespace WorldBuilder
 
     double interpolation::operator() (const double x) const
     {
-      const size_t mx_size_min = m_x.size()-1;
+      //const size_t mx_size_min = m_x.size()-1;
       // Todo: The following two lines would work if m_x can be assumed to be [0,1,2,3,...]
       // Which would allow to optimize m_x away completely. I can only do that once I get
       // rid of the non-contiuous interpolation schemes, because the contiuous one doesn't
       // need any extra items in m_x.
-      //const size_t idx = std::min((size_t)std::max( (int)x, (int)0),mx_size_min);
-      //const double h = x-m_x[idx];
+      const size_t idx = std::min((size_t)std::max( (int)x, (int)0),mx_size_min);
+      const double h = x-idx;
       // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
-      std::vector<double>::const_iterator it;
-      it = std::lower_bound(m_x.begin(),m_x.end(),x);
-      size_t idx = static_cast<size_t>(std::max( static_cast<int>(it-m_x.begin())-1, 0));
+      //std::vector<double>::const_iterator it;
+      //it = std::lower_bound(m_x.begin(),m_x.end(),x);
+      //size_t idx = static_cast<size_t>(std::max( static_cast<int>(it-m_x.begin())-1, 0));
+      //double h = x-m_x[idx];
 
-      double h = x-m_x[idx];
-      return (((x >= m_x[0] && x <= m_x[mx_size_min] ? m_a[idx]*h : 0) + m_b[idx])*h + m_c[idx])*h + m_y[idx];
+      return (((x >= 0 && x <= mx_size_min ? m_a[idx]*h : 0) + m_b[idx])*h + m_c[idx])*h + m_y[idx];
     }
 
     double wrap_angle(const double angle)

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -439,8 +439,7 @@ namespace WorldBuilder
                                       const bool only_positive,
                                       const InterpolationType interpolation_type,
                                       const interpolation &x_spline,
-                                      const interpolation &y_spline,
-                                      std::vector<double> global_x_list)
+                                      const interpolation &y_spline)
     {
       // TODO: Assert that point_list, plane_segment_angles and plane_segment_lenghts have the same size.
       /*WBAssert(point_list.size() == plane_segment_lengths.size(),
@@ -449,19 +448,7 @@ namespace WorldBuilder
       WBAssert(point_list.size() == plane_segment_angles.size(),
                "Internal error: The size of point_list (" << point_list.size()
                << ") and plane_segment_angles (" << plane_segment_angles.size() << ") are different.");
-      WBAssert(point_list.size() == plane_segment_angles.size(),
-               "Internal error: The size of point_list (" << point_list.size()
-               << ") and global_x_list (" << global_x_list.size() << ") are different.");*/
-
-      if (global_x_list.empty())
-        {
-          // fill it
-          global_x_list.resize(point_list.size());
-          for (size_t i = 0; i < point_list.size(); ++i)
-            global_x_list[i] = static_cast<double>(i);
-        }
-      WBAssertThrow(global_x_list.size() == point_list.size(), "The given global_x_list doesn't have "
-                    "the same size as the point list. This is required.");
+      */
 
       double distance = INFINITY;
       double new_distance = INFINITY;
@@ -516,7 +503,7 @@ namespace WorldBuilder
       double minimum_distance_to_reference_point = splines.cheap_relative_distance(check_point_surface_2d);
 
       // Compute the clostest point on the spline as a double.
-      for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(global_x_list[point_list.size()-1])+1); i_estimate++)
+      for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
         {
           splines[0] = x_spline(min_estimate_solution_temp);
           splines[1] = y_spline(min_estimate_solution_temp);
@@ -564,10 +551,8 @@ namespace WorldBuilder
 
 
 
-      if (solution > 0 && floor(solution) <= global_x_list[point_list.size()-2] && floor(solution)  >= 0)
+      if (solution > 0 && floor(solution) <= point_list.size()-2 && floor(solution)  >= 0)
         {
-
-
           closest_point_on_line_2d = Point<2>(x_spline(solution),y_spline(solution),natural_coordinate_system);
           i_section_min_distance = static_cast<size_t>(floor(solution));
           fraction_CPL_P1P2 = solution-floor(solution);
@@ -606,7 +591,7 @@ namespace WorldBuilder
 
 
           // translate to orignal coordinates current and next section
-          size_t original_current_section = static_cast<size_t>(std::floor(global_x_list[i_section_min_distance]));
+          size_t original_current_section = static_cast<size_t>(std::floor(i_section_min_distance));
           size_t original_next_section = original_current_section + 1;
 
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -524,10 +524,10 @@ namespace WorldBuilder
       // Compute the clostest point on the spline as a double.
       for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
         {
-          min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
-          interpolation_h = min_estimate_solution_temp-(double)min_estimate_solution_temp_size_t;
-          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
-          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
+          const size_t min_estimate_solution_temp_size_t_temp = (size_t)min_estimate_solution_temp;
+          const double interpolation_h_temp = min_estimate_solution_temp-(double)min_estimate_solution_temp_size_t_temp;
+          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
+          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
           const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance(check_point_surface_2d);
 
           if (fabs(minimum_distance_to_reference_point_temp) < fabs(minimum_distance_to_reference_point))
@@ -542,19 +542,19 @@ namespace WorldBuilder
       double search_step = 1./parts;
       for (size_t i_search_step = 0; i_search_step < 10; i_search_step++)
         {
-          min_estimate_solution_temp = min_estimate_solution-search_step;
-          min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
-          interpolation_h = min_estimate_solution_temp-(double)min_estimate_solution_temp_size_t;
-          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
-          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
+          const double min_estimate_solution_temp_min = min_estimate_solution-search_step;
+          const size_t min_estimate_solution_temp_min_st = (size_t)min_estimate_solution_temp_min;
+          const double interpolation_h_min = min_estimate_solution_temp_min-(double)min_estimate_solution_temp_min_st;
+          splines[0] = x_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
+          splines[1] = y_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
           const double minimum_distance_to_reference_point_min = splines.cheap_relative_distance(check_point_surface_2d);
 
 
-          min_estimate_solution_temp = min_estimate_solution+search_step;
-          min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
-          interpolation_h = min_estimate_solution_temp-(double)min_estimate_solution_temp_size_t;
-          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
-          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
+          const double min_estimate_solution_temp_plus = min_estimate_solution+search_step;
+          const size_t min_estimate_solution_temp_plus_st = (size_t)min_estimate_solution_temp_plus;
+          const double interpolation_h_plus = min_estimate_solution_temp_plus-(double)min_estimate_solution_temp_plus_st;
+          splines[0] = x_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
+          splines[1] = y_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
           const double minimum_distance_to_reference_point_plus = splines.cheap_relative_distance(check_point_surface_2d);
 
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -526,8 +526,8 @@ namespace WorldBuilder
           // Compute the clostest point on the spline as a double.
           for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
             {
-              const size_t min_estimate_solution_temp_size_t_temp = (size_t)min_estimate_solution_temp;
-              const double interpolation_h_temp = min_estimate_solution_temp-(double)min_estimate_solution_temp_size_t_temp;
+              const size_t min_estimate_solution_temp_size_t_temp = static_cast<size_t>(min_estimate_solution_temp);
+              const double interpolation_h_temp = min_estimate_solution_temp-static_cast<double>(min_estimate_solution_temp_size_t_temp);
               splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
               splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
               const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance_cartesian(check_point_surface_2d);
@@ -581,8 +581,8 @@ namespace WorldBuilder
           // Compute the clostest point on the spline as a double.
           for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
             {
-              const size_t min_estimate_solution_temp_size_t_temp = (size_t)min_estimate_solution_temp;
-              const double interpolation_h_temp = min_estimate_solution_temp-(double)min_estimate_solution_temp_size_t_temp;
+              const size_t min_estimate_solution_temp_size_t_temp = static_cast<size_t>(min_estimate_solution_temp);
+              const double interpolation_h_temp = min_estimate_solution_temp-static_cast<double>(min_estimate_solution_temp_size_t_temp);
               splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
               splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
               const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance_spherical(check_point_surface_2d);
@@ -600,16 +600,16 @@ namespace WorldBuilder
           for (size_t i_search_step = 0; i_search_step < 10; i_search_step++)
             {
               const double min_estimate_solution_temp_min = min_estimate_solution-search_step;
-              const size_t min_estimate_solution_temp_min_st = (size_t)min_estimate_solution_temp_min;
-              const double interpolation_h_min = min_estimate_solution_temp_min-(double)min_estimate_solution_temp_min_st;
+              const size_t min_estimate_solution_temp_min_st = static_cast<size_t>(min_estimate_solution_temp_min);
+              const double interpolation_h_min = min_estimate_solution_temp_min-static_cast<double>(min_estimate_solution_temp_min_st);
               splines[0] = x_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
               splines[1] = y_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
               const double minimum_distance_to_reference_point_min = splines.cheap_relative_distance_spherical(check_point_surface_2d);
 
 
               const double min_estimate_solution_temp_plus = min_estimate_solution+search_step;
-              const size_t min_estimate_solution_temp_plus_st = (size_t)min_estimate_solution_temp_plus;
-              const double interpolation_h_plus = min_estimate_solution_temp_plus-(double)min_estimate_solution_temp_plus_st;
+              const size_t min_estimate_solution_temp_plus_st = static_cast<size_t>(min_estimate_solution_temp_plus);
+              const double interpolation_h_plus = min_estimate_solution_temp_plus-static_cast<double>(min_estimate_solution_temp_plus_st);
               splines[0] = x_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
               splines[1] = y_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
               const double minimum_distance_to_reference_point_plus = splines.cheap_relative_distance_spherical(check_point_surface_2d);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -507,67 +507,67 @@ namespace WorldBuilder
       double fraction_CPL_P1P2_strict =  INFINITY; // or NAN?
       double fraction_CPL_P1P2 = INFINITY;
 
-        
-          // get an estimate for the closest point between P1 and P2.
-          const double parts = 3;
-          double min_estimate_solution = 0;
-          double min_estimate_solution_temp = min_estimate_solution;
-          Point<2> splines(x_spline(min_estimate_solution),y_spline(min_estimate_solution), natural_coordinate_system);
-          double minimum_distance_to_reference_point = splines.cheap_relative_distance(check_point_surface_2d);
 
-          // Compute the clostest point on the spline as a double.
-          for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(global_x_list[point_list.size()-1])+1); i_estimate++)
+      // get an estimate for the closest point between P1 and P2.
+      const double parts = 3;
+      double min_estimate_solution = 0;
+      double min_estimate_solution_temp = min_estimate_solution;
+      Point<2> splines(x_spline(min_estimate_solution),y_spline(min_estimate_solution), natural_coordinate_system);
+      double minimum_distance_to_reference_point = splines.cheap_relative_distance(check_point_surface_2d);
+
+      // Compute the clostest point on the spline as a double.
+      for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(global_x_list[point_list.size()-1])+1); i_estimate++)
+        {
+          splines[0] = x_spline(min_estimate_solution_temp);
+          splines[1] = y_spline(min_estimate_solution_temp);
+          const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance(check_point_surface_2d);
+
+          if (fabs(minimum_distance_to_reference_point_temp) < fabs(minimum_distance_to_reference_point))
             {
-              splines[0] = x_spline(min_estimate_solution_temp);
-              splines[1] = y_spline(min_estimate_solution_temp);
-              const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance(check_point_surface_2d);
-
-              if (fabs(minimum_distance_to_reference_point_temp) < fabs(minimum_distance_to_reference_point))
-                {
-                  minimum_distance_to_reference_point = minimum_distance_to_reference_point_temp;
-                  min_estimate_solution = min_estimate_solution_temp;
-                }
-              min_estimate_solution_temp = min_estimate_solution_temp + 1.0/parts;
+              minimum_distance_to_reference_point = minimum_distance_to_reference_point_temp;
+              min_estimate_solution = min_estimate_solution_temp;
             }
+          min_estimate_solution_temp = min_estimate_solution_temp + 1.0/parts;
+        }
 
-          // search above and below the solution and replace if the distance is smaller.
-          double search_step = 1./parts;
-          for (size_t i_search_step = 0; i_search_step < 10; i_search_step++)
+      // search above and below the solution and replace if the distance is smaller.
+      double search_step = 1./parts;
+      for (size_t i_search_step = 0; i_search_step < 10; i_search_step++)
+        {
+          splines[0] = x_spline(min_estimate_solution-search_step);
+          splines[1] = y_spline(min_estimate_solution-search_step);
+          const double minimum_distance_to_reference_point_min = splines.cheap_relative_distance(check_point_surface_2d);
+
+
+          splines[0] = x_spline(min_estimate_solution+search_step);
+          splines[1] = y_spline(min_estimate_solution+search_step);
+          const double minimum_distance_to_reference_point_plus = splines.cheap_relative_distance(check_point_surface_2d);
+
+
+          if (minimum_distance_to_reference_point_plus < minimum_distance_to_reference_point)
             {
-              splines[0] = x_spline(min_estimate_solution-search_step);
-              splines[1] = y_spline(min_estimate_solution-search_step);
-              const double minimum_distance_to_reference_point_min = splines.cheap_relative_distance(check_point_surface_2d);
-
-
-              splines[0] = x_spline(min_estimate_solution+search_step);
-              splines[1] = y_spline(min_estimate_solution+search_step);
-              const double minimum_distance_to_reference_point_plus = splines.cheap_relative_distance(check_point_surface_2d);
-
-
-              if (minimum_distance_to_reference_point_plus < minimum_distance_to_reference_point)
-                {
-                  min_estimate_solution = min_estimate_solution+search_step;
-                  minimum_distance_to_reference_point = minimum_distance_to_reference_point_plus;
-                }
-              else if (minimum_distance_to_reference_point_min < minimum_distance_to_reference_point)
-                {
-                  min_estimate_solution = min_estimate_solution-search_step;
-                  minimum_distance_to_reference_point = minimum_distance_to_reference_point_min;
-                }
-              else
-                {
-                  search_step *=0.5;
-                }
+              min_estimate_solution = min_estimate_solution+search_step;
+              minimum_distance_to_reference_point = minimum_distance_to_reference_point_plus;
             }
-          double solution = min_estimate_solution;
+          else if (minimum_distance_to_reference_point_min < minimum_distance_to_reference_point)
+            {
+              min_estimate_solution = min_estimate_solution-search_step;
+              minimum_distance_to_reference_point = minimum_distance_to_reference_point_min;
+            }
+          else
+            {
+              search_step *=0.5;
+            }
+        }
+      double solution = min_estimate_solution;
 
-        
+
 
 
       if (solution > 0 && floor(solution) <= global_x_list[point_list.size()-2] && floor(solution)  >= 0)
         {
 
-          
+
           closest_point_on_line_2d = Point<2>(x_spline(solution),y_spline(solution),natural_coordinate_system);
           i_section_min_distance = static_cast<size_t>(floor(solution));
           fraction_CPL_P1P2 = solution-floor(solution);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -995,8 +995,8 @@ namespace WorldBuilder
                   // this segment and the distance.
                   if (std::fabs(interpolated_segment_length) > std::numeric_limits<double>::epsilon())
                     {
-                      end_segment[0] += interpolated_segment_length * std::sin(degree_90_to_rad - interpolated_angle_top);
-                      end_segment[1] -= interpolated_segment_length * std::cos(degree_90_to_rad - interpolated_angle_top);
+                      end_segment[0] += interpolated_segment_length * std::cos(interpolated_angle_top);
+                      end_segment[1] -= interpolated_segment_length * std::sin(interpolated_angle_top);
 
                       Point<2> begin_end_segment = end_segment - begin_segment;
                       Point<2> normal_2d_plane(-begin_end_segment[0],begin_end_segment[1], cartesian);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -955,7 +955,6 @@ namespace WorldBuilder
 
               // This interpolates different properties between P1 and P2 (the
               // points of the plane at the surface)
-              const double degree_90_to_rad = 0.5 * const_pi;
 
               WBAssert(plane_segment_angles.size() > original_next_section,
                        "Error: original_next_section = " << original_next_section

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -458,7 +458,20 @@ namespace WorldBuilder
       const CoordinateSystem natural_coordinate_system = coordinate_system->natural_coordinate_system();
       const bool bool_cartesian = natural_coordinate_system == cartesian;
 
-      const std::array<double,3> &check_point_surface_2d_array = natural_coordinate.get_coordinates();
+      std::array<double,3> check_point_surface_2d_array = natural_coordinate.get_coordinates();
+      // make sure the values are between -pi and pi
+      if(!bool_cartesian){
+        check_point_surface_2d_array[1] = (check_point_surface_2d_array[1]  > -const_pi && check_point_surface_2d_array[1]  < const_pi)
+                           ?
+                           check_point_surface_2d_array[1] 
+                           :
+                           FT::fmod(check_point_surface_2d_array[1]  + std::copysign(const_pi,check_point_surface_2d_array[1] ), const_pi * 2.0) - std::copysign(const_pi,check_point_surface_2d_array[1] );
+        check_point_surface_2d_array[2] = (check_point_surface_2d_array[2]  > -const_pi && check_point_surface_2d_array[2]  < const_pi)
+                           ?
+                           check_point_surface_2d_array[2] 
+                           :
+                           FT::fmod(check_point_surface_2d_array[2]  + std::copysign(const_pi,check_point_surface_2d_array[2] ), const_pi * 2.0) - std::copysign(const_pi,check_point_surface_2d_array[2] );
+      }
       const Point<3> check_point_surface(bool_cartesian ? check_point_surface_2d_array[0] : start_radius,
                                          check_point_surface_2d_array[1],
                                          bool_cartesian ? start_radius : check_point_surface_2d_array[2],
@@ -1204,23 +1217,6 @@ namespace WorldBuilder
         }
     }
 
-    double interpolation::operator() (const double x) const
-    {
-      //const size_t mx_size_min = m_x.size()-1;
-      // Todo: The following two lines would work if m_x can be assumed to be [0,1,2,3,...]
-      // Which would allow to optimize m_x away completely. I can only do that once I get
-      // rid of the non-contiuous interpolation schemes, because the contiuous one doesn't
-      // need any extra items in m_x.
-      const size_t idx = std::min((size_t)std::max( (int)x, (int)0),mx_size_min);
-      const double h = x-idx;
-      // find the closest point m_x[idx] < x, idx=0 even if x<m_x[0]
-      //std::vector<double>::const_iterator it;
-      //it = std::lower_bound(m_x.begin(),m_x.end(),x);
-      //size_t idx = static_cast<size_t>(std::max( static_cast<int>(it-m_x.begin())-1, 0));
-      //double h = x-m_x[idx];
-
-      return (((x >= 0 && x <= mx_size_min ? m_a[idx]*h : 0) + m_b[idx])*h + m_c[idx])*h + m_y[idx];
-    }
 
     double wrap_angle(const double angle)
     {

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -587,7 +587,7 @@ namespace WorldBuilder
           // Compute the clostest point on the spline as a double.
           const size_t number_of_points = static_cast<size_t>(parts*(point_list.size()-1)+1);
           std::vector<Point<2> > splines_vector(number_of_points,Point<2>(cartesian));
-          for (size_t i_estimate = 0; i_estimate <= number_of_points; i_estimate++)
+          for (size_t i_estimate = 0; i_estimate < number_of_points; i_estimate++)
           {
             const size_t min_estimate_solution_temp_size_t_temp = static_cast<size_t>(min_estimate_solution_temp);
             const double interpolation_h_temp = min_estimate_solution_temp - min_estimate_solution_temp_size_t_temp;
@@ -597,7 +597,7 @@ namespace WorldBuilder
           }
           min_estimate_solution_temp = 0;
           min_estimate_solution_temp = 0;
-          for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
+          for (size_t i_estimate = 0; i_estimate < static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
             {
               const double minimum_distance_to_reference_point_temp = splines_vector[i_estimate].cheap_relative_distance_spherical(check_point_surface_2d);
 
@@ -610,8 +610,8 @@ namespace WorldBuilder
             }
 
           // search above and below the solution and replace if the distance is smaller.
-          double search_step = 1./parts;
-          for (size_t i_search_step = 0; i_search_step < search_steps; i_search_step++)
+          double search_step = 1./search_steps;
+          for (size_t i_search_step = 0; i_search_step < search_steps-1; i_search_step++)
             {
               const double min_estimate_solution_temp_min = min_estimate_solution-search_step;
               const size_t min_estimate_solution_temp_min_st = static_cast<size_t>(min_estimate_solution_temp_min);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -513,14 +513,16 @@ namespace WorldBuilder
       const double parts = interpolation_type == InterpolationType::None || interpolation_type == InterpolationType::Linear ? 1 : 3;
       double min_estimate_solution = 0;
       double min_estimate_solution_temp = min_estimate_solution;
-      Point<2> splines(x_spline(min_estimate_solution),y_spline(min_estimate_solution), natural_coordinate_system);
+
+      size_t min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
+      Point<2> splines(x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t),y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t), natural_coordinate_system);
       double minimum_distance_to_reference_point = splines.cheap_relative_distance(check_point_surface_2d);
 
       // Compute the clostest point on the spline as a double.
       for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
         {
-          splines[0] = x_spline(min_estimate_solution_temp);
-          splines[1] = y_spline(min_estimate_solution_temp);
+          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
+          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
           const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance(check_point_surface_2d);
 
           if (fabs(minimum_distance_to_reference_point_temp) < fabs(minimum_distance_to_reference_point))
@@ -529,19 +531,24 @@ namespace WorldBuilder
               min_estimate_solution = min_estimate_solution_temp;
             }
           min_estimate_solution_temp = min_estimate_solution_temp + 1.0/parts;
+          min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
         }
 
       // search above and below the solution and replace if the distance is smaller.
       double search_step = 1./parts;
       for (size_t i_search_step = 0; i_search_step < 10; i_search_step++)
         {
-          splines[0] = x_spline(min_estimate_solution-search_step);
-          splines[1] = y_spline(min_estimate_solution-search_step);
+          min_estimate_solution_temp = min_estimate_solution-search_step;
+          min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
+          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
+          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
           const double minimum_distance_to_reference_point_min = splines.cheap_relative_distance(check_point_surface_2d);
 
 
-          splines[0] = x_spline(min_estimate_solution+search_step);
-          splines[1] = y_spline(min_estimate_solution+search_step);
+          min_estimate_solution_temp = min_estimate_solution+search_step;
+          min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
+          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
+          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
           const double minimum_distance_to_reference_point_plus = splines.cheap_relative_distance(check_point_surface_2d);
 
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -514,15 +514,20 @@ namespace WorldBuilder
       double min_estimate_solution = 0;
       double min_estimate_solution_temp = min_estimate_solution;
 
-      size_t min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
-      Point<2> splines(x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t),y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t), natural_coordinate_system);
+      size_t min_estimate_solution_temp_size_t;
+      double interpolation_h;
+      Point<2> splines(0.,
+                       0.,
+                       natural_coordinate_system);
       double minimum_distance_to_reference_point = splines.cheap_relative_distance(check_point_surface_2d);
 
       // Compute the clostest point on the spline as a double.
       for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
         {
-          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
-          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
+          min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
+          interpolation_h = min_estimate_solution_temp-(double)min_estimate_solution_temp_size_t;
+          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
+          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
           const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance(check_point_surface_2d);
 
           if (fabs(minimum_distance_to_reference_point_temp) < fabs(minimum_distance_to_reference_point))
@@ -531,7 +536,6 @@ namespace WorldBuilder
               min_estimate_solution = min_estimate_solution_temp;
             }
           min_estimate_solution_temp = min_estimate_solution_temp + 1.0/parts;
-          min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
         }
 
       // search above and below the solution and replace if the distance is smaller.
@@ -540,15 +544,17 @@ namespace WorldBuilder
         {
           min_estimate_solution_temp = min_estimate_solution-search_step;
           min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
-          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
-          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
+          interpolation_h = min_estimate_solution_temp-(double)min_estimate_solution_temp_size_t;
+          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
+          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
           const double minimum_distance_to_reference_point_min = splines.cheap_relative_distance(check_point_surface_2d);
 
 
           min_estimate_solution_temp = min_estimate_solution+search_step;
           min_estimate_solution_temp_size_t = (size_t)min_estimate_solution_temp;
-          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
-          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t);
+          interpolation_h = min_estimate_solution_temp-(double)min_estimate_solution_temp_size_t;
+          splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
+          splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t,interpolation_h);
           const double minimum_distance_to_reference_point_plus = splines.cheap_relative_distance(check_point_surface_2d);
 
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -583,10 +583,10 @@ namespace WorldBuilder
           // Compute the clostest point on the spline as a double.
           for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
             {
-              //const size_t min_estimate_solution_temp_size_t_temp =std::min((size_t)std::max( (int)min_estimate_solution_temp, (int)0),mx_size_min);
-              //const double interpolation_h_temp = min_estimate_solution_temp-static_cast<double>(min_estimate_solution_temp_size_t_temp);
-              splines[0] = x_spline(min_estimate_solution_temp);//,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
-              splines[1] = y_spline(min_estimate_solution_temp);//,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
+              const size_t min_estimate_solution_temp_size_t_temp =std::min((size_t)std::max( (int)min_estimate_solution_temp, (int)0),mx_size_min);
+              const double interpolation_h_temp = min_estimate_solution_temp-static_cast<double>(min_estimate_solution_temp_size_t_temp);
+              splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
+              splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
               const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance_spherical(check_point_surface_2d);
 
               if (fabs(minimum_distance_to_reference_point_temp) < fabs(minimum_distance_to_reference_point))
@@ -602,18 +602,18 @@ namespace WorldBuilder
           for (size_t i_search_step = 0; i_search_step < 10; i_search_step++)
             {
               const double min_estimate_solution_temp_min = min_estimate_solution-search_step;
-              //const size_t min_estimate_solution_temp_min_st = std::min((size_t)std::max( (int)min_estimate_solution_temp_min, (int)0),mx_size_min);
-              //const double interpolation_h_min = min_estimate_solution_temp_min-(double)min_estimate_solution_temp_min_st;
-              splines[0] = x_spline(min_estimate_solution_temp_min);//,min_estimate_solution_temp_min_st,interpolation_h_min);
-              splines[1] = y_spline(min_estimate_solution_temp_min);//,min_estimate_solution_temp_min_st,interpolation_h_min);
+              const size_t min_estimate_solution_temp_min_st = std::min((size_t)std::max( (int)min_estimate_solution_temp_min, (int)0),mx_size_min);
+              const double interpolation_h_min = min_estimate_solution_temp_min-(double)min_estimate_solution_temp_min_st;
+              splines[0] = x_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
+              splines[1] = y_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
               const double minimum_distance_to_reference_point_min = splines.cheap_relative_distance_spherical(check_point_surface_2d);
 
 
               const double min_estimate_solution_temp_plus = min_estimate_solution+search_step;
-              //const size_t min_estimate_solution_temp_plus_st = std::min((size_t)std::max( (int)min_estimate_solution_temp_plus, (int)0),mx_size_min);
-              //const double interpolation_h_plus = min_estimate_solution_temp_plus-(double)min_estimate_solution_temp_plus_st;
-              splines[0] = x_spline(min_estimate_solution_temp_plus);//,min_estimate_solution_temp_plus_st,interpolation_h_plus);
-              splines[1] = y_spline(min_estimate_solution_temp_plus);//,min_estimate_solution_temp_plus_st,interpolation_h_plus);
+              const size_t min_estimate_solution_temp_plus_st = std::min((size_t)std::max( (int)min_estimate_solution_temp_plus, (int)0),mx_size_min);
+              const double interpolation_h_plus = min_estimate_solution_temp_plus-(double)min_estimate_solution_temp_plus_st;
+              splines[0] = x_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
+              splines[1] = y_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
               const double minimum_distance_to_reference_point_plus = splines.cheap_relative_distance_spherical(check_point_surface_2d);
 
 
@@ -653,6 +653,8 @@ namespace WorldBuilder
                                                        bool_cartesian ? start_radius : closest_point_on_line_2d[1],
                                                        natural_coordinate_system);
 
+
+
           Point<3> closest_point_on_line_bottom = closest_point_on_line_surface;
           closest_point_on_line_bottom[bool_cartesian ? 2 : 0] = 0;
 
@@ -667,15 +669,15 @@ namespace WorldBuilder
           // closest_point_on_line, we need to push them to cartesian.
           Point<3>closest_point_on_line_cartesian(coordinate_system->natural_to_cartesian_coordinates(closest_point_on_line_surface.get_array()),cartesian);
           Point<3> closest_point_on_line_bottom_cartesian(coordinate_system->natural_to_cartesian_coordinates(closest_point_on_line_bottom.get_array()),cartesian);
-          Point<3> check_point_surface_cartesian(coordinate_system->natural_to_cartesian_coordinates(check_point_surface.get_array()),cartesian);
+          //Point<3> check_point_surface_cartesian(coordinate_system->natural_to_cartesian_coordinates(check_point_surface.get_array()),cartesian);
 
 
-          WBAssert(!std::isnan(closest_point_on_line_bottom_cartesian[0]),
-                   "Internal error: The y_axis variable is not a number: " << closest_point_on_line_bottom_cartesian[0]);
-          WBAssert(!std::isnan(closest_point_on_line_bottom_cartesian[1]),
-                   "Internal error: The y_axis variable is not a number: " << closest_point_on_line_bottom_cartesian[1]);
-          WBAssert(!std::isnan(closest_point_on_line_bottom_cartesian[2]),
-                   "Internal error: The y_axis variable is not a number: " << closest_point_on_line_bottom_cartesian[2]);
+          //WBAssert(!std::isnan(closest_point_on_line_bottom_cartesian[0]),
+          //         "Internal error: The y_axis variable is not a number: " << closest_point_on_line_bottom_cartesian[0]);
+          //WBAssert(!std::isnan(closest_point_on_line_bottom_cartesian[1]),
+          //         "Internal error: The y_axis variable is not a number: " << closest_point_on_line_bottom_cartesian[1]);
+          //WBAssert(!std::isnan(closest_point_on_line_bottom_cartesian[2]),
+          //         "Internal error: The y_axis variable is not a number: " << closest_point_on_line_bottom_cartesian[2]);
 
 
           // translate to orignal coordinates current and next section
@@ -685,8 +687,8 @@ namespace WorldBuilder
 
           // These are the mostly likely cases for the x and y axis, so initialize them to these values. They will be checked
           // in the else statement or replaced in the if statement.
-          Point<3> y_axis = closest_point_on_line_cartesian - closest_point_on_line_bottom_cartesian;
-          Point<3> x_axis = closest_point_on_line_cartesian - check_point_surface_cartesian;
+          Point<3> y_axis(0.,0.,0.,cartesian);//closest_point_on_line_cartesian - closest_point_on_line_bottom_cartesian;
+          Point<3> x_axis(0.,0.,0.,cartesian);//closest_point_on_line_cartesian - check_point_surface_cartesian;
 
           // This are accouting for corner cases.
           // If the point to check is exactly on or below the line, we can not compute the x-axis with this method.
@@ -715,6 +717,7 @@ namespace WorldBuilder
                   const Point<3> closest_point_on_line_plus_normal_to_plane_cartesian(coordinate_system->natural_to_cartesian_coordinates(closest_point_on_line_plus_normal_to_plane_surface_spherical.get_array()),cartesian);
                   Point<3> normal_to_plane = closest_point_on_line_plus_normal_to_plane_cartesian - closest_point_on_line_cartesian;
                   normal_to_plane = normal_to_plane / normal_to_plane.norm();
+
 
                   // The y-axis is from the bottom/center to the closest_point_on_line,
                   // the x-axis is 90 degrees rotated from that, so we rotate around
@@ -800,6 +803,14 @@ namespace WorldBuilder
             }
           else
             {
+
+          Point<3> check_point_surface_cartesian(coordinate_system->natural_to_cartesian_coordinates(check_point_surface.get_array()),cartesian);
+
+
+          // These are the mostly likely cases for the x and y axis, so initialize them to these values. They will be checked
+          // in the else statement or replaced in the if statement.
+          y_axis = closest_point_on_line_cartesian - closest_point_on_line_bottom_cartesian;
+          x_axis = closest_point_on_line_cartesian - check_point_surface_cartesian;
 
 
               WBAssert(std::abs(y_axis.norm()) > std::numeric_limits<double>::epsilon(),

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -324,13 +324,11 @@ namespace WorldBuilder
     spherical_to_cartesian_coordinates(const std::array<double,3> &scoord)
     {
       Point<3> ccoord(cartesian);
-      constexpr double half_pi = 0.5*const_pi;
-      const double longitude = half_pi - scoord[2];
-      const double sin_long = std::sin(longitude);
+      const double cos_long = FT::cos(scoord[2]);
 
-      ccoord[0] = scoord[0] * sin_long * std::cos(scoord[1]); // X
-      ccoord[1] = scoord[0] * sin_long * std::sin(scoord[1]); // Y
-      ccoord[2] = scoord[0] * std::cos(longitude); // Z
+      ccoord[0] = scoord[0] * cos_long * FT::cos(scoord[1]); // X
+      ccoord[1] = scoord[0] * cos_long * FT::sin(scoord[1]); // Y
+      ccoord[2] = scoord[0] * FT::sin(scoord[2]); // Z
 
 
       return ccoord;
@@ -994,8 +992,8 @@ namespace WorldBuilder
                   // this segment and the distance.
                   if (std::fabs(interpolated_segment_length) > std::numeric_limits<double>::epsilon())
                     {
-                      end_segment[0] += interpolated_segment_length * std::cos(interpolated_angle_top);
-                      end_segment[1] -= interpolated_segment_length * std::sin(interpolated_angle_top);
+                      end_segment[0] += interpolated_segment_length * FT::cos(interpolated_angle_top);
+                      end_segment[1] -= interpolated_segment_length * FT::sin(interpolated_angle_top);
 
                       Point<2> begin_end_segment = end_segment - begin_segment;
                       Point<2> normal_2d_plane(-begin_end_segment[0],begin_end_segment[1], cartesian);
@@ -1043,7 +1041,7 @@ namespace WorldBuilder
                            << ". interpolated_segment_length = " << interpolated_segment_length
                            << ", difference_in_angle_along_segment = " << difference_in_angle_along_segment);
 
-                  const double cos_angle_top = std::cos(interpolated_angle_top);
+                  const double cos_angle_top = FT::cos(interpolated_angle_top);
 
                   WBAssert(!std::isnan(cos_angle_top),
                            "Internal error: The radius_angle_circle variable is not a number: " << cos_angle_top

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <iostream>
 
 #include "world_builder/utilities.h"
 
@@ -521,15 +522,16 @@ namespace WorldBuilder
                        natural_coordinate_system);
       double minimum_distance_to_reference_point = INFINITY;
 
+          const size_t mx_size_min = point_list.size()-1;
       if (natural_coordinate_system == cartesian)
         {
           // Compute the clostest point on the spline as a double.
           for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
             {
-              const size_t min_estimate_solution_temp_size_t_temp = static_cast<size_t>(min_estimate_solution_temp);
-              const double interpolation_h_temp = min_estimate_solution_temp-static_cast<double>(min_estimate_solution_temp_size_t_temp);
-              splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
-              splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
+              //const size_t min_estimate_solution_temp_size_t_temp =std::min((size_t)std::max( (int)min_estimate_solution_temp, (int)0),mx_size_min);
+              //const double interpolation_h_temp = min_estimate_solution_temp-static_cast<double>(min_estimate_solution_temp_size_t_temp);
+              splines[0] = x_spline(min_estimate_solution_temp);//,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
+              splines[1] = y_spline(min_estimate_solution_temp);//,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
               const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance_cartesian(check_point_surface_2d);
 
               if (fabs(minimum_distance_to_reference_point_temp) < fabs(minimum_distance_to_reference_point))
@@ -545,18 +547,18 @@ namespace WorldBuilder
           for (size_t i_search_step = 0; i_search_step < 10; i_search_step++)
             {
               const double min_estimate_solution_temp_min = min_estimate_solution-search_step;
-              const size_t min_estimate_solution_temp_min_st = (size_t)min_estimate_solution_temp_min;
-              const double interpolation_h_min = min_estimate_solution_temp_min-(double)min_estimate_solution_temp_min_st;
-              splines[0] = x_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
-              splines[1] = y_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
+              //const size_t min_estimate_solution_temp_min_st = std::min((size_t)std::max( (int)min_estimate_solution_temp_min, (int)0),mx_size_min);
+              //const double interpolation_h_min = min_estimate_solution_temp_min-(double)min_estimate_solution_temp_min_st;
+              splines[0] = x_spline(min_estimate_solution_temp_min);//,min_estimate_solution_temp_min_st,interpolation_h_min);
+              splines[1] = y_spline(min_estimate_solution_temp_min);//,min_estimate_solution_temp_min_st,interpolation_h_min);
               const double minimum_distance_to_reference_point_min = splines.cheap_relative_distance_cartesian(check_point_surface_2d);
 
 
               const double min_estimate_solution_temp_plus = min_estimate_solution+search_step;
-              const size_t min_estimate_solution_temp_plus_st = (size_t)min_estimate_solution_temp_plus;
-              const double interpolation_h_plus = min_estimate_solution_temp_plus-(double)min_estimate_solution_temp_plus_st;
-              splines[0] = x_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
-              splines[1] = y_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
+              //const size_t min_estimate_solution_temp_plus_st = std::min((size_t)std::max( (int)min_estimate_solution_temp_plus, (int)0),mx_size_min);
+              //const double interpolation_h_plus = min_estimate_solution_temp_plus-(double)min_estimate_solution_temp_plus_st;
+              splines[0] = x_spline(min_estimate_solution_temp_plus);//,min_estimate_solution_temp_plus_st,interpolation_h_plus);
+              splines[1] = y_spline(min_estimate_solution_temp_plus);//,min_estimate_solution_temp_plus_st,interpolation_h_plus);
               const double minimum_distance_to_reference_point_plus = splines.cheap_relative_distance_cartesian(check_point_surface_2d);
 
 
@@ -581,10 +583,10 @@ namespace WorldBuilder
           // Compute the clostest point on the spline as a double.
           for (size_t i_estimate = 0; i_estimate <= static_cast<size_t>(parts*(point_list.size()-1)+1); i_estimate++)
             {
-              const size_t min_estimate_solution_temp_size_t_temp = static_cast<size_t>(min_estimate_solution_temp);
-              const double interpolation_h_temp = min_estimate_solution_temp-static_cast<double>(min_estimate_solution_temp_size_t_temp);
-              splines[0] = x_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
-              splines[1] = y_spline(min_estimate_solution_temp,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
+              //const size_t min_estimate_solution_temp_size_t_temp =std::min((size_t)std::max( (int)min_estimate_solution_temp, (int)0),mx_size_min);
+              //const double interpolation_h_temp = min_estimate_solution_temp-static_cast<double>(min_estimate_solution_temp_size_t_temp);
+              splines[0] = x_spline(min_estimate_solution_temp);//,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
+              splines[1] = y_spline(min_estimate_solution_temp);//,min_estimate_solution_temp_size_t_temp,interpolation_h_temp);
               const double minimum_distance_to_reference_point_temp = splines.cheap_relative_distance_spherical(check_point_surface_2d);
 
               if (fabs(minimum_distance_to_reference_point_temp) < fabs(minimum_distance_to_reference_point))
@@ -600,18 +602,18 @@ namespace WorldBuilder
           for (size_t i_search_step = 0; i_search_step < 10; i_search_step++)
             {
               const double min_estimate_solution_temp_min = min_estimate_solution-search_step;
-              const size_t min_estimate_solution_temp_min_st = static_cast<size_t>(min_estimate_solution_temp_min);
-              const double interpolation_h_min = min_estimate_solution_temp_min-static_cast<double>(min_estimate_solution_temp_min_st);
-              splines[0] = x_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
-              splines[1] = y_spline(min_estimate_solution_temp_min,min_estimate_solution_temp_min_st,interpolation_h_min);
+              //const size_t min_estimate_solution_temp_min_st = std::min((size_t)std::max( (int)min_estimate_solution_temp_min, (int)0),mx_size_min);
+              //const double interpolation_h_min = min_estimate_solution_temp_min-(double)min_estimate_solution_temp_min_st;
+              splines[0] = x_spline(min_estimate_solution_temp_min);//,min_estimate_solution_temp_min_st,interpolation_h_min);
+              splines[1] = y_spline(min_estimate_solution_temp_min);//,min_estimate_solution_temp_min_st,interpolation_h_min);
               const double minimum_distance_to_reference_point_min = splines.cheap_relative_distance_spherical(check_point_surface_2d);
 
 
               const double min_estimate_solution_temp_plus = min_estimate_solution+search_step;
-              const size_t min_estimate_solution_temp_plus_st = static_cast<size_t>(min_estimate_solution_temp_plus);
-              const double interpolation_h_plus = min_estimate_solution_temp_plus-static_cast<double>(min_estimate_solution_temp_plus_st);
-              splines[0] = x_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
-              splines[1] = y_spline(min_estimate_solution_temp_plus,min_estimate_solution_temp_plus_st,interpolation_h_plus);
+              //const size_t min_estimate_solution_temp_plus_st = std::min((size_t)std::max( (int)min_estimate_solution_temp_plus, (int)0),mx_size_min);
+              //const double interpolation_h_plus = min_estimate_solution_temp_plus-(double)min_estimate_solution_temp_plus_st;
+              splines[0] = x_spline(min_estimate_solution_temp_plus);//,min_estimate_solution_temp_plus_st,interpolation_h_plus);
+              splines[1] = y_spline(min_estimate_solution_temp_plus);//,min_estimate_solution_temp_plus_st,interpolation_h_plus);
               const double minimum_distance_to_reference_point_plus = splines.cheap_relative_distance_spherical(check_point_surface_2d);
 
 
@@ -635,9 +637,10 @@ namespace WorldBuilder
 
 
 
-
+//std::cout << "solution = " << solution << std::endl;
       if (solution > 0 && floor(solution) <= point_list.size()-2 && floor(solution)  >= 0)
         {
+//std::cout << "endered with solution = " << solution << std::endl;
           closest_point_on_line_2d = Point<2>(x_spline(solution),y_spline(solution),natural_coordinate_system);
           i_section_min_distance = static_cast<size_t>(floor(solution));
           fraction_CPL_P1P2 = solution-floor(solution);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -507,58 +507,7 @@ namespace WorldBuilder
       double fraction_CPL_P1P2_strict =  INFINITY; // or NAN?
       double fraction_CPL_P1P2 = INFINITY;
 
-      bool continue_computation = false;
-      if (interpolation_type != InterpolationType::ContinuousMonotoneSpline)
-        {
-          // loop over all the planes to find out which one is closest to the point.
-          for (size_t i_section=0; i_section < point_list.size()-1; ++i_section)
-            {
-              const Point<2> P1(point_list[i_section]);
-              const Point<2> P2(point_list[i_section+1]);
-
-              const Point<2> P1P2 = P2 - P1;
-              const double P1P2_norm = P1P2.norm();
-              if (P1P2_norm < 1e-14)
-                {
-                  // P1 and P2 are at exactly the same location. Just continue.
-                  continue;
-                }
-              const Point<2> P1PC = check_point_surface_2d - P1;
-
-              // Compute the closest point on the line P1 to P2 from the check
-              // point at the surface. We do this in natural coordinates on
-              // purpose, because in spherical coordinates it is more accurate.
-              closest_point_on_line_2d_temp = P1 + ((P1PC * P1P2) / (P1P2 * P1P2)) * P1P2;
-
-              // compute what fraction of the distance between P1 and P2 the
-              // closest point lies.
-              Point<2> P1CPL = closest_point_on_line_2d_temp - P1;
-
-              // This determines where the check point is between the coordinates
-              // in the coordinate list.
-              double fraction_CPL_P1P2_strict_temp = (P1CPL * P1P2 <= 0 ? -1.0 : 1.0) * (1 - (P1P2.norm() - P1CPL.norm()) / P1P2.norm());
-
-              double min_distance_check_point_surface_2d_line_temp = closest_point_on_line_2d_temp.cheap_relative_distance(check_point_surface_2d);//(closest_point_on_line_2d_temp - check_point_surface_2d).norm();//closest_point_on_line_2d_temp.distance(check_point_surface_2d);
-              // If fraction_CPL_P1P2_strict_temp is between 0 and 1 it means that the point can be projected perpendicual to the line segment. For the non-contiuous case we only conder points which are
-              // perpendicular to a line segment.
-              // There can be mutliple lines segment to which a point is perpundicual. Choose the point which is closed in 2D (x-y).
-              if (fraction_CPL_P1P2_strict_temp >= 0. && fraction_CPL_P1P2_strict_temp <= 1. && fabs(min_distance_check_point_surface_2d_line_temp) < fabs(min_distance_check_point_surface_2d_line))
-                {
-                  min_distance_check_point_surface_2d_line = min_distance_check_point_surface_2d_line_temp;
-                  i_section_min_distance = i_section;
-                  closest_point_on_line_2d = closest_point_on_line_2d_temp;
-                  fraction_CPL_P1P2_strict = fraction_CPL_P1P2_strict_temp;
-                }
-            }
-          // If the point on the line does not lay between point P1 and P2
-          // then ignore it. Otherwise continue.
-          continue_computation = (fabs(fraction_CPL_P1P2_strict) < INFINITY && fraction_CPL_P1P2_strict >= 0. && fraction_CPL_P1P2_strict <= 1.);
-
-          fraction_CPL_P1P2 = global_x_list[i_section_min_distance] - static_cast<int>(global_x_list[i_section_min_distance])
-                              + (global_x_list[i_section_min_distance+1]-global_x_list[i_section_min_distance]) * fraction_CPL_P1P2_strict;
-        }
-      else
-        {
+        
           // get an estimate for the closest point between P1 and P2.
           const double parts = 3;
           double min_estimate_solution = 0;
@@ -612,16 +561,17 @@ namespace WorldBuilder
             }
           double solution = min_estimate_solution;
 
-          continue_computation = (solution > 0 && floor(solution) <= global_x_list[point_list.size()-2] && floor(solution)  >= 0);
+        
 
+
+      if (solution > 0 && floor(solution) <= global_x_list[point_list.size()-2] && floor(solution)  >= 0)
+        {
+
+          
           closest_point_on_line_2d = Point<2>(x_spline(solution),y_spline(solution),natural_coordinate_system);
           i_section_min_distance = static_cast<size_t>(floor(solution));
           fraction_CPL_P1P2 = solution-floor(solution);
-        }
 
-
-      if (continue_computation)
-        {
           // We now need 3d points from this point on, so make them.
           // The order of a Cartesian coordinate is x,y,z and the order of
           // a spherical coordinate it radius, long, lat (in rad).

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -324,10 +324,13 @@ namespace WorldBuilder
     spherical_to_cartesian_coordinates(const std::array<double,3> &scoord)
     {
       Point<3> ccoord(cartesian);
+      constexpr double half_pi = 0.5*const_pi;
+      const double longitude = half_pi - scoord[2];
+      const double sin_long = std::sin(longitude);
 
-      ccoord[0] = scoord[0] * std::sin(0.5 * const_pi - scoord[2]) * std::cos(scoord[1]); // X
-      ccoord[1] = scoord[0] * std::sin(0.5 * const_pi - scoord[2]) * std::sin(scoord[1]); // Y
-      ccoord[2] = scoord[0] * std::cos(0.5 * const_pi - scoord[2]); // Z
+      ccoord[0] = scoord[0] * sin_long * std::cos(scoord[1]); // X
+      ccoord[1] = scoord[0] * sin_long * std::sin(scoord[1]); // Y
+      ccoord[2] = scoord[0] * std::cos(longitude); // Z
 
 
       return ccoord;

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -7301,12 +7301,12 @@ TEST_CASE("Fast vs slow distance function")
   const Point<3> cartesian_1(1,2,3, cartesian);
   const Point<3> cartesian_2(2,3,4, cartesian);
   // Should be exactly the same.
-  CHECK(sqrt(cartesian_1.cheap_relative_distance(cartesian_2)) == Approx(cartesian_1.distance(cartesian_2)));
+  CHECK(sqrt(cartesian_1.cheap_relative_distance_cartesian(cartesian_2)) == Approx(cartesian_1.distance(cartesian_2)));
 
   const Point<3> spherical_1(1,2,3, spherical);
   const Point<3> spherical_2(2,3,4, spherical);
   // will have an error associated with the faster sin functions.
-  CHECK(fabs(2.0 * asin(sqrt((spherical_1.cheap_relative_distance(spherical_2))))- spherical_1.distance(spherical_2)) < 3e-5);
+  CHECK(fabs(2.0 * asin(sqrt((spherical_1.cheap_relative_distance_spherical(spherical_2))))- spherical_1.distance(spherical_2)) < 3e-5);
 }
 
 TEST_CASE("Fast version of fmod")

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -6781,8 +6781,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,1,2});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
@@ -6809,8 +6808,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
@@ -6837,8 +6835,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
@@ -6865,8 +6862,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
@@ -6893,8 +6889,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-12);
@@ -6923,8 +6918,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);


### PR DESCRIPTION
This is a first attempt to address issue #302.

 This will change the result for the old interpolation schemes and therefore break some tests, but in my opinion the new result is closer to what a use would expect anyway. I see no reason why a user would want to have a slab or fault which is discontiuous at the points which define the location of the slab/fault. If a user wants a discontiuous areas in a slab, they can still create it explicitly.

So if this pull request is implemented, all the slabs will be continuous. At the same time allows this allows for some (hopefully significant) optimizations in the interpolation scheme.

