### PR TITLE
Remove an operator that is mathematically not well defined.

### DIFF
--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -417,17 +417,5 @@ namespace WorldBuilder
   {
     return point*scalar;
   }
-
-  template<int dim>
-  inline
-  Point<dim> operator/(const double scalar, const Point<dim> &point)
-  {
-    // initialize the array to zero.
-    std::array<double,dim> array = Point<dim>(point.coordinate_system).get_array();
-    for (unsigned int i = 0; i < dim; ++i)
-      array[i] = scalar / point[i];
-    return Point<dim>(array,point.coordinate_system);
-  }
-
 } // namespace WorldBuilder
 #endif


### PR DESCRIPTION
This is an operator of that would support the operation `3.141 / point`, but that is mathematically not well defined: We can divide a vector by a number, but we can't divide a number by a vector.

It turns out that this operator is (unsurprisingly) not actually used in WorldBuilder at the moment.