### PR TITLE
Define model geometry extend in or to the world builder.

### DIFF
--- a/app/main.cc
+++ b/app/main.cc
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
       //try
       {
         std::string output_dir = wb_file.substr(0,wb_file.find_last_of("/\\") + 1);
-        world = std::make_unique<WorldBuilder::World>(wb_file, true, output_dir);
+        world = std::make_unique<WorldBuilder::World>(wb_file, INFINITY, true, output_dir);
       }
       /*catch (std::exception &e)
         {

--- a/examples/C/example.c
+++ b/examples/C/example.c
@@ -21,7 +21,7 @@ int main() {
 
   // Show how to call the functions.
   printf("create world \n");
-  create_world(&ptr_world, file_name, &has_output_dir, output_dir, random_number_seed);
+  create_world(&ptr_world, INFINITY, file_name, &has_output_dir, output_dir, random_number_seed);
 
   printf("2d temperature: \n");
   temperature_2d(ptr_world,x,z,depth,gravity,&temperature);

--- a/examples/fortran/example.f90
+++ b/examples/fortran/example.f90
@@ -4,7 +4,7 @@ use WorldBuilder
 IMPLICIT NONE
 
   ! Declare the types which will be needed.
-  REAL*8 :: temperature,x=120e3,y=500e3,z=0,depth=0,gravity = 10
+  REAL*8 :: temperature,x=120e3,y=500e3,z=0,depth=0,gravity = 10, max_model_depth
   INTEGER :: composition_number = 3
   INTEGER*8 :: random_number_seed = 1.0 !! use a random number seed larger than zero
   REAL*8 :: composition
@@ -12,8 +12,12 @@ IMPLICIT NONE
   logical(1) :: has_output_dir = .false.
   character(len=256) :: output_dir = "../../doc/manual/"//C_NULL_CHAR
 
+  IF (ieee_support_inf(max_model_depth)) THEN
+    max_model_depth = ieee_value(max_model_depth,  ieee_positive_inf)
+  END IF
+
   ! Show how to call the functions.
-  CALL create_world(cworld, file_name, has_output_dir, output_dir, random_number_seed)
+  CALL create_world(cworld, max_model_depth, file_name, has_output_dir, output_dir, random_number_seed)
 
   write(*, *) '2d temperature:'
   CALL temperature_2d(cworld,x,z,depth,gravity,temperature)

--- a/include/world_builder/coordinate_systems/cartesian.h
+++ b/include/world_builder/coordinate_systems/cartesian.h
@@ -101,6 +101,12 @@ namespace WorldBuilder
          */
         double distance_between_points_at_same_depth(const Point<3> &point_1, const Point<3> &point_2) const override final;
 
+        /**
+         * Returns the max model depth. This always returns infinity for Cartesian
+         * models.
+         */
+        virtual
+        double max_model_depth() const override final;
 
       private:
 

--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -107,6 +107,13 @@ namespace WorldBuilder
         double distance_between_points_at_same_depth(const Point<3> &point_1, const Point<3> &point_2) const = 0;
 
         /**
+         * Returns the max model depth. This should be the infinity for Cartesian
+         * models and the radius in spherical models.
+         */
+        virtual
+        double max_model_depth() const = 0;
+
+        /**
          * A function to register a new type. This is part of the automatic
          * registration of the object factory.
          */

--- a/include/world_builder/coordinate_systems/spherical.h
+++ b/include/world_builder/coordinate_systems/spherical.h
@@ -106,6 +106,13 @@ namespace WorldBuilder
         double distance_between_points_at_same_depth(const Point<3> &point_1, const Point<3> &point_2) const override final;
 
         /**
+         * Returns the max model depth. This returns the radius in spherical
+         * models.
+         */
+        virtual
+        double max_model_depth() const override final;
+
+        /**
          * What depth method the spherical coordinates use.
          */
         DepthMethod used_depth_method;

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -88,7 +88,9 @@ namespace WorldBuilder
        * \param has_output_dir A bool indicating whether the world builder may write out information.
        * \param output_dir A string with the path to the directory where it can output information if allowed by has_output_dir
        */
-      void initialize(std::string &filename, bool has_output_dir = false, const std::string &output_dir = "");
+      void initialize(std::string &filename,
+                      bool has_output_dir = false,
+                      const std::string &output_dir = "");
 
       /**
        * A generic get function to retrieve setting from the parameter file.

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -78,8 +78,17 @@ namespace WorldBuilder
 
       /**
        * read in the world builder file
+       * \param prm The Parameters structure to be parsed.
+       * \param max_model_depth This is the maximum model depth. For Cartesian models this
+       * should normally be infinity. For spherical models this should be the radius. For
+       * now infinity in spherical models with mean that the value is ignored, but this
+       * will become more strict in later in this version or in future versions. The current
+       * main purpose of this value is to make sure that the radius of the model is consistant
+       * between what is provided in the world builder (addition of this is planned) and what
+       * the calling program thinks the radius is.
        */
-      void parse_entries(Parameters &prm);
+      void parse_entries(Parameters &prm,
+                         const double max_model_depth);
 
       /**
        * Returns the temperature based on a 2d Cartesian point, the depth in the

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -42,6 +42,13 @@ namespace WorldBuilder
        * are optional.
        * \param filename  a string with the location of
        * the world builder file to initialize the world.
+       * \param max_model_depth This is the maximum model depth. For Cartesian models this
+       * should normally be infinity. For spherical models this should be the radius. For
+       * now infinity in spherical models with mean that the value is ignored, but this
+       * will become more strict in later in this version or in future versions. The current
+       * main purpose of this value is to make sure that the radius of the model is consistant
+       * between what is provided in the world builder (addition of this is planned) and what
+       * the calling program thinks the radius is.
        * \param has_output_dir a bool indicating whether the world builder is allowed to
        * write out information to a directly.
        * \param output_dir a string with the location of the directory where the world builder
@@ -56,7 +63,7 @@ namespace WorldBuilder
        * documented algorithm), we can test the results and they should be the same even for different
        * compilers and machines.
        */
-      World(std::string filename, bool has_output_dir = false, const std::string &output_dir = "", unsigned long random_number_seed = 1);
+      World(std::string filename, double max_model_depth=INFINITY, bool has_output_dir = false, const std::string &output_dir = "", unsigned long random_number_seed = 1);
 
       /**
        * Destructor

--- a/include/world_builder/wrapper_c.h
+++ b/include/world_builder/wrapper_c.h
@@ -31,7 +31,7 @@ extern "C" {
  * to it. This pointer can then be used to call the temperature and composition
  * functions. When done call the release world function to destroy the object.
  */
-void create_world(void **ptr_ptr_world, const char *world_builder_file, const bool *has_output_dir, const char *output_dir, const unsigned long random_number_seed);
+void create_world(void **ptr_ptr_world, const double max_model_depth, const char *world_builder_file, const bool *has_output_dir, const char *output_dir, const unsigned long random_number_seed);
 
 /**
  * This function return the temperature at a specific location given x, z, depth and

--- a/include/world_builder/wrapper_cpp.h
+++ b/include/world_builder/wrapper_cpp.h
@@ -20,6 +20,7 @@
 #ifndef WORLD_BUILDER_WRAPPER_CPP_H
 #define WORLD_BUILDER_WRAPPER_CPP_H
 
+#include <cmath>
 #include <string>
 
 namespace wrapper_cpp
@@ -36,7 +37,7 @@ namespace wrapper_cpp
       /**
        * constructor
        */
-      WorldBuilderWrapper(std::string filename, bool has_output_dir = false, const std::string &output_dir = "", const unsigned long random_number_seed = 1.0);
+      WorldBuilderWrapper(std::string filename, const double max_model_depth = INFINITY, bool has_output_dir = false, const std::string &output_dir = "", const unsigned long random_number_seed = 1.0);
 
       /**
        * destructor

--- a/source/coordinate_systems/cartesian.cc
+++ b/source/coordinate_systems/cartesian.cc
@@ -83,6 +83,13 @@ namespace WorldBuilder
       return point_at_depth.norm();
     }
 
+
+    double
+    Cartesian::max_model_depth() const
+    {
+      return INFINITY;
+    }
+
     /**
      * Register plugin
      */

--- a/source/coordinate_systems/spherical.cc
+++ b/source/coordinate_systems/spherical.cc
@@ -21,6 +21,7 @@
 
 
 #include "world_builder/types/object.h"
+#include "world_builder/types/double.h"
 #include "world_builder/utilities.h"
 
 namespace WorldBuilder
@@ -46,6 +47,10 @@ namespace WorldBuilder
       prm.declare_entry("depth method",
                         Types::String("",std::vector<std::string>({"starting point", "begin segment", "continuous"})),
                         R"(Which depth method to use in the spherical case. The available options are 'starting point' and 'begin segment'.)");
+
+      prm.declare_entry("radius",
+                        Types::Double(6371000.),
+                        R"(The radius of the sphere.)");
 
 
     }
@@ -127,6 +132,13 @@ namespace WorldBuilder
       const double bottom = sin_lat_1 * sin_lat_2 + cos_lat_1 * cos_lat_2 * cos_long_diff;
 
       return radius * std::atan2(top, bottom);
+    }
+
+
+    double
+    Spherical::max_model_depth() const
+    {
+      return INFINITY;
     }
 
     /**

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -52,7 +52,9 @@ namespace WorldBuilder
   Parameters::~Parameters()
     = default;
 
-  void Parameters::initialize(std::string &filename, bool has_output_dir, const std::string &output_dir)
+  void Parameters::initialize(std::string &filename,
+                              bool has_output_dir,
+                              const std::string &output_dir)
   {
 
     if (has_output_dir)

--- a/source/world.cc
+++ b/source/world.cc
@@ -120,7 +120,7 @@ namespace WorldBuilder
 
 
   void World::parse_entries(Parameters &prm,
-                            const double max_model_depth)
+                            const double max_model_depth_external)
   {
     using namespace rapidjson;
 
@@ -151,6 +151,21 @@ namespace WorldBuilder
      */
     prm.coordinate_system = prm.get_unique_pointer<CoordinateSystems::Interface>("coordinate system");
     prm.coordinate_system->parse_entries(prm);
+
+
+    // For now allow a value of ININITY to escape the check. This escape will
+    // be removed in future versions.
+    double max_model_depth = prm.coordinate_system->max_model_depth();
+    WBAssertThrow(max_model_depth_external == INFINITY
+                  ||
+                  std::fabs(max_model_depth_external-max_model_depth)
+                  < std::fabs(std::min(max_model_depth_external,max_model_depth))*std::numeric_limits<double>::epsilon(),
+                  "The maximum model depth provided during the initialization is not "
+                  "the same as the one parsed from the world builder file. This is most "
+                  "likely due to using the sperhical coordinate system with a different "
+                  "radius than provided by the external program you are using. \n\n"
+                  "max_model_depth_external = " << max_model_depth_external << " and "
+                  "max_model_depth = " << max_model_depth << ".");
 
     prm.get_unique_pointers<Features::Interface>("features",prm.features);
 

--- a/source/world.cc
+++ b/source/world.cc
@@ -159,10 +159,10 @@ namespace WorldBuilder
     WBAssertThrow(max_model_depth_external == INFINITY
                   ||
                   std::fabs(max_model_depth_external-max_model_depth)
-                  < std::fabs(std::min(max_model_depth_external,max_model_depth))*std::numeric_limits<double>::epsilon(),
+                  < std::fabs(std::min(max_model_depth_external,max_model_depth))*1e6*std::numeric_limits<double>::epsilon(),
                   "The maximum model depth provided during the initialization is not "
                   "the same as the one parsed from the world builder file. This is most "
-                  "likely due to using the sperhical coordinate system with a different "
+                  "likely due to using the spherical coordinate system with a different "
                   "radius than provided by the external program you are using. \n\n"
                   "max_model_depth_external = " << max_model_depth_external << " and "
                   "max_model_depth = " << max_model_depth << ".");

--- a/source/world.cc
+++ b/source/world.cc
@@ -39,7 +39,7 @@ namespace WorldBuilder
 {
   using namespace Utilities;
 
-  World::World(std::string filename, bool has_output_dir, const std::string &output_dir, unsigned long random_number_seed)
+  World::World(std::string filename, double max_model_depth, bool has_output_dir, const std::string &output_dir, unsigned long random_number_seed)
     :
     parameters(*this),
     surface_coord_conversions(invalid),

--- a/source/world.cc
+++ b/source/world.cc
@@ -68,7 +68,7 @@ namespace WorldBuilder
 
     parameters.initialize(filename, has_output_dir, output_dir);
 
-    this->parse_entries(parameters);
+    this->parse_entries(parameters, max_model_depth);
   }
 
   World::~World()
@@ -119,7 +119,8 @@ namespace WorldBuilder
   }
 
 
-  void World::parse_entries(Parameters &prm)
+  void World::parse_entries(Parameters &prm,
+                            const double max_model_depth)
   {
     using namespace rapidjson;
 

--- a/source/wrapper_c.cc
+++ b/source/wrapper_c.cc
@@ -27,7 +27,7 @@ extern "C" {
    * to it. This pointer can then be used to call the temperature and composition
    * functions. When done call the release world function to destroy the object.
    */
-  void create_world(void **ptr_ptr_world, const char *world_builder_file, const bool *has_output_dir_, const char *output_dir_, const unsigned long random_number_seed)
+  void create_world(void **ptr_ptr_world, const double max_model_depth, const char *world_builder_file, const bool *has_output_dir_, const char *output_dir_, const unsigned long random_number_seed)
   {
     bool has_output_dir = false;
 
@@ -42,7 +42,7 @@ extern "C" {
         output_dir = *output_dir_;
       }
 
-    WorldBuilder::World *a = new WorldBuilder::World(std::string(world_builder_file), has_output_dir, output_dir,random_number_seed);
+    WorldBuilder::World *a = new WorldBuilder::World(std::string(world_builder_file), max_model_depth, has_output_dir, output_dir,random_number_seed);
 
     *ptr_ptr_world = reinterpret_cast<void *>(a);
   }

--- a/source/wrapper_cpp.cc
+++ b/source/wrapper_cpp.cc
@@ -24,10 +24,10 @@
 using namespace WorldBuilder;
 namespace wrapper_cpp
 {
-  WorldBuilderWrapper::WorldBuilderWrapper(std::string filename, bool has_output_dir, const std::string &output_dir, const unsigned long random_number_seed)
+  WorldBuilderWrapper::WorldBuilderWrapper(std::string filename, const double max_model_depth, bool has_output_dir, const std::string &output_dir, const unsigned long random_number_seed)
     : ptr_ptr_world(nullptr)
   {
-    WorldBuilder::World *a = new WorldBuilder::World(std::move(filename), has_output_dir, output_dir, random_number_seed);
+    WorldBuilder::World *a = new WorldBuilder::World(std::move(filename), max_model_depth, has_output_dir, output_dir, random_number_seed);
     ptr_ptr_world = reinterpret_cast<void *>(a);
   }
 

--- a/source/wrapper_fortran.f90
+++ b/source/wrapper_fortran.f90
@@ -29,12 +29,14 @@ USE, INTRINSIC :: ISO_C_BINDING!, ONLY: C_PTR
   !! Please not that the basic type for the random number seed is a unsigned long,
   !! so it is advisable to not use negative numbers if you want to reproduce the 
   !! same result as other codes.
-   SUBROUTINE create_world(cworld, file_name, has_output_dir, output_dir, random_number_seed) BIND(C, NAME='create_world') 
-      USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_PTR, C_BOOL, C_CHAR, C_LONG
+   SUBROUTINE create_world(cworld, max_model_depth, file_name, has_output_dir, output_dir, random_number_seed) &
+    BIND(C, NAME='create_world') 
+      USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_PTR, C_BOOL, C_CHAR, C_DOUBLE, C_LONG
       IMPLICIT NONE
       ! This argument is a pointer passed by reference.
       TYPE(C_PTR), INTENT(OUT) :: cworld
       character(KIND=C_CHAR,len=1),  intent(in)  :: file_name
+      REAL(KIND=C_DOUBLE), intent(in), value ::max_model_depth
       logical(KIND=C_BOOL), intent(in) :: has_output_dir
       character(KIND=C_CHAR,len=1),  intent(in)  :: output_dir
       INTEGER(C_LONG), intent(in), value ::random_number_seed

--- a/tests/C/example.c
+++ b/tests/C/example.c
@@ -1,5 +1,6 @@
 
 #include "world_builder/wrapper_c.h"
+#include <math.h>
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {
@@ -29,7 +30,7 @@ int main(int argc, char *argv[]) {
   // Show how to call the functions.
   printf("create world \n");
   
-  create_world(&ptr_world, argv[1], &has_output_dir, output_dir, random_number_seed);
+  create_world(&ptr_world, INFINITY, argv[1], &has_output_dir, output_dir, random_number_seed);
 
   printf("2d temperature: \n");
   temperature_2d(ptr_world,x,z,depth,gravity,&temperature);

--- a/tests/CPP_MPI/example.cpp
+++ b/tests/CPP_MPI/example.cpp
@@ -1,6 +1,7 @@
 
 #include "world_builder/world.h"
 
+#include <cmath>
 #include <stdio.h>
 #include <mpi.h>
 
@@ -36,7 +37,7 @@ int main(int argc, char *argv[]) {
   MPI_Comm_rank(MPI_COMM_WORLD, &MPI_RANK);
   MPI_Comm_size(MPI_COMM_WORLD, &MPI_SIZE);
   
-  std::unique_ptr<WorldBuilder::World> world = std::unique_ptr<WorldBuilder::World>(new WorldBuilder::World(argv[1], has_output_dir, output_dir, random_number_seed)); 
+  std::unique_ptr<WorldBuilder::World> world = std::unique_ptr<WorldBuilder::World>(new WorldBuilder::World(argv[1], INFINITY, has_output_dir, output_dir, random_number_seed)); 
 
 
   if(MPI_RANK == 1)

--- a/tests/fortran/example.f90
+++ b/tests/fortran/example.f90
@@ -1,10 +1,11 @@
 program test
 use WorldBuilder
 USE, INTRINSIC :: ISO_C_BINDING, ONLY: C_LONG
+USE ieee_arithmetic
 IMPLICIT NONE
 
   ! Declare the types which will be needed.
-  REAL*8 :: temperature,x=120e3,y=500e3,z=0,depth=0,gravity = 10
+  REAL*8 :: temperature,x=120e3,y=500e3,z=0,depth=0,gravity = 10, max_model_depth
   INTEGER :: composition_number = 3
   INTEGER(C_LONG) :: random_number_seed = 1
   REAL*8 :: composition
@@ -14,10 +15,14 @@ IMPLICIT NONE
   logical(1) :: has_output_dir = .false.
   character(len=256) :: output_dir = "../../../doc/manual/"//C_NULL_CHAR
 
+  IF (ieee_support_inf(max_model_depth)) THEN
+    max_model_depth = ieee_value(max_model_depth,  ieee_positive_inf)
+  END IF
+
   call getarg( k, file_name )
 !  file_name = trim(file_name//C_NULL_CHAR
   ! Show how to call the functions.
-  CALL create_world(cworld, trim(file_name)//C_NULL_CHAR, has_output_dir, output_dir,random_number_seed)
+  CALL create_world(cworld, max_model_depth, trim(file_name)//C_NULL_CHAR, has_output_dir, output_dir,random_number_seed)
 
   write(*, *) '2d temperature:'
   CALL temperature_2d(cworld,x,z,depth,gravity,temperature)

--- a/tests/python/example.py
+++ b/tests/python/example.py
@@ -13,7 +13,7 @@ def main(argv):
      if opt in ("-i", "--ifile"):
         filename = arg
 
-  world_builder = WorldBuilderWrapper(filename, False, "", 1);
+  world_builder = WorldBuilderWrapper(filename, float('inf'), False, "", 1);
 
   print ("2d temperature:")
   print ("temperature in Python = ", world_builder.temperature_2d(120.0e3,500.0e3,0,10));

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -704,7 +704,7 @@ TEST_CASE("WorldBuilder C wrapper")
   const char *world_builder_file = file.c_str();
   bool has_output_dir = false;
 
-  create_world(ptr_ptr_world, world_builder_file, &has_output_dir, "", 1);
+  create_world(ptr_ptr_world, INFINITY, world_builder_file, &has_output_dir, "", 1);
 
   double temperature = 0.;
 
@@ -738,7 +738,7 @@ TEST_CASE("WorldBuilder C wrapper")
   const char *world_builder_file2 = file.c_str();
   has_output_dir = false;
 
-  create_world(ptr_ptr_world, world_builder_file2, &has_output_dir, "", 1.0);
+  create_world(ptr_ptr_world, INFINITY, world_builder_file2, &has_output_dir, "", 1.0);
 
 
   CHECK_THROWS_WITH(temperature_2d(*ptr_ptr_world, 1, 2, 0, 10, &temperature),
@@ -829,7 +829,7 @@ TEST_CASE("WorldBuilder World random")
   // deterministic (known and documented algorithm), we can test the results and they
   // should be the same even for different compilers and machines.
   std::string file_name = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/oceanic_plate_spherical.wb";
-  WorldBuilder::World world1(file_name, false, "", 1);
+  WorldBuilder::World world1(file_name, INFINITY, false, "", 1);
   // same result as https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine/seed
   CHECK(world1.get_random_number_engine()() == 1791095845);
   CHECK(world1.get_random_number_engine()() == 4282876139);
@@ -838,14 +838,14 @@ TEST_CASE("WorldBuilder World random")
   CHECK(dist(world1.get_random_number_engine()) == Approx(1.1281244478));
 
   // test wheter the seed indeed changes the resuls
-  WorldBuilder::World world2(file_name, false, "", 2);
+  WorldBuilder::World world2(file_name, INFINITY, false, "", 2);
   CHECK(world2.get_random_number_engine()() == 1872583848);
   CHECK(world2.get_random_number_engine()() == 794921487);
   CHECK(dist(world2.get_random_number_engine()) == Approx(1.9315408636));
   CHECK(dist(world2.get_random_number_engine()) == Approx(1.947730611));
 
   // Test reproducability with the same seed.
-  WorldBuilder::World world3(file_name, false, "", 1);
+  WorldBuilder::World world3(file_name, INFINITY, false, "", 1);
   CHECK(world3.get_random_number_engine()() == 1791095845);
   CHECK(world3.get_random_number_engine()() == 4282876139);
   CHECK(dist(world3.get_random_number_engine()) == Approx(1.9325573614));


### PR DESCRIPTION
This is a work in progress to resolve issue #331 and related to issue #318. The first commit just adds an optional (if possible) parameter to the initialization of the world builder. Further commits are going to add this value to the parameters initialization function, add a radius parameter to the spherical coordinate system, which will have default of a reasonable radius of the Earth, and a check that both values are the same.

That should be a good starting point for both adding this new information to the ASPECT construction and to start making these optimizations.