### PR TITLE
Improve latex declarations readability in the manual.

### DIFF
--- a/include/rapidjson/latexwriter.h
+++ b/include/rapidjson/latexwriter.h
@@ -176,13 +176,13 @@ class LatexWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, 
           if (skip_next_push_back == false)
             {
               if (section_level <= 2)
-                begin += "\\section{" + get_path() + "}";
+                begin += "\\section{(" + std::to_string(section_level) + ") " + get_path() + "}";
               else if (section_level <= 5)
-                begin += "\\subsection{" + get_path() + "}";
+                begin += "\\subsection{(" + std::to_string(section_level) + ") " + get_path() + "}";
               else if (section_level <= 8)
-                begin += "\\subsubsection{" + get_path() + "}";
+                begin += "\\subsubsection{(" + std::to_string(section_level) + ") " + get_path() + "}";
               else
-                begin += "\\paragraph{" + get_path() + "}";
+                begin += "\\paragraph{(" + std::to_string(section_level) + ") " + get_path() + "}";
 
               open_new_itemize = true;
               level_type.push_back(0);
@@ -209,13 +209,13 @@ class LatexWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, 
           section_level++;
 
           if (section_level <= 2)
-            begin += "\\section{" + get_path() + "}";
+            begin += "\\section{(" + std::to_string(section_level) + ") " + get_path() + "}";
           else if (section_level <= 5)
-            begin += "\\subsection{" + get_path() + "}";
+            begin += "\\subsection{(" + std::to_string(section_level) + ") " + get_path() + "}";
           else if (section_level <= 8)
-            begin += "\\subsubsection{" + get_path() + "}";
+            begin += "\\subsubsection{(" + std::to_string(section_level) + ") " + get_path() + "}";
           else
-            begin += "\\paragraph{" + get_path() + "}";
+            begin += "\\paragraph{(" + std::to_string(section_level) + ") " + get_path() + "}";
 
           open_new_itemize = true;
         }
@@ -229,13 +229,13 @@ class LatexWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, 
 
           //begin += "C";
           if (section_level <= 2)
-            begin += "\\section{" + get_path() + "}";
+            begin += "\\section{(" + std::to_string(section_level) + ") " + get_path() + "}";
           else if (section_level <= 5)
-            begin += "\\subsection{" + get_path() + "}";
+            begin += "\\subsection{(" + std::to_string(section_level) + ") " + get_path() + "}";
           else if (section_level <= 8)
-            begin += "\\subsubsection{" + get_path() + "}";
+            begin += "\\subsubsection{(" + std::to_string(section_level) + ") " + get_path() + "}";
           else
-            begin += "\\paragraph{" + get_path() + "}";
+            begin += "\\paragraph{(" + std::to_string(section_level) + ") " + get_path() + "}";
 
           open_new_itemize = true;
           if (level_type.size() > 0 && (level_type.back() != 3 || level_type.size() == 0))
@@ -258,7 +258,7 @@ class LatexWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, 
         {
           if (open_new_itemize == true)
             {
-              item += "\\begin{itemize}";
+              item += "\\begin{itemize}[leftmargin=" + std::to_string(section_level) + "em]";
               itemize_open++;
             }
           level_type.push_back(1);
@@ -273,7 +273,7 @@ class LatexWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, 
         {
           if (open_new_itemize == true)
             {
-              item += "\\begin{itemize}";
+              item += "\\begin{itemize}[leftmargin=" + std::to_string(section_level) + "em]";
               itemize_open++;
             }
           section_level++;
@@ -292,7 +292,7 @@ class LatexWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, 
         {
           if (open_new_itemize == true)
             {
-              item += "\\begin{itemize}";
+              item += "\\begin{itemize}[leftmargin=" + std::to_string(section_level) + "em]";
               itemize_open++;
 
             }


### PR DESCRIPTION
The World Builder file parameter reference section in the manual is very hard to read because the nested structure it is trying to represent is very deep (up to 14 levels) and very big/long. This is partly a limitation with latex and moving to a html based manual or a xml file interface like aspect has may be best. But I think I found some setting which do improve the situation. 

1. Add the depth of the current header in front of the header: `(4) /this/has/four/levels/`
2. Indent the information in each section/header with 1em per level. 

This is the results, which I think looks easier to read to me. I will leave the pull request open for a few days in case there are comments or objections. 

![example_new_manual_parameters](https://user-images.githubusercontent.com/7631629/141233515-848a858e-e496-4ae4-a1f3-aea216c46000.png)
