### PR TITLE
Rename a variable to clarify that it duplicates information of another variable.

### DIFF
--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -85,7 +85,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -97,7 +97,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition) const override final;
@@ -111,7 +111,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+               const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -85,7 +85,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -97,7 +97,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition) const override final;
@@ -111,7 +111,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -87,7 +87,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -99,7 +99,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition_value) const override final;
@@ -113,7 +113,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+               const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -87,7 +87,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -99,7 +99,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition_value) const override final;
@@ -113,7 +113,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -87,7 +87,7 @@ namespace WorldBuilder
          */
         virtual
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const = 0;
@@ -97,7 +97,7 @@ namespace WorldBuilder
          */
         virtual
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double value) const = 0;
@@ -108,7 +108,7 @@ namespace WorldBuilder
          */
         virtual
         WorldBuilder::grains grains(const Point<3> &position,
-                                    const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                                    const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                                     const double depth,
                                     const unsigned int composition_number,
                                     WorldBuilder::grains value) const = 0;

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -87,7 +87,7 @@ namespace WorldBuilder
          */
         virtual
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const = 0;
@@ -97,7 +97,7 @@ namespace WorldBuilder
          */
         virtual
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double value) const = 0;
@@ -108,7 +108,7 @@ namespace WorldBuilder
          */
         virtual
         WorldBuilder::grains grains(const Point<3> &position,
-                                    const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                                    const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                                     const double depth,
                                     const unsigned int composition_number,
                                     WorldBuilder::grains value) const = 0;

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -86,7 +86,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -99,7 +99,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition) const override final;
@@ -114,7 +114,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+               const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -86,7 +86,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -99,7 +99,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition) const override final;
@@ -114,7 +114,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -86,7 +86,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -99,7 +99,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition) const override final;
@@ -114,7 +114,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+               const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -86,7 +86,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -99,7 +99,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition) const override final;
@@ -114,7 +114,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -89,7 +89,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -102,7 +102,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+                           const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition_value) const override final;
@@ -116,7 +116,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
+               const WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -89,7 +89,7 @@ namespace WorldBuilder
          * gravity and current temperature.
          */
         double temperature(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const double gravity,
                            double temperature) const override final;
@@ -102,7 +102,7 @@ namespace WorldBuilder
          * of that composition at this location and depth.
          */
         double composition(const Point<3> &position,
-                           const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+                           const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                            const double depth,
                            const unsigned int composition_number,
                            double composition_value) const override final;
@@ -116,7 +116,7 @@ namespace WorldBuilder
 
         WorldBuilder::grains
         grains(const Point<3> &position,
-               const  WorldBuilder::Utilities::NaturalCoordinate &natural_coordinate,
+               const  WorldBuilder::Utilities::NaturalCoordinate &position_in_natural_coordinates,
                const double depth,
                const unsigned int composition_number,
                WorldBuilder::grains grains) const override final;

--- a/source/features/continental_plate.cc
+++ b/source/features/continental_plate.cc
@@ -135,7 +135,7 @@ namespace WorldBuilder
 
     double
     ContinentalPlate::temperature(const Point<3> &position,
-                                  const  NaturalCoordinate &natural_coordinate,
+                                  const NaturalCoordinate &natural_coordinate,
                                   const double depth,
                                   const double gravity_norm,
                                   double temperature) const
@@ -166,7 +166,7 @@ namespace WorldBuilder
 
     double
     ContinentalPlate::composition(const Point<3> &position,
-                                  const  NaturalCoordinate &natural_coordinate,
+                                  const NaturalCoordinate &natural_coordinate,
                                   const double depth,
                                   const unsigned int composition_number,
                                   double composition) const
@@ -198,7 +198,7 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     ContinentalPlate::grains(const Point<3> &position,
-                             const  NaturalCoordinate &natural_coordinate,
+                             const NaturalCoordinate &natural_coordinate,
                              const double depth,
                              const unsigned int composition_number,
                              WorldBuilder::grains grains) const

--- a/source/features/continental_plate.cc
+++ b/source/features/continental_plate.cc
@@ -135,13 +135,13 @@ namespace WorldBuilder
 
     double
     ContinentalPlate::temperature(const Point<3> &position,
-                                  const NaturalCoordinate &natural_coordinate,
+                                  const NaturalCoordinate &position_in_natural_coordinates,
                                   const double depth,
                                   const double gravity_norm,
                                   double temperature) const
     {
       if (depth <= max_depth && depth >= min_depth &&
-          Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+          Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
                                                                   world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (const auto &temperature_model: temperature_models)
@@ -166,14 +166,14 @@ namespace WorldBuilder
 
     double
     ContinentalPlate::composition(const Point<3> &position,
-                                  const NaturalCoordinate &natural_coordinate,
+                                  const NaturalCoordinate &position_in_natural_coordinates,
                                   const double depth,
                                   const unsigned int composition_number,
                                   double composition) const
     {
 
       if (depth <= max_depth && depth >= min_depth &&
-          Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+          Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
                                                                   world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (const auto &composition_model: composition_models)
@@ -198,14 +198,14 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     ContinentalPlate::grains(const Point<3> &position,
-                             const NaturalCoordinate &natural_coordinate,
+                             const NaturalCoordinate &position_in_natural_coordinates,
                              const double depth,
                              const unsigned int composition_number,
                              WorldBuilder::grains grains) const
     {
 
       if (depth <= max_depth && depth >= min_depth &&
-          Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+          Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
                                                                   world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (const auto &grains_model: grains_models)

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -330,7 +330,7 @@ namespace WorldBuilder
 
     double
     Fault::temperature(const Point<3> &position,
-                       const  NaturalCoordinate &natural_coordinate,
+                       const NaturalCoordinate &natural_coordinate,
                        const double depth,
                        const double gravity_norm,
                        double temperature) const
@@ -470,7 +470,7 @@ namespace WorldBuilder
 
     double
     Fault::composition(const Point<3> &position,
-                       const  NaturalCoordinate &natural_coordinate,
+                       const NaturalCoordinate &natural_coordinate,
                        const double depth,
                        const unsigned int composition_number,
                        double composition) const
@@ -604,7 +604,7 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     Fault::grains(const Point<3> &position,
-                  const  NaturalCoordinate &natural_coordinate,
+                  const NaturalCoordinate &natural_coordinate,
                   const double depth,
                   const unsigned int composition_number,
                   WorldBuilder::grains grains) const

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -330,7 +330,7 @@ namespace WorldBuilder
 
     double
     Fault::temperature(const Point<3> &position,
-                       const NaturalCoordinate &natural_coordinate,
+                       const NaturalCoordinate &position_in_natural_coordinates,
                        const double depth,
                        const double gravity_norm,
                        double temperature) const
@@ -338,11 +338,11 @@ namespace WorldBuilder
       // The depth variable is the distance from the surface to the position, the depth
       // coordinate is the distance from the bottom of the model to the position and
       // the starting radius is the distance from the bottom of the model to the surface.
-      const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
+      const double starting_radius = position_in_natural_coordinates.get_depth_coordinate() + depth - starting_depth;
 
       WBAssert(std::abs(starting_radius) > std::numeric_limits<double>::epsilon(), "World Builder error: starting_radius can not be zero. "
                << "Position = " << position[0] << ":" << position[1] << ":" << position[2]
-               << ", natural_coordinate.get_depth_coordinate() = " << natural_coordinate.get_depth_coordinate()
+               << ", position_in_natural_coordinates.get_depth_coordinate() = " << position_in_natural_coordinates.get_depth_coordinate()
                << ", depth = " << depth
                << ", starting_depth " << starting_depth
               );
@@ -355,7 +355,7 @@ namespace WorldBuilder
           // the fault to be centered around the line provided by the user.
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
-                                                                       natural_coordinate,
+                                                                       position_in_natural_coordinates,
                                                                        reference_point,
                                                                        coordinates,
                                                                        fault_segment_lengths,
@@ -470,13 +470,13 @@ namespace WorldBuilder
 
     double
     Fault::composition(const Point<3> &position,
-                       const NaturalCoordinate &natural_coordinate,
+                       const NaturalCoordinate &position_in_natural_coordinates,
                        const double depth,
                        const unsigned int composition_number,
                        double composition) const
     {
       // todo: explain
-      const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
+      const double starting_radius = position_in_natural_coordinates.get_depth_coordinate() + depth - starting_depth;
 
       // todo: explain and check -starting_depth
       if (depth <= maximum_depth && depth >= starting_depth && depth <= maximum_total_fault_length + maximum_fault_thickness)
@@ -486,7 +486,7 @@ namespace WorldBuilder
           // the fault to be centered around the line provided by the user.
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
-                                                                       natural_coordinate,
+                                                                       position_in_natural_coordinates,
                                                                        reference_point,
                                                                        coordinates,
                                                                        fault_segment_lengths,
@@ -604,13 +604,13 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     Fault::grains(const Point<3> &position,
-                  const NaturalCoordinate &natural_coordinate,
+                  const NaturalCoordinate &position_in_natural_coordinates,
                   const double depth,
                   const unsigned int composition_number,
                   WorldBuilder::grains grains) const
     {
       // todo: explain
-      const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
+      const double starting_radius = position_in_natural_coordinates.get_depth_coordinate() + depth - starting_depth;
 
       // todo: explain and check -starting_depth
       if (depth <= maximum_depth && depth >= starting_depth && depth <= maximum_total_fault_length + maximum_fault_thickness)
@@ -620,7 +620,7 @@ namespace WorldBuilder
           // the fault to be centered around the line provided by the user.
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
-                                                                       natural_coordinate,
+                                                                       position_in_natural_coordinates,
                                                                        reference_point,
                                                                        coordinates,
                                                                        fault_segment_lengths,

--- a/source/features/mantle_layer.cc
+++ b/source/features/mantle_layer.cc
@@ -128,7 +128,7 @@ namespace WorldBuilder
 
     double
     MantleLayer::temperature(const Point<3> &position,
-                             const  NaturalCoordinate &natural_coordinate,
+                             const NaturalCoordinate &natural_coordinate,
                              const double depth,
                              const double gravity_norm,
                              double temperature) const
@@ -159,7 +159,7 @@ namespace WorldBuilder
 
     double
     MantleLayer::composition(const Point<3> &position,
-                             const  NaturalCoordinate &natural_coordinate,
+                             const NaturalCoordinate &natural_coordinate,
                              const double depth,
                              const unsigned int composition_number,
                              double composition) const
@@ -192,7 +192,7 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     MantleLayer::grains(const Point<3> &position,
-                        const  NaturalCoordinate &natural_coordinate,
+                        const NaturalCoordinate &natural_coordinate,
                         const double depth,
                         const unsigned int composition_number,
                         WorldBuilder::grains grains) const

--- a/source/features/mantle_layer.cc
+++ b/source/features/mantle_layer.cc
@@ -128,13 +128,13 @@ namespace WorldBuilder
 
     double
     MantleLayer::temperature(const Point<3> &position,
-                             const NaturalCoordinate &natural_coordinate,
+                             const NaturalCoordinate &position_in_natural_coordinates,
                              const double depth,
                              const double gravity_norm,
                              double temperature) const
     {
       if (depth <= max_depth && depth >= min_depth &&
-          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (const auto &temperature_model: temperature_models)
@@ -159,13 +159,13 @@ namespace WorldBuilder
 
     double
     MantleLayer::composition(const Point<3> &position,
-                             const NaturalCoordinate &natural_coordinate,
+                             const NaturalCoordinate &position_in_natural_coordinates,
                              const double depth,
                              const unsigned int composition_number,
                              double composition) const
     {
       if (depth <= max_depth && depth >= min_depth &&
-          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (const auto &composition_model: composition_models)
@@ -192,13 +192,13 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     MantleLayer::grains(const Point<3> &position,
-                        const NaturalCoordinate &natural_coordinate,
+                        const NaturalCoordinate &position_in_natural_coordinates,
                         const double depth,
                         const unsigned int composition_number,
                         WorldBuilder::grains grains) const
     {
       if (depth <= max_depth && depth >= min_depth &&
-          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (const auto &grains_model: grains_models)

--- a/source/features/oceanic_plate.cc
+++ b/source/features/oceanic_plate.cc
@@ -132,7 +132,7 @@ namespace WorldBuilder
 
     double
     OceanicPlate::temperature(const Point<3> &position,
-                              const  NaturalCoordinate &natural_coordinate,
+                              const NaturalCoordinate &natural_coordinate,
                               const double depth,
                               const double gravity_norm,
                               double temperature) const
@@ -163,7 +163,7 @@ namespace WorldBuilder
 
     double
     OceanicPlate::composition(const Point<3> &position,
-                              const  NaturalCoordinate &natural_coordinate,
+                              const NaturalCoordinate &natural_coordinate,
                               const double depth,
                               const unsigned int composition_number,
                               double composition) const

--- a/source/features/oceanic_plate.cc
+++ b/source/features/oceanic_plate.cc
@@ -132,13 +132,13 @@ namespace WorldBuilder
 
     double
     OceanicPlate::temperature(const Point<3> &position,
-                              const NaturalCoordinate &natural_coordinate,
+                              const NaturalCoordinate &position_in_natural_coordinates,
                               const double depth,
                               const double gravity_norm,
                               double temperature) const
     {
       if (depth <= max_depth && depth >= min_depth &&
-          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (const auto &temperature_model: temperature_models)
@@ -163,13 +163,13 @@ namespace WorldBuilder
 
     double
     OceanicPlate::composition(const Point<3> &position,
-                              const NaturalCoordinate &natural_coordinate,
+                              const NaturalCoordinate &position_in_natural_coordinates,
                               const double depth,
                               const unsigned int composition_number,
                               double composition) const
     {
       if (depth <= max_depth && depth >= min_depth &&
-          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (const auto &composition_model: composition_models)
@@ -194,13 +194,13 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     OceanicPlate::grains(const Point<3> &position,
-                         const NaturalCoordinate &natural_coordinate,
+                         const NaturalCoordinate &position_in_natural_coordinates,
                          const double depth,
                          const unsigned int composition_number,
                          WorldBuilder::grains grains) const
     {
       if (depth <= max_depth && depth >= min_depth &&
-          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(natural_coordinate.get_surface_coordinates(),
+          WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
                                                                                 world->parameters.coordinate_system->natural_coordinate_system())))
         {
           for (const auto &grains_model: grains_models)

--- a/source/features/oceanic_plate_models/temperature/plate_model.cc
+++ b/source/features/oceanic_plate_models/temperature/plate_model.cc
@@ -113,8 +113,8 @@ namespace WorldBuilder
         {
           if (depth <= max_depth && depth >= min_depth)
             {
-              WorldBuilder::Utilities::NaturalCoordinate natural_coordinate = WorldBuilder::Utilities::NaturalCoordinate(position,
-                                                                              *(world->parameters.coordinate_system));
+              WorldBuilder::Utilities::NaturalCoordinate position_in_natural_coordinates = WorldBuilder::Utilities::NaturalCoordinate(position,
+                                                                                           *(world->parameters.coordinate_system));
 
 
               double bottom_temperature_local = bottom_temperature;
@@ -136,7 +136,7 @@ namespace WorldBuilder
                   const Point<2> segment_point0 = ridge_coordinates[i_ridge];
                   const Point<2> segment_point1 = ridge_coordinates[i_ridge+1];
 
-                  const Point<2> check_point(natural_coordinate.get_surface_coordinates(),natural_coordinate.get_coordinate_system());
+                  const Point<2> check_point(position_in_natural_coordinates.get_surface_coordinates(),position_in_natural_coordinates.get_coordinate_system());
                   // based on http://geomalgorithms.com/a02-_lines.html
                   const Point<2> v = segment_point1 - segment_point0;
                   const Point<2> w = check_point - segment_point0;
@@ -157,11 +157,11 @@ namespace WorldBuilder
 
                   Point<3> compare_point(coordinate_system);
 
-                  compare_point[0] = coordinate_system == cartesian ? Pb[0] :  natural_coordinate.get_depth_coordinate();
+                  compare_point[0] = coordinate_system == cartesian ? Pb[0] :  position_in_natural_coordinates.get_depth_coordinate();
                   compare_point[1] = coordinate_system == cartesian ? Pb[1] : Pb[0];
-                  compare_point[2] = coordinate_system == cartesian ? natural_coordinate.get_depth_coordinate() : Pb[1];
+                  compare_point[2] = coordinate_system == cartesian ? position_in_natural_coordinates.get_depth_coordinate() : Pb[1];
 
-                  distance_ridge = std::min(distance_ridge,this->world->parameters.coordinate_system->distance_between_points_at_same_depth(Point<3>(natural_coordinate.get_coordinates(),natural_coordinate.get_coordinate_system()),compare_point));
+                  distance_ridge = std::min(distance_ridge,this->world->parameters.coordinate_system->distance_between_points_at_same_depth(Point<3>(position_in_natural_coordinates.get_coordinates(),position_in_natural_coordinates.get_coordinate_system()),compare_point));
 
                 }
 

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -334,7 +334,7 @@ namespace WorldBuilder
 
     double
     SubductingPlate::temperature(const Point<3> &position,
-                                 const  NaturalCoordinate &natural_coordinate,
+                                 const NaturalCoordinate &natural_coordinate,
                                  const double depth,
                                  const double gravity_norm,
                                  double temperature) const
@@ -480,7 +480,7 @@ namespace WorldBuilder
 
     double
     SubductingPlate::composition(const Point<3> &position,
-                                 const  NaturalCoordinate &natural_coordinate,
+                                 const NaturalCoordinate &natural_coordinate,
                                  const double depth,
                                  const unsigned int composition_number,
                                  double composition) const
@@ -611,7 +611,7 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     SubductingPlate::grains(const Point<3> &position,
-                            const  NaturalCoordinate &natural_coordinate,
+                            const NaturalCoordinate &natural_coordinate,
                             const double depth,
                             const unsigned int composition_number,
                             WorldBuilder::grains grains) const

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -334,7 +334,7 @@ namespace WorldBuilder
 
     double
     SubductingPlate::temperature(const Point<3> &position,
-                                 const NaturalCoordinate &natural_coordinate,
+                                 const NaturalCoordinate &position_in_natural_coordinates,
                                  const double depth,
                                  const double gravity_norm,
                                  double temperature) const
@@ -342,11 +342,11 @@ namespace WorldBuilder
       // The depth variable is the distance from the surface to the position, the depth
       // coordinate is the distance from the bottom of the model to the position and
       // the starting radius is the distance from the bottom of the model to the surface.
-      const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
+      const double starting_radius = position_in_natural_coordinates.get_depth_coordinate() + depth - starting_depth;
 
       WBAssert(std::abs(starting_radius) > std::numeric_limits<double>::epsilon(), "World Builder error: starting_radius can not be zero. "
                << "Position = " << position[0] << ":" << position[1] << ":" << position[2]
-               << ", natural_coordinate.get_depth_coordinate() = " << natural_coordinate.get_depth_coordinate()
+               << ", position_in_natural_coordinates.get_depth_coordinate() = " << position_in_natural_coordinates.get_depth_coordinate()
                << ", depth = " << depth
                << ", starting_depth " << starting_depth
               );
@@ -366,7 +366,7 @@ namespace WorldBuilder
           // todo: explain
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
-                                                                       natural_coordinate,
+                                                                       position_in_natural_coordinates,
                                                                        reference_point,
                                                                        coordinates,
                                                                        slab_segment_lengths,
@@ -480,13 +480,13 @@ namespace WorldBuilder
 
     double
     SubductingPlate::composition(const Point<3> &position,
-                                 const NaturalCoordinate &natural_coordinate,
+                                 const NaturalCoordinate &position_in_natural_coordinates,
                                  const double depth,
                                  const unsigned int composition_number,
                                  double composition) const
     {
       // todo: explain
-      const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
+      const double starting_radius = position_in_natural_coordinates.get_depth_coordinate() + depth - starting_depth;
 
       // todo: explain and check -starting_depth
       if (depth <= maximum_depth && depth >= starting_depth && depth <= maximum_total_slab_length + maximum_slab_thickness)
@@ -494,7 +494,7 @@ namespace WorldBuilder
           // todo: explain
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
-                                                                       natural_coordinate,
+                                                                       position_in_natural_coordinates,
                                                                        reference_point,
                                                                        coordinates,
                                                                        slab_segment_lengths,
@@ -611,13 +611,13 @@ namespace WorldBuilder
 
     WorldBuilder::grains
     SubductingPlate::grains(const Point<3> &position,
-                            const NaturalCoordinate &natural_coordinate,
+                            const NaturalCoordinate &position_in_natural_coordinates,
                             const double depth,
                             const unsigned int composition_number,
                             WorldBuilder::grains grains) const
     {
       // todo: explain
-      const double starting_radius = natural_coordinate.get_depth_coordinate() + depth - starting_depth;
+      const double starting_radius = position_in_natural_coordinates.get_depth_coordinate() + depth - starting_depth;
 
       // todo: explain and check -starting_depth
       if (depth <= maximum_depth && depth >= starting_depth && depth <= maximum_total_slab_length + maximum_slab_thickness)
@@ -625,7 +625,7 @@ namespace WorldBuilder
           // todo: explain
           WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
             WorldBuilder::Utilities::distance_point_from_curved_planes(position,
-                                                                       natural_coordinate,
+                                                                       position_in_natural_coordinates,
                                                                        reference_point,
                                                                        coordinates,
                                                                        slab_segment_lengths,


### PR DESCRIPTION
Make it clear that one variable is the same as another variable, just expressed in a different coordinate system. Should I also rename `position` to `position_in_cartesian_coordinates`?