### PR TITLE
add depth of closest point on reference surface to struct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - The World Builder Visualizer can now compress vtu files with zlib and output in binary throught the vtu11 library. ASCII output is still avaiable.  \[Menno Fraters; 2021-06-26; [#282](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/282)\]
 - The option to use a half space cooling model for the temperature of an oceanic plate has been added to the oceanic plate feature. \[Magali Billen; 2021-07-15; [#317](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/317)\] 
+- Information about the depth of the reference surface in the PointDistanceFromCurvedPlanes structure. \[Menno Fraters; 2021-07-20; [#320](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/320)\]
 
 ### Changed
 - The World Builder Visualizer will now use zlib compression for vtu files by default. If zlib is not available binary output will be used. \[Menno Fraters; 2021-06-26; [#282](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/282)\]

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -303,6 +303,11 @@ namespace WorldBuilder
        */
       double average_angle;
 
+      /**
+       * The depth of the closest point on reference surface.
+       */
+      double depth_reference_surface;
+
       // This is unrelated and should not be stored in here, but some
       // plugins rely on this structure as temporary storage space.
       double local_thickness;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -467,6 +467,7 @@ namespace WorldBuilder
       double new_distance = INFINITY;
       double along_plane_distance = INFINITY;
       double new_along_plane_distance  = INFINITY;
+      double new_depth_reference_surface = INFINITY;
 
       const CoordinateSystem natural_coordinate_system = coordinate_system->natural_coordinate_system();
       const bool bool_cartesian = natural_coordinate_system == cartesian;
@@ -492,6 +493,7 @@ namespace WorldBuilder
       // point on the line is.
       double segment_fraction = 0.0;
       double total_average_angle = 0.0;
+      double depth_reference_surface = 0.0;
 
       const DepthMethod depth_method = coordinate_system->depth_method();
       WBAssertThrow(depth_method == DepthMethod::none
@@ -983,6 +985,7 @@ namespace WorldBuilder
                         {
                           new_distance = INFINITY;
                           new_along_plane_distance = INFINITY;
+                          new_depth_reference_surface = INFINITY;
                         }
                       else
                         {
@@ -993,6 +996,7 @@ namespace WorldBuilder
 
                           new_distance = side_of_line * (check_point_2d - Pb).norm();
                           new_along_plane_distance = (begin_segment - Pb).norm();
+                          new_depth_reference_surface = start_radius - Pb[1];
                         }
                     }
                 }
@@ -1125,6 +1129,8 @@ namespace WorldBuilder
                     {
                       new_distance = (radius_angle_circle - CPCR_norm) * (difference_in_angle_along_segment < 0 ? 1 : -1);
                       new_along_plane_distance = (radius_angle_circle * check_point_angle - radius_angle_circle * interpolated_angle_top) * (difference_in_angle_along_segment < 0 ? 1 : -1);
+                      // compute the new depth by rotating the begin point to the check point location.
+                      new_depth_reference_surface = start_radius-(sin(check_point_angle + interpolated_angle_top) * BSPC[0] + cos(check_point_angle + interpolated_angle_top) * BSPC[1] + center_circle[1]);
                     }
 
                 }
@@ -1152,6 +1158,7 @@ namespace WorldBuilder
                                          + 0.5 * (interpolated_angle_top + interpolated_angle_bottom  - 2 * add_angle) * new_along_plane_distance);
                   total_average_angle = (std::fabs(total_average_angle) < std::numeric_limits<double>::epsilon() ? 0 : total_average_angle /
                                          (total_length + new_along_plane_distance));
+                  depth_reference_surface = new_depth_reference_surface;
                 }
 
               // increase average angle
@@ -1172,6 +1179,7 @@ namespace WorldBuilder
       return_values.section = section;
       return_values.segment = segment;
       return_values.average_angle = total_average_angle;
+      return_values.depth_reference_surface = depth_reference_surface;
       return return_values;
     }
 

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -4685,6 +4685,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(10.0));
 
 
   // center square test 2
@@ -4710,6 +4711,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  CHECK(distance_from_planes.depth_reference_surface == Approx(0.0));
 
   // center square test 3
   position[1] = 20;
@@ -4735,6 +4737,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(10.0));
 
   // center square test 4
   reference_point[1] = 0;
@@ -4759,6 +4762,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  CHECK(distance_from_planes.depth_reference_surface == Approx(0.0));
 
   // center square test 5
   position[1] = -10;
@@ -4785,6 +4789,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(1.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(0.0707106781)); // practically zero
+  CHECK(distance_from_planes.depth_reference_surface == Approx(20.0));
 
   // begin section square test 6
   position[0] = 0;
@@ -4810,6 +4815,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(1.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(0.0707106781)); // practically zero
+  CHECK(distance_from_planes.depth_reference_surface == Approx(20.0));
 
 
   // end section square test 7
@@ -4836,6 +4842,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(1.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(0.0707106781)); // practically zero
+  CHECK(distance_from_planes.depth_reference_surface == Approx(20.0));
 
   // before begin section square test 8
   position[0] = -10;
@@ -4861,6 +4868,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  CHECK(distance_from_planes.depth_reference_surface == Approx(0.0));
 
   // beyond end section square test 9
   position[0] = 25;
@@ -4886,6 +4894,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  CHECK(distance_from_planes.depth_reference_surface == Approx(0.0));
 
 
   // beyond end section square test 10
@@ -4914,6 +4923,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(0.75));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(7.5));
 
   // beyond end section square test 10 (only positive version)
   position[0] = 10;
@@ -5255,6 +5265,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(0.0));
 
 
   // Now check the center of the second segment, each segment should have a length of 75.
@@ -5568,6 +5579,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(1.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(10.0));
 
   // curve test 2
   position[0] = 10;
@@ -5595,6 +5607,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(1.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(10.0));
 
   // curve test 3
   position[0] = 10;
@@ -5622,6 +5635,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(1.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(10.0));
 
 
   // curve test 4
@@ -5650,6 +5664,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(2.9289321881));
 
   // curve test 5
   position[0] = 10;
@@ -5677,6 +5692,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(2.9289321881));
 
   // curve test 6
   position[0] = 10;
@@ -5708,6 +5724,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(0.0));
 
 
   // curve test 7
@@ -5736,6 +5753,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(0.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(0.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(0.0));
 
   // curve test 8
   slab_segment_lengths[0][0] = 5 * 45 * dtr;
@@ -5768,6 +5786,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(1.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(1.0));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(5.0));
 
   // curve test 9
   position[0] = 10;
@@ -5891,6 +5910,7 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   CHECK(distance_from_planes.section == Approx(0.0));
   CHECK(distance_from_planes.segment == Approx(1.0));
   CHECK(distance_from_planes.fraction_of_segment == Approx(0.5));
+  CHECK(distance_from_planes.depth_reference_surface == Approx(17.0710678119));
 
 
   // curve test 13


### PR DESCRIPTION
Adding a variable in `PointDistanceFromCurvedPlanes` storing the depth of the closets point on the reference surface from the `distance_point_from_curved_planes` function. 


This functionality is needed for a better slab temperature being developed by @mibillen. 

I have tested it locally (see pictures), but will need to add tests to the unit tester.

![Screenshot from 2021-07-19 17-46-42](https://user-images.githubusercontent.com/7631629/126245497-1b75145f-3c09-442a-91fd-3602639b770a.png)
![Screenshot from 2021-07-19 17-46-16](https://user-images.githubusercontent.com/7631629/126245499-4417f868-d68e-4469-9384-c00b536613b9.png)