### PR TITLE
Address new manual outline first round of comments.

### DIFF
--- a/doc/sphinx/api_manual/API_FFI/CPP_interface/ASPECT_integration.md
+++ b/doc/sphinx/api_manual/API_FFI/CPP_interface/ASPECT_integration.md
@@ -1,0 +1,6 @@
+ASPECT intgration
+=================
+
+```{todo}
+Explain how the GWB is integrated into ASPECT
+```

--- a/doc/sphinx/api_manual/API_FFI/CPP_interface/index.md
+++ b/doc/sphinx/api_manual/API_FFI/CPP_interface/index.md
@@ -1,0 +1,12 @@
+C++ interface
+=============
+
+```{todo}
+Explain how to use the CP interface in your program. Point to or show the example in the example directory.
+```
+
+```{toctree}
+:hidden:
+
+ASPECT_integration
+```

--- a/doc/sphinx/api_manual/API_FFI/C_interface.md
+++ b/doc/sphinx/api_manual/API_FFI/C_interface.md
@@ -1,0 +1,6 @@
+C interface
+===========
+
+```{todo}
+Explain how to use the C interface in your program. Point to or show the example in the example directory.
+```

--- a/doc/sphinx/api_manual/API_FFI/Fortran_interface.md
+++ b/doc/sphinx/api_manual/API_FFI/Fortran_interface.md
@@ -1,0 +1,6 @@
+Fortran interface
+===========
+
+```{todo}
+Explain how to use the Fortran interface in your program. Point to or show the example in the example directory.
+```

--- a/doc/sphinx/api_manual/API_FFI/Python_interface.md
+++ b/doc/sphinx/api_manual/API_FFI/Python_interface.md
@@ -1,0 +1,6 @@
+Python interface
+===========
+
+```{todo}
+Explain how to use the Python interface in your program. Point to or show the example in the example directory.
+```

--- a/doc/sphinx/api_manual/API_FFI/index.md
+++ b/doc/sphinx/api_manual/API_FFI/index.md
@@ -1,0 +1,16 @@
+API in different languages (FFI)
+==========================================
+
+```{todo}
+Provide examples how to use the API in different programming languages.
+```
+
+
+```{toctree}
+:hidden:
+
+C_interface
+CPP_interface/index
+Fortran_interface
+Python_interface
+```

--- a/doc/sphinx/api_manual/api_design.md
+++ b/doc/sphinx/api_manual/api_design.md
@@ -1,0 +1,6 @@
+API design
+==========
+
+```{todo}
+Explain that the API works in a two (or three) phased process: World creation, world query and (depending on lanuage) worl destruction. Also explain that the basic question the world query is asking, what is the temperature/composition/etc. at this location in the world.
+```

--- a/doc/sphinx/api_manual/available_apis.md
+++ b/doc/sphinx/api_manual/available_apis.md
@@ -1,0 +1,6 @@
+Available APIs
+==============
+
+```{todo}
+Show the different APIs which are currently available in the world builder (temperture, composition and CPO. Others will be added as well.)
+```

--- a/doc/sphinx/how_to_use_this_manual.md
+++ b/doc/sphinx/how_to_use_this_manual.md
@@ -1,6 +1,0 @@
-How to use this manual
-======================
-
-```{todo}
-Todo: Explain side bar, arrow keys and top elements (full screen, github)
-```

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -1,4 +1,4 @@
-# The Geodynamic World Builder Manual
+# The Geodynamic World Builder (GWB)
 
 Welcome to the manual of the Geodynamic World Builder (GWB). The GWB is a stand-alone library which allows for the **easy** creation of **complex** initial conditions for geodynamic models, such as [ASPECT](https://aspect.geodynamics.org), ELEPANT or SEPRAN.
 
@@ -8,13 +8,17 @@ This manual will guide you **step-by-step** to everything you need to know to **
 
 
 ```{toctree}
+:caption: Introduction
+:maxdepth: 4
 :hidden:
-how_to_use_this_manual
+introduction/what_is_the_gwb
+introduction/gwb_philosophy
+introduction/how_to_use_this_manual
 ```
 
 
 ```{toctree}
-:caption: User manual
+:caption: Input file manual
 :maxdepth: 4
 :hidden:
 
@@ -24,6 +28,17 @@ user_manual/installation/index
 user_manual/how_to_use_the_applications/index
 user_manual/basic_starter_tutorial/index
 user_manual/cookbooks/index
+```
+
+
+```{toctree}
+:caption: API manual
+:maxdepth: 4
+:hidden:
+
+api_manual/api_design
+api_manual/available_apis
+api_manual/API_FFI/index
 ```
 
 

--- a/doc/sphinx/introduction/gwb_philosophy.md
+++ b/doc/sphinx/introduction/gwb_philosophy.md
@@ -1,0 +1,6 @@
+GWB philosophy
+==============
+
+```{todo}
+Explain that previous solution where: not readable, modifiable, extendable, portable and/or shareable. Show how we use two separate philosophies (coding and user philosopies) to adress these issues.
+```

--- a/doc/sphinx/introduction/how_to_use_this_manual.md
+++ b/doc/sphinx/introduction/how_to_use_this_manual.md
@@ -1,0 +1,6 @@
+How to use this manual
+======================
+
+```{todo}
+Todo: Explain side bar, arrow keys and top elements (full screen, github). Also explain what sections to read depending on what you are interested in (e.g. make an input file, connect the world builder to your program, improve the world builder).
+```

--- a/doc/sphinx/introduction/what_is_the_gwb.md
+++ b/doc/sphinx/introduction/what_is_the_gwb.md
@@ -1,0 +1,9 @@
+What is the GWB?
+================
+
+```{todo}
+Briefly explain why the GWB was build and what kind of problems it is designed to solve.
+
+(This is the story about simple syntetic models vs data driven models vs comple syntetic models.)
+
+```


### PR DESCRIPTION
This pull request addresses some of the issues with the new manual outline raised by @bangerth. I read your comments as  the two following issues (please correct me if I am wrong)

1. One issue is that there is not a good introduction of what the world builder is and the philosophy behind it.
2. I didn't explain have a section on the API and did not realize in the manual that that is a completely different audience.

For the second item, I think that there are now actually three different audiences: people who wat to make input files, people how want to link the GWB to their code and people who want to modify and/or extend the GWB. I have now put them into three different sections and made a global introduction section where I put the items of point 1 into.

@bangerth Do these changes to the outline address your issues?

The preview of the manual with these changes can be found here: https://gwb--387.org.readthedocs.build/en/387/

Related to #379  and #386.