### PR TITLE
Fix the way cards look like in the latex/pdf version of the sphinx manual.

### DIFF
--- a/doc/sphinx/user_manual/concepts/painting_in_the_world.md
+++ b/doc/sphinx/user_manual/concepts/painting_in_the_world.md
@@ -11,13 +11,22 @@ Some introduction test to this section...
 
 ::::{grid} 3
 
-:::{grid-item-card} Starting with a "geologic map"
+:::{grid-item-card}
+
+**Starting with a "geologic map"**
+
 ![Starting with a geologic map](../../_static/images/user_manual/map_to_top_view_v2_plain.svg)
 :::
-:::{grid-item-card} Now we select a region and define points
+:::{grid-item-card}
+
+**Now we select a region and define points**
+
 ![Starting with a geologic map](../../_static/images/user_manual/map_to_top_view_v2_plain_text_frame_sds.svg)
 :::
-:::{grid-item-card} Coloring in the rest of the region
+:::{grid-item-card}
+
+**Coloring in the rest of the region**
+
 ![Starting with a geologic map](../../_static/images/user_manual/map_to_top_view_v2_plain_text_frame_sds_orp_sdp.svg)
 :::
 ::::
@@ -29,34 +38,43 @@ Using the topographic map to make a 3D model
 
 Some introduction test to this section...
 
-:::{card} We start with a box without compositions
+:::{card}
 
+**We start with a box without compositions**
 
 ![Starting with a box without compositions](../../_static/images/user_manual/gwb_box_building_plain_text_frame.svg)
 
 :::
 
 
-:::{card} Next we add a mantle compostion
+:::{card}
+
+**Next we add a mantle compostion**
 
 ![Starting with a box without compositions](../../_static/images/user_manual/gwb_box_building_plain_text_frame_mtl.svg)
 :::
 
 
 
-:::{card} Now we add an overriding plate
+:::{card}
+
+**Now we add an overriding plate**
 
 
 ![adding an overiding plate](../../_static/images/user_manual/gwb_box_building_plain_text_frame_mtl_orp.svg)
 :::
 
-:::{card} Then we add an oceanic plate
+:::{card}
+
+**Then we add an oceanic plate**
 
 
 ![adding an oceanic plate](../../_static/images/user_manual/gwb_box_building_plain_text_frame_mtl_orp_sdp.svg)
 :::
 
-:::{card} Finally, we add a slab, the "Painting" of the model is now complete
+:::{card}
+
+**Finally, we add a slab, the "Painting" of the model is now complete**
 
 
 ![Painting in model completed by adding a slab](../../_static/images/user_manual/gwb_box_building_plain_text_frame_mtl_orp_sdp_sds.svg)


### PR DESCRIPTION
The headers of the cards in the latex/pdf version are put horizontally in front of the content, which caused issues with images dropping off the page. With this solution there is no difference with the way the html version looks like.

Related to #379 