### PR TITLE
Add function deprecation mechanism.

### DIFF
--- a/include/world_builder/deprecate.h
+++ b/include/world_builder/deprecate.h
@@ -1,0 +1,13 @@
+// if depricated is supported, which is definitely C++14, but some compilers support it before C++14.
+// Once the world builder switches to C++14 this can be simplified.
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(deprecated)
+#define DEPRECATED(msg, func) [[deprecated(msg)]] func
+#endif
+#else
+#if defined(__GNUC__) || defined(__clang__)
+#define DEPRECATED(msg, func) func __attribute__ ((deprecated(msg)))
+#elif defined(_MSC_VER)
+#define DEPRECATED(msg, func) __declspec(deprecated(msg)) func
+#endif
+#endif


### PR DESCRIPTION
This adds a way to deprecate functions and resolves #368. I have tested it locally, but don't really know a good way to include it in the test suite without a lot work and extra complicated code.

Usage:
```
DEPRECATED("Please use 'World::temperature(const std::array<double,3> &point_) const' instead",  
World::temperature(const std::array<double,3> &point_,
                     const double depth,
                     const double gravity_norm) const);
```