### PR TITLE
Avoid using namespace to set config variables

### DIFF
--- a/source/config.cc.in
+++ b/source/config.cc.in
@@ -19,17 +19,17 @@
 
 #include "world_builder/config.h"
 
-using namespace WorldBuilder;
+namespace WorldBuilder
+{
+  const std::string Version::MAJOR = "@WORLD_BUILDER_VERSION_MAJOR@";
+  const std::string Version::MINOR = "@WORLD_BUILDER_VERSION_MINOR@";
+  const std::string Version::PATCH = "@WORLD_BUILDER_VERSION_PATCH@";
+  const std::string Version::LABEL = "@WORLD_BUILDER_VERSION_LABEL@";
 
-const std::string Version::MAJOR = "@WORLD_BUILDER_VERSION_MAJOR@";
-const std::string Version::MINOR = "@WORLD_BUILDER_VERSION_MINOR@";
-const std::string Version::PATCH = "@WORLD_BUILDER_VERSION_PATCH@";
-const std::string Version::LABEL = "@WORLD_BUILDER_VERSION_LABEL@";
+  const std::string Version::GIT_SHA1 = "@GIT_SHA1@";
+  const std::string Version::GIT_BRANCH = "@GIT_BRANCH@";
+  const std::string Version::GIT_DATE = "@GIT_DATE@";
+  const std::string Version::GIT_COMMIT_SUBJECT = "@GIT_COMMIT_SUBJECT@";
 
-const std::string Version::GIT_SHA1 = "@GIT_SHA1@";
-const std::string Version::GIT_BRANCH = "@GIT_BRANCH@";
-const std::string Version::GIT_DATE = "@GIT_DATE@";
-const std::string Version::GIT_COMMIT_SUBJECT = "@GIT_COMMIT_SUBJECT@";
-
-const std::string Data::WORLD_BUILDER_SOURCE_DIR = "@WORLD_BUILDER_SOURCE_DIR@"; 
-
+  const std::string Data::WORLD_BUILDER_SOURCE_DIR = "@WORLD_BUILDER_SOURCE_DIR@";
+}


### PR DESCRIPTION
I think this is the cleaner way to set these config variables. It usually does not matter much, except for unity builds, where the `using WorldBuilder` introduces all world builder names into the top namespace, which can lead to problems in downstream codes (see https://github.com/geodynamics/aspect/pull/4138). I hope nothing in world builder relies on this using statement, but it should not, because it is in a .cc file, not a header.