### PR TITLE
add .gitattributes which uses merge=union on CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
Adding a .gitattributes should help if a merge conflict arises in the changelog. I seems that github doesn't know how to use .gitattributes, but it should help locally to automatically resolve the conflict.