### PR TITLE
fix mass conserving distance calculation for spherical case.

### DIFF
--- a/source/features/subducting_plate_models/temperature/mass_conserving.cc
+++ b/source/features/subducting_plate_models/temperature/mass_conserving.cc
@@ -229,7 +229,7 @@ namespace WorldBuilder
                   compare_point[1] = coordinate_system == cartesian ? Pb[1] : Pb[0];
                   compare_point[2] = coordinate_system == cartesian ? trench_point_natural.get_depth_coordinate() : Pb[1];
 
-                  distance_ridge = std::min(distance_ridge, this->world->parameters.coordinate_system->distance_between_points_at_same_depth(trench_point, compare_point));
+                  distance_ridge = std::min(distance_ridge, this->world->parameters.coordinate_system->distance_between_points_at_same_depth(Point<3>(trench_point_natural.get_coordinates(),trench_point_natural.get_coordinate_system()), compare_point));
                 }
 
               const double age_at_trench = distance_ridge / plate_velocity; // yr


### PR DESCRIPTION
resolves #339. Thanks for reporting this @rfildes! It turns out that the mass conservative plugin tried to compare a cartesian with a spherical point. I guess the asserts checking this saved the day, because otherwise the results would have been incorrect and debugging this would have been a lot harder.

@mibillen, I will leave this open for a bit so you can have a look at it if you want.

Here is a figure of a working results from issue #339 
![mass_conservative_resolved](https://user-images.githubusercontent.com/7631629/137056113-6f3381d6-4ff1-4f23-acb1-44942a6885cf.png)

