### PR TITLE
WIP: remove non contiuous option from distance point from curved planes [v2]

### DIFF
--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -194,7 +194,7 @@ namespace WorldBuilder
         /**
          * x coordinates of points
          */
-        std::vector<double> m_x;
+        size_t mx_size_min;
 
         /**
          * interpolation parameters
@@ -347,10 +347,9 @@ namespace WorldBuilder
                                                                     const double start_radius,
                                                                     const std::unique_ptr<CoordinateSystems::Interface> &coordinate_system,
                                                                     const bool only_positive,
-                                                                    const InterpolationType interpolation_type,
                                                                     const interpolation &x_spline,
                                                                     const interpolation &y_spline,
-                                                                    std::vector<double> global_x_list = {});
+                                                                    const double max_surface_distance = INFINITY);
 
 
 

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -182,8 +182,7 @@ namespace WorldBuilder
          * @param y Values in the interpolation points.
          * @param monotone_spline Whether to construct a monotone cubic spline or just do linear interpolation.
          */
-        void set_points(const std::vector<double> &x,
-                        const std::vector<double> &y,
+        void set_points(const std::vector<double> &y,
                         const bool monotone_spline = false);
         /**
          * Evaluate at point @p x.

--- a/source/features/fault.cc
+++ b/source/features/fault.cc
@@ -431,15 +431,13 @@ namespace WorldBuilder
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
                                                                        true,
-                                                                       interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
@@ -568,15 +566,13 @@ namespace WorldBuilder
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
                                                                        true,
-                                                                       interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment;
           //const size_t next_segment = current_segment + 1;
@@ -707,15 +703,13 @@ namespace WorldBuilder
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
                                                                        true,
-                                                                       interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment;
           //const size_t next_segment = current_segment + 1;

--- a/source/features/interface.cc
+++ b/source/features/interface.cc
@@ -138,12 +138,6 @@ namespace WorldBuilder
       // the one_dimensional_coordinates is always needed, so fill it.
       original_number_of_coordinates = coordinates.size();
 
-      std::vector<double> one_dimensional_coordinates_local(original_number_of_coordinates,0.0);
-      for (size_t j=0; j<original_number_of_coordinates; ++j)
-        {
-          one_dimensional_coordinates_local[j] = static_cast<double>(j);
-        }
-
       double maximum_distance_between_coordinates = this->world->maximum_distance_between_coordinates *
                                                     (coordinate_system == CoordinateSystem::spherical ? const_pi / 180.0 : 1.0);
 
@@ -159,11 +153,9 @@ namespace WorldBuilder
           y_list[j] = coordinates[j][1];
         }
 
-      x_spline.set_points(one_dimensional_coordinates_local,
-                          x_list,
+      x_spline.set_points(x_list,
                           interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear);
-      y_spline.set_points(one_dimensional_coordinates_local,
-                          y_list,
+      y_spline.set_points(y_list,
                           interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear);
     }
 

--- a/source/features/interface.cc
+++ b/source/features/interface.cc
@@ -144,64 +144,27 @@ namespace WorldBuilder
           one_dimensional_coordinates_local[j] = static_cast<double>(j);
         }
 
-      if (interpolation_type != WorldBuilder::Utilities::InterpolationType::None)
+      double maximum_distance_between_coordinates = this->world->maximum_distance_between_coordinates *
+                                                    (coordinate_system == CoordinateSystem::spherical ? const_pi / 180.0 : 1.0);
+
+
+      // I don't think this is usefull for continuous monotone spline, although it might
+      // help in a spherical case like for the linear case.
+      std::vector<double> x_list(original_number_of_coordinates,0.0);
+      std::vector<double> y_list(original_number_of_coordinates,0.0);
+      std::vector<Point<2> > coordinate_list_local = coordinates;
+      for (size_t j=0; j<original_number_of_coordinates; ++j)
         {
-          WBAssert(interpolation_type == WorldBuilder::Utilities::InterpolationType::Linear ||
-                   interpolation_type == WorldBuilder::Utilities::InterpolationType::MonotoneSpline ||
-                   interpolation_type == WorldBuilder::Utilities::InterpolationType::ContinuousMonotoneSpline,
-                   "For interpolation, linear and monotone spline are the only allowed values. "
-                   << "You provided " << interpolation_type_string << '.');
-
-          double maximum_distance_between_coordinates = this->world->maximum_distance_between_coordinates *
-                                                        (coordinate_system == CoordinateSystem::spherical ? const_pi / 180.0 : 1.0);
-
-
-          // I don't think this is usefull for continuous monotone spline, although it might
-          // help in a spherical case like for the linear case.
-          std::vector<double> x_list(original_number_of_coordinates,0.0);
-          std::vector<double> y_list(original_number_of_coordinates,0.0);
-          std::vector<Point<2> > coordinate_list_local = coordinates;
-          for (size_t j=0; j<original_number_of_coordinates; ++j)
-            {
-              x_list[j] = coordinates[j][0];
-              y_list[j] = coordinates[j][1];
-            }
-
-          x_spline.set_points(one_dimensional_coordinates_local,
-                              x_list,
-                              interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear);
-          y_spline.set_points(one_dimensional_coordinates_local,
-                              y_list,
-                              interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear);
-
-          if (maximum_distance_between_coordinates > 0 && interpolation_type != WorldBuilder::Utilities::InterpolationType::ContinuousMonotoneSpline)
-            {
-              size_t additional_parts = 0;
-              for (size_t i_plane=0; i_plane<original_number_of_coordinates-1; ++i_plane)
-                {
-                  const Point<2> P1 (x_spline(one_dimensional_coordinates_local[i_plane + additional_parts]),
-                                     y_spline(one_dimensional_coordinates_local[i_plane + additional_parts]),
-                                     coordinate_system);
-
-                  const Point<2> P2 (x_spline(one_dimensional_coordinates_local[i_plane + additional_parts + 1]),
-                                     y_spline(one_dimensional_coordinates_local[i_plane  + additional_parts+ 1]),
-                                     coordinate_system);
-
-                  const double length = (P1 - P2).norm();
-                  const size_t parts = static_cast<size_t>(std::ceil(length / maximum_distance_between_coordinates));
-                  for (size_t j = 1; j < parts; j++)
-                    {
-                      const double x_position3 = static_cast<double>(i_plane) + static_cast<double>(j)/static_cast<double>(parts);
-                      const Point<2> P3(x_spline(x_position3), y_spline(x_position3), coordinate_system);
-                      one_dimensional_coordinates_local.insert(one_dimensional_coordinates_local.begin() + static_cast<std::vector<double>::difference_type>(additional_parts + i_plane + 1), x_position3);
-                      coordinate_list_local.insert(coordinate_list_local.begin() + static_cast<std::vector<double>::difference_type>(additional_parts + i_plane + 1), P3);
-                      additional_parts++;
-                    }
-                }
-              coordinates = coordinate_list_local;
-            }
+          x_list[j] = coordinates[j][0];
+          y_list[j] = coordinates[j][1];
         }
-      one_dimensional_coordinates = one_dimensional_coordinates_local;
+
+      x_spline.set_points(one_dimensional_coordinates_local,
+                          x_list,
+                          interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear);
+      y_spline.set_points(one_dimensional_coordinates_local,
+                          y_list,
+                          interpolation_type != WorldBuilder::Utilities::InterpolationType::Linear);
     }
 
 

--- a/source/features/subducting_plate.cc
+++ b/source/features/subducting_plate.cc
@@ -449,15 +449,13 @@ namespace WorldBuilder
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
                                                                        false,
-                                                                       interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
@@ -581,15 +579,13 @@ namespace WorldBuilder
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
                                                                        false,
-                                                                       interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;
@@ -716,15 +712,13 @@ namespace WorldBuilder
                                                                        starting_radius,
                                                                        this->world->parameters.coordinate_system,
                                                                        false,
-                                                                       interpolation_type,
                                                                        this->x_spline,
-                                                                       this->y_spline,
-                                                                       one_dimensional_coordinates);
+                                                                       this->y_spline);
 
           const double distance_from_plane = distance_from_planes.distance_from_plane;
           const double distance_along_plane = distance_from_planes.distance_along_plane;
           const double section_fraction = distance_from_planes.fraction_of_section;
-          const size_t current_section = static_cast<size_t>(std::floor(one_dimensional_coordinates[distance_from_planes.section]));
+          const size_t current_section = distance_from_planes.section;
           const size_t next_section = current_section + 1;
           const size_t current_segment = distance_from_planes.segment; // the original value was a unsigned in, converting it back.
           //const size_t next_segment = current_segment + 1;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -405,7 +405,7 @@ namespace WorldBuilder
 
       double min_distance_check_point_surface_2d_line = std::numeric_limits<double>::infinity();
       size_t i_section_min_distance = 0;
-      Point<2> closest_point_on_line_2d(NaN::DSNAN,NaN::DSNAN,natural_coordinate_system);
+      Point<2> closest_point_on_line_2d(0,0,natural_coordinate_system);
       Point<2> closest_point_on_line_2d_temp(0,0,natural_coordinate_system);
       double fraction_CPL_P1P2_strict =  std::numeric_limits<double>::infinity(); // or NAN?
       double fraction_CPL_P1P2 = std::numeric_limits<double>::infinity();
@@ -476,6 +476,14 @@ namespace WorldBuilder
                                                        bool_cartesian ? start_radius : closest_point_on_line_2d[1],
                                                        natural_coordinate_system);
 
+          WBAssert(!std::isnan(closest_point_on_line_surface[0])
+                   &&
+                   !std::isnan(closest_point_on_line_surface[1])
+                   &&
+                   !std::isnan(closest_point_on_line_surface[2]),
+                   "Internal error: The closest_point_on_line_bottom variables contains not a number: " << closest_point_on_line_surface 
+                   << ", closest_point_on_line_2d = " << closest_point_on_line_2d);
+
       Point<3> closest_point_on_line_cartesian(coordinate_system->natural_to_cartesian_coordinates(closest_point_on_line_surface.get_array()),cartesian);
 
 
@@ -490,11 +498,11 @@ namespace WorldBuilder
           closest_point_on_line_bottom[bool_cartesian ? 2 : 0] = 0;
 
           WBAssert(!std::isnan(closest_point_on_line_bottom[0])
-                   ||
+                   &&
                    !std::isnan(closest_point_on_line_bottom[1])
-                   ||
+                   &&
                    !std::isnan(closest_point_on_line_bottom[2]),
-                   "Internal error: The y_axis variable contains not a number: " << closest_point_on_line_bottom);
+                   "Internal error: The closest_point_on_line_bottom variables contains not a number: " << closest_point_on_line_bottom);
 
           // Now that we have both the check point and the
           // closest_point_on_line, we need to push them to cartesian.
@@ -503,11 +511,11 @@ namespace WorldBuilder
 
 
           WBAssert(!std::isnan(closest_point_on_line_bottom_cartesian[0]),
-                   "Internal error: The y_axis variable is not a number: " << closest_point_on_line_bottom_cartesian[0]);
+                   "Internal error: The closest_point_on_line_bottom_cartesian[0] variable is not a number: " << closest_point_on_line_bottom_cartesian[0]);
           WBAssert(!std::isnan(closest_point_on_line_bottom_cartesian[1]),
-                   "Internal error: The y_axis variable is not a number: " << closest_point_on_line_bottom_cartesian[1]);
+                   "Internal error: The closest_point_on_line_bottom_cartesian[1] variable is not a number: " << closest_point_on_line_bottom_cartesian[1]);
           WBAssert(!std::isnan(closest_point_on_line_bottom_cartesian[2]),
-                   "Internal error: The y_axis variable is not a number: " << closest_point_on_line_bottom_cartesian[2]);
+                   "Internal error: The closest_point_on_line_bottom_cartesian[2] variable is not a number: " << closest_point_on_line_bottom_cartesian[2]);
 
 
           // translate to orignal coordinates current and next section

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -485,9 +485,9 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   CHECK(monotone_cubic_spline_x(1.75) == Approx(6.484375));
   CHECK(monotone_cubic_spline_x(2) == Approx(5.0));
   CHECK(monotone_cubic_spline_x(2.25) == Approx(3.75));
-  CHECK(monotone_cubic_spline_x(2.125) == Approx(2.5));
+  CHECK(monotone_cubic_spline_x(2.5) == Approx(2.5));
   CHECK(monotone_cubic_spline_x(2.75) == Approx(1.25));
-  CHECK(monotone_cubic_spline_x(2.25) == Approx(0));
+  CHECK(monotone_cubic_spline_x(3) == Approx(0));
 
   CHECK(monotone_cubic_spline_y(0) == Approx(0));
   CHECK(monotone_cubic_spline_y(0.25) == Approx(0.546875));

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -345,9 +345,8 @@ TEST_CASE("WorldBuilder Utilities: string to conversions")
 TEST_CASE("WorldBuilder Utilities: interpolation")
 {
   Utilities::interpolation linear;
-  std::vector<double> x = {{0,1,2,3}};
   std::vector<double> y = {{10,5,5,35}};
-  linear.set_points(x,y,false);
+  linear.set_points(y,false);
   CHECK(linear(-1.1) == Approx(15.5));
   CHECK(linear(-1) == Approx(15.0));
   CHECK(linear(-0.9) == Approx(14.5));
@@ -376,7 +375,7 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   CHECK(linear(3.375) == Approx(46.25));
 
   Utilities::interpolation monotone_cubic_spline;
-  monotone_cubic_spline.set_points(x,y,true);
+  monotone_cubic_spline.set_points(y,true);
 
   CHECK(monotone_cubic_spline(-1) == Approx(-5));
   CHECK(monotone_cubic_spline(-0.9) == Approx(-2.15));
@@ -419,7 +418,7 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   Utilities::interpolation monotone_cubic_spline2;
   y[1] = -5;
   y[3] = -35;
-  monotone_cubic_spline2.set_points(x,y,true);
+  monotone_cubic_spline2.set_points(y,true);
   CHECK(monotone_cubic_spline2(-1) == Approx(-35));
   CHECK(monotone_cubic_spline2(-0.5) == Approx(-1.25));
   CHECK(monotone_cubic_spline2(0) == Approx(10));
@@ -443,7 +442,7 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   y[1] = -5;
   y[2] = -10;
   y[3] = -35;
-  monotone_cubic_spline3.set_points(x,y,true);
+  monotone_cubic_spline3.set_points(y,true);
   CHECK(monotone_cubic_spline3(-1) == Approx(-27.5));
   CHECK(monotone_cubic_spline3(-0.5) == Approx(0.625));
   CHECK(monotone_cubic_spline3(0) == Approx(10.0));
@@ -465,20 +464,16 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   // bi monotone cubic spline
   Utilities::interpolation monotone_cubic_spline_x;
   Utilities::interpolation monotone_cubic_spline_y;
-  x[0] = 0;
-  x[1] = 1;
-  x[2] = 2;
-  x[3] = 3;
   y[0] = 10;
   y[1] = 10;
   y[2] = 5;
   y[3] = 0;
-  monotone_cubic_spline_x.set_points(x,y,true);
+  monotone_cubic_spline_x.set_points(y,true);
   y[0] = 0;
   y[1] = 5;
   y[2] = 10;
   y[3] = 10;
-  monotone_cubic_spline_y.set_points(x,y,true);
+  monotone_cubic_spline_y.set_points(y,true);
 
   CHECK(monotone_cubic_spline_x(0) == Approx(10));
   CHECK(monotone_cubic_spline_x(0.25) == Approx(10));
@@ -490,9 +485,9 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   CHECK(monotone_cubic_spline_x(1.75) == Approx(6.484375));
   CHECK(monotone_cubic_spline_x(2) == Approx(5.0));
   CHECK(monotone_cubic_spline_x(2.25) == Approx(3.75));
-  CHECK(monotone_cubic_spline_x(2.5) == Approx(2.5));
+  CHECK(monotone_cubic_spline_x(2.125) == Approx(2.5));
   CHECK(monotone_cubic_spline_x(2.75) == Approx(1.25));
-  CHECK(monotone_cubic_spline_x(3) == Approx(0));
+  CHECK(monotone_cubic_spline_x(2.25) == Approx(0));
 
   CHECK(monotone_cubic_spline_y(0) == Approx(0));
   CHECK(monotone_cubic_spline_y(0.25) == Approx(0.546875));
@@ -504,9 +499,9 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   CHECK(monotone_cubic_spline_y(1.75) == Approx(9.453125));
   CHECK(monotone_cubic_spline_y(2) == Approx(10.0));
   CHECK(monotone_cubic_spline_y(2.25) == Approx(10.0));
-  CHECK(monotone_cubic_spline_y(2.5) == Approx(10.0));
+  CHECK(monotone_cubic_spline_y(2.125) == Approx(10.0));
   CHECK(monotone_cubic_spline_y(2.75) == Approx(10.0));
-  CHECK(monotone_cubic_spline_y(3) == Approx(10.0));
+  CHECK(monotone_cubic_spline_y(2.25) == Approx(10.0));
 }
 
 TEST_CASE("WorldBuilder Utilities: Point in polygon")
@@ -4843,11 +4838,9 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   std::vector<double> y_list = {10.,10.};
   std::vector<Point<2> > coordinate_list_local = coordinates;
 
-  x_spline.set_points({0,1},
-                      x_list,
+  x_spline.set_points(x_list,
                       interpolation_type_CMS != WorldBuilder::Utilities::InterpolationType::Linear);
-  y_spline.set_points({0,1},
-                      y_list,
+  y_spline.set_points(y_list,
                       interpolation_type_CMS != WorldBuilder::Utilities::InterpolationType::Linear);
 
 
@@ -4884,7 +4877,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type_CMS,
                                                  x_spline,
                                                  y_spline);
 
@@ -5095,7 +5087,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type_CMS,
                                                  x_spline,
                                                  y_spline);
 
@@ -5148,7 +5139,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type_CMS,
                                                  x_spline,
                                                  y_spline);
 

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -4861,7 +4861,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -4914,7 +4913,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -4941,7 +4939,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -4967,7 +4964,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -4995,7 +4991,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5022,7 +5017,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5050,7 +5044,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5077,7 +5070,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5131,7 +5123,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5189,7 +5180,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5218,7 +5208,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  true,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5246,7 +5235,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5274,7 +5262,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  true,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5311,7 +5298,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5347,7 +5333,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5374,7 +5359,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5401,7 +5385,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5449,7 +5432,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5476,7 +5458,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5503,7 +5484,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5532,7 +5512,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5562,7 +5541,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5589,7 +5567,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5616,7 +5593,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5645,7 +5621,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5673,7 +5648,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5700,7 +5674,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5727,7 +5700,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5756,7 +5728,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5846,7 +5817,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5874,7 +5844,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5902,7 +5871,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5931,7 +5899,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5959,7 +5926,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -5987,7 +5953,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6020,7 +5985,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6053,7 +6017,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6081,7 +6044,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6123,7 +6085,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6150,7 +6111,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6177,7 +6137,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6206,7 +6165,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6247,7 +6205,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6274,7 +6231,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6301,7 +6257,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6328,7 +6283,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6355,7 +6309,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6383,7 +6336,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6410,7 +6362,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6452,7 +6403,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6479,7 +6429,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6506,7 +6455,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6533,7 +6481,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6577,7 +6524,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6607,7 +6553,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6635,7 +6580,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6680,7 +6624,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6724,7 +6667,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6751,7 +6693,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6778,7 +6719,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6807,7 +6747,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6835,7 +6774,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6876,7 +6814,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6904,7 +6841,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6932,7 +6868,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6961,7 +6896,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -6991,7 +6925,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -7019,7 +6952,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -7047,7 +6979,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -7076,10 +7007,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,1,2});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
@@ -7104,10 +7033,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
@@ -7132,10 +7059,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
@@ -7160,10 +7085,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
@@ -7188,10 +7111,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-12);
@@ -7218,10 +7139,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  starting_radius,
                                                  cartesian_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
-                                                 y_spline,
-  {0,0.5,1});
+                                                 y_spline);
 
   CHECK(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   CHECK(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
@@ -7283,7 +7202,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  starting_radius,
                                                  world.parameters.coordinate_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -7311,7 +7229,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  starting_radius,
                                                  world.parameters.coordinate_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -7343,7 +7260,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  starting_radius,
                                                  world.parameters.coordinate_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -7370,7 +7286,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  starting_radius,
                                                  world.parameters.coordinate_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -7406,7 +7321,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  starting_radius,
                                                  world.parameters.coordinate_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -7432,7 +7346,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  starting_radius,
                                                  world.parameters.coordinate_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 
@@ -7470,7 +7383,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  starting_radius,
                                                  world.parameters.coordinate_system,
                                                  false,
-                                                 interpolation_type,
                                                  x_spline,
                                                  y_spline);
 


### PR DESCRIPTION
This is a replacement for #304, because I would like to cut that pull request up in multiple steps. It completely removes the option to interpolate coordinates in the feature interface. I don't think these kind of options should be available on that level, because already some options do not make sense for all features (continuous for continental plates). I have not removed the enum for the interpolation types, since I might want to make this kind of interpolation available again for the area features (oceanic/contineteal/... plates). For slabs and faults the only option left will be the continuous monotone spline. 

Todo:
- [ ] find what to do with the current top level interpolation type. I am thinking of removing it
- [ ] remove one dimensional coordinates from spline.

I am still doubting about these two todo's since they also have consequences for area features. For the slab and fault I have convinced myself that the continuous function is always the best. 

Also, I have not done my best to do optimalization here, but I have changed the `distance_point_from_curved_planes` such that there is already room for future optimizations.

@bangerth feel free to take a look at this. It should be much more readable than #304.