### PR TITLE
Add max_model_depth variable to cartesian and spherical geometries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The option for a temperature model for an oceanic plate with a constant age using the plate model. \[Haoyuan Li; 2021-10-29; [#344](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/344)\]
 - The cmake targets to easily switch between debug and release mode \[Menno Fraters; 2021-10-31; [#361](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/361)\]
 - A new depth method for the spherical coordinate system called begin at end segment. This adds the spherical correction to the end of the segment instead of the beginning, resulting in a smoother transition between segments. \[Menno Fraters; 2021-11-06; [#364](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/364), [#365](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/365)\]
+- A new input parameter and accociated functions which define the maximum depth of a model. This allows the world builder to create a complete picture of the world. \[Menno Fraters; 2021-11-08; [#367](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/367) and [#331](https://github.com/GeodynamicWorldBuilder/WorldBuilder/issues/331)\]
  
 ### Changed
 - The World Builder Visualizer will now use zlib compression for vtu files by default. If zlib is not available binary output will be used. \[Menno Fraters; 2021-06-26; [#282](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/282)\]

--- a/include/world_builder/coordinate_systems/cartesian.h
+++ b/include/world_builder/coordinate_systems/cartesian.h
@@ -101,6 +101,12 @@ namespace WorldBuilder
          */
         double distance_between_points_at_same_depth(const Point<3> &point_1, const Point<3> &point_2) const override final;
 
+        /**
+         * Returns the max model depth. This always returns infinity for Cartesian
+         * models.
+         */
+        virtual
+        double max_model_depth() const override final;
 
       private:
 

--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -107,6 +107,13 @@ namespace WorldBuilder
         double distance_between_points_at_same_depth(const Point<3> &point_1, const Point<3> &point_2) const = 0;
 
         /**
+         * Returns the max model depth. This should be the infinity for Cartesian
+         * models and the radius in spherical models.
+         */
+        virtual
+        double max_model_depth() const = 0;
+
+        /**
          * A function to register a new type. This is part of the automatic
          * registration of the object factory.
          */

--- a/include/world_builder/coordinate_systems/spherical.h
+++ b/include/world_builder/coordinate_systems/spherical.h
@@ -106,12 +106,23 @@ namespace WorldBuilder
         double distance_between_points_at_same_depth(const Point<3> &point_1, const Point<3> &point_2) const override final;
 
         /**
+         * Returns the max model depth. This returns the radius in spherical
+         * models.
+         */
+        virtual
+        double max_model_depth() const override final;
+
+        /**
          * What depth method the spherical coordinates use.
          */
         DepthMethod used_depth_method;
 
       private:
-
+        /**
+         * The maximum depth of the model. In the spherical case that is equal to the
+         * radius of the sphere.
+         */
+        double radius_sphere;
     };
   } // namespace CoordinateSystems
 } // namespace WorldBuilder

--- a/source/coordinate_systems/cartesian.cc
+++ b/source/coordinate_systems/cartesian.cc
@@ -83,6 +83,13 @@ namespace WorldBuilder
       return point_at_depth.norm();
     }
 
+
+    double
+    Cartesian::max_model_depth() const
+    {
+      return std::numeric_limits<double>::infinity();
+    }
+
     /**
      * Register plugin
      */

--- a/source/coordinate_systems/spherical.cc
+++ b/source/coordinate_systems/spherical.cc
@@ -21,6 +21,7 @@
 
 
 #include "world_builder/types/object.h"
+#include "world_builder/types/double.h"
 #include "world_builder/utilities.h"
 
 namespace WorldBuilder
@@ -40,7 +41,7 @@ namespace WorldBuilder
     {
 
       // Add depth method to the requried parameters.
-      prm.declare_entry("", Types::Object({"depth method"}), "Coordinate sysetm object");
+      prm.declare_entry("", Types::Object({"depth method"}), "Coordinate system object");
 
 
       prm.declare_entry("depth method",
@@ -48,6 +49,10 @@ namespace WorldBuilder
                         R"(Which depth method to use in the spherical case. The available options are 'starting point', )"
                         R"('begin segment' and 'begin at end segment'. See the manual section on coordinate systems for )"
                         R"(more info.)");
+
+      prm.declare_entry("radius",
+                        Types::Double(6371000.),
+                        R"(The radius of the sphere.)");
 
 
     }
@@ -71,7 +76,7 @@ namespace WorldBuilder
                         "coordinates. The available options are 'starting point', 'begin segment' and 'begin at end segment'. "
                         "The option 'continuous' is not yet available.");
 
-        //std::cout << "string_depth_method = " << string_depth_method << std::endl;
+        radius_sphere = prm.get<double>("radius");
       }
       prm.leave_subsection();
     }
@@ -131,6 +136,13 @@ namespace WorldBuilder
       const double bottom = sin_lat_1 * sin_lat_2 + cos_lat_1 * cos_lat_2 * cos_long_diff;
 
       return radius * std::atan2(top, bottom);
+    }
+
+
+    double
+    Spherical::max_model_depth() const
+    {
+      return radius_sphere;
     }
 
     /**

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -3823,8 +3823,11 @@ TEST_CASE("WorldBuilder Parameters")
 {
   // First test a world builder file with a cross section defined
   std::string file = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/type_data.json";
-  std::string file_name = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/subducting_plate_different_angles_spherical.wb";
+  std::string file_name = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/subducting_plate_different_angles_cartesian.wb";
   WorldBuilder::World world(file_name);
+
+  world.parse_entries(world.parameters);
+  CHECK(std::isinf(world.parameters.coordinate_system->max_model_depth()));
 
   Parameters prm(world);
   prm.initialize(file);
@@ -7344,6 +7347,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
     WorldBuilder::World world(file_name);
 
     const double dtr = Utilities::const_pi/180.0;
+    world.parse_entries(world.parameters);
+    CHECK(world.parameters.coordinate_system->max_model_depth() == Approx(6371000.));
     // slab goes down and up again
     // origin
     std::array<double,3> position = {{6371000 - 0, 0 * dtr, 0 * dtr}};


### PR DESCRIPTION
This is a first step based on the discussion in both #331 and #345. This only add max_model_depth variable to cartesian and spherical geometries with a get function and a radius input parameter for the spherical geometry model to define the `max_model_depth`. 

Merging this will allow to start writing code which uses this internally and within ASPECT. 
