### PR TITLE
fix bug in calculation of maximum fault and slab thickness.

### DIFF
--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -316,11 +316,12 @@ namespace WorldBuilder
               local_total_fault_length += segment_vector[i][j].value_length;
 
               fault_segment_thickness[i][j] = segment_vector[i][j].value_thickness;
+              maximum_fault_thickness = std::max(maximum_fault_thickness, fault_segment_thickness[i][j][0]);
+              maximum_fault_thickness = std::max(maximum_fault_thickness, fault_segment_thickness[i][j][1]);
               fault_segment_top_truncation[i][j] = segment_vector[i][j].value_top_truncation;
 
               fault_segment_angles[i][j] = segment_vector[i][j].value_angle * (const_pi/180);
             }
-          maximum_fault_thickness = std::max(maximum_fault_thickness, local_total_fault_length);
           total_fault_length[i] = local_total_fault_length;
           maximum_total_fault_length = std::max(maximum_total_fault_length, local_total_fault_length);
         }

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -320,11 +320,12 @@ namespace WorldBuilder
               local_total_slab_length += segment_vector[i][j].value_length;
 
               slab_segment_thickness[i][j] = segment_vector[i][j].value_thickness;
+              maximum_slab_thickness = std::max(maximum_slab_thickness, slab_segment_thickness[i][j][0]);
+              maximum_slab_thickness = std::max(maximum_slab_thickness, slab_segment_thickness[i][j][1]);
               slab_segment_top_truncation[i][j] = segment_vector[i][j].value_top_truncation;
 
               slab_segment_angles[i][j] = segment_vector[i][j].value_angle * (const_pi/180);
             }
-          maximum_slab_thickness = std::max(maximum_slab_thickness, local_total_slab_length);
           total_slab_length[i] = local_total_slab_length;
           maximum_total_slab_length = std::max(maximum_total_slab_length, local_total_slab_length);
         }


### PR DESCRIPTION
I found this while working on #304. The maximum thickness was defined as the total length. This should not change any results, but may speedup the benchmarks.