### PR TITLE
Add kd tree as first step to variable plate depth

### DIFF
--- a/include/world_builder/kd_tree.h
+++ b/include/world_builder/kd_tree.h
@@ -1,0 +1,156 @@
+/*
+  Copyright (C) 2022 by the authors of the World Builder code.
+
+  This file is part of the World Builder.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef KD_TREE_H
+#define KD_TREE_H
+
+#include <vector>
+#include <cstddef>
+#include <iostream>
+#include <limits>
+
+#include "world_builder/assert.h"
+#include "world_builder/point.h"
+
+namespace WorldBuilder
+{
+  namespace KDTree
+  {
+    /**
+     * A struct to store an index for a point and the
+     * distance to that point.
+     */
+    struct IndexDistance
+    {
+      size_t index;
+      double distance;
+    };
+
+
+    /**
+     * A struct to store an index for a point and the
+     * distance to that point.
+     */
+    struct IndexDistances
+    {
+      size_t min_index;
+      double min_distance;
+      std::vector<IndexDistance> vector;
+    };
+
+    /**
+     * Each item contains an index and an x and y coordinate
+     */
+    struct Node
+    {
+      size_t index;
+      double x;
+      double y;
+
+      Node(size_t index_, double x_, double y_)
+        :
+        index(index_),
+        x(x_),
+        y(y_)
+      {}
+
+
+      /**
+       * access index (const)
+       */
+      inline
+      const double &operator[](const bool y_axis) const
+      {
+        WBAssert(abs((y_axis ? y : x) - *(&x+y_axis)) < std::numeric_limits<double>::epsilon(),
+                 "Internal error: y_axis=" << y_axis << ", x=" << x << ", y=" << y <<", *(&x+y_axis)=" << *(&x+y_axis) << ", ((bool)y_axis ? x : y) - *(&x+y_axis)=" << abs(((bool)y_axis ? x : y) - *(&x+y_axis)));
+        return *(&x+y_axis);
+      }
+    };
+
+    class KDTree
+    {
+      public:
+        /**
+         * Constructor. Requires a list of Nodes.
+         */
+        KDTree(const std::vector<Node> point_list);
+
+        /**
+         * Create a tree based on the current information in the
+         * node vector.
+         */
+        void create_tree(const size_t left,
+                         const size_t right,
+                         const bool x_axis);
+
+        /**
+         * Retun a reference to the vector containing the nodes.
+         */
+        std::vector<Node> &get_nodes();
+
+        /**
+         * Returns the index of the closest point and the distance
+         * of that point to the check point.
+         */
+        IndexDistance find_closest_point(const Point<2> &check_point) const;
+
+
+
+        /**
+         * Returns the index of the closest point and the distance
+         * of that point to the check point. Stores the points searched
+         * through in a unsorted vector.
+         * Note: I can only guarentee that the point with the least distance
+         * is the closest point. The point in the list with the second/third/etc.
+         * smallest distance may or may not actually be the global point
+         * with the second/third/etc. smallest distance. It will most likely be a
+         * very good guess though.
+         */
+        IndexDistances find_closest_points(const Point<2> &check_point) const;
+
+
+      private:
+        /**
+         * Returns the index of the closest point and the distance
+         * of that point to the check point. This function is used
+         * by find_closest_point to find the correct point.
+         */
+        void find_closest_point_recursive(const Point<2> &check_point,
+                                          const size_t left,
+                                          const size_t right,
+                                          const bool y_axis,
+                                          IndexDistance &index_distance) const;
+
+
+        /**
+         * Returns the index of the closest point and the distance
+         * of that point to the check point. This function is used
+         * by find_closest_point to find the correct point.
+         */
+        void find_closest_points_recursive(const Point<2> &check_point,
+                                           const size_t left,
+                                           const size_t right,
+                                           const bool y_axis,
+                                           IndexDistances &index_distances) const;
+
+        std::vector<Node> nodes;
+    };
+  }
+}
+#endif

--- a/source/kd_tree.cc
+++ b/source/kd_tree.cc
@@ -1,0 +1,207 @@
+/*
+  Copyright (C) 2022 by the authors of the World Builder code.
+
+  This file is part of the World Builder.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "world_builder/kd_tree.h"
+#include <algorithm>
+
+namespace WorldBuilder
+{
+  namespace KDTree
+  {
+    KDTree::KDTree(std::vector<Node> point_list)
+      : nodes(point_list)
+    {}
+
+
+    void
+    KDTree::create_tree(const size_t left,
+                        const size_t right,
+                        const bool y_axis)
+    {
+      size_t mid=(left+right)>>1;
+      std::nth_element(nodes.begin()+left,nodes.begin()+mid,nodes.begin()+right+1,
+                       [y_axis](Node& i, Node& j) -> bool
+      {
+        return i[y_axis] < j[y_axis];
+      });
+
+      if (left<mid)
+        create_tree(left,mid-1,!y_axis);
+      if (right>mid)
+        create_tree(mid+1,right,!y_axis);
+    }
+
+
+    std::vector<Node> &
+    KDTree::get_nodes()
+    {
+      return nodes;
+    }
+
+
+    IndexDistance
+    KDTree::find_closest_point(const Point<2> &check_point) const
+    {
+      size_t start_node_index = 0;
+      IndexDistance index_distance = {start_node_index,
+                                      std::numeric_limits<double>::max()
+                                     };
+
+      find_closest_point_recursive(check_point,0,nodes.size()-1,false,index_distance);
+
+      return index_distance;
+    }
+
+
+    void
+    KDTree::find_closest_point_recursive(const Point<2> &check_point,
+                                         const size_t left,
+                                         const size_t right,
+                                         const bool y_axis,
+                                         IndexDistance &index_distance) const
+    {
+      // Calculate the index of this node
+      const size_t mid=(left+right)>>1;
+      if (check_point[y_axis] < nodes[mid][y_axis])
+        {
+          // Traverse left child
+          if (left<mid)
+            {
+              find_closest_point_recursive(check_point,left,mid-1,!y_axis,index_distance);
+            }
+
+          // Compare node's point to current closest point
+          double distance = sqrt((nodes[mid][0]-check_point[0])*(nodes[mid][0]-check_point[0])
+                                 +(nodes[mid][1]-check_point[1])*(nodes[mid][1]-check_point[1]));
+          if (index_distance.distance > distance)
+            {
+              index_distance.index = mid;
+              index_distance.distance = distance;
+            }
+
+          // Traverse right child
+          if (right>mid)
+            {
+              if ((nodes[mid][y_axis]-check_point[y_axis]) < index_distance.distance)
+                {
+                  find_closest_point_recursive(check_point,mid+1,right,!y_axis,index_distance);
+                }
+            }
+        }
+      else
+        {
+          // Traverse right child
+          if (right>mid)
+            find_closest_point_recursive(check_point,mid+1,right,!y_axis,index_distance);
+
+          // Compare node's point to current closest point
+          double distance = sqrt((nodes[mid][0]-check_point[0])*(nodes[mid][0]-check_point[0])
+                                 +(nodes[mid][1]-check_point[1])*(nodes[mid][1]-check_point[1]));
+          if (index_distance.distance > distance)
+            {
+              index_distance.index = mid;
+              index_distance.distance = distance;
+            }
+
+          // Traverse left child
+          if (left<mid)
+            if ((nodes[mid][y_axis]-check_point[y_axis]) < index_distance.distance)
+              find_closest_point_recursive(check_point,left,mid-1,!y_axis,index_distance);
+        }
+    }
+
+
+
+    IndexDistances
+    KDTree::find_closest_points(const Point<2> &check_point) const
+    {
+      size_t start_node_index = 0;
+      IndexDistances index_distances = {start_node_index,
+                                        std::numeric_limits<double>::max(),
+                                        {}
+                                       };
+
+      find_closest_points_recursive(check_point,0,nodes.size()-1,false,index_distances);
+
+      return index_distances;
+    }
+
+
+    void
+    KDTree::find_closest_points_recursive(const Point<2> &check_point,
+                                          const size_t left,
+                                          const size_t right,
+                                          const bool y_axis,
+                                          IndexDistances &index_distances) const
+    {
+      // Calculate the index of this node
+      const size_t mid=(left+right)>>1;
+      if (check_point[y_axis] < nodes[mid][y_axis])
+        {
+          // Traverse left child
+          if (left<mid)
+            {
+              find_closest_points_recursive(check_point,left,mid-1,!y_axis,index_distances);
+            }
+
+          // Compare node's point to current closest point
+          double distance = sqrt((nodes[mid][0]-check_point[0])*(nodes[mid][0]-check_point[0])
+                                 +(nodes[mid][1]-check_point[1])*(nodes[mid][1]-check_point[1]));
+          if (index_distances.min_distance > distance)
+            {
+              index_distances.min_index = mid;
+              index_distances.min_distance = distance;
+            }
+
+          index_distances.vector.push_back({mid, distance});
+
+          // Traverse right child
+          if (right>mid)
+            {
+              if ((nodes[mid][y_axis]-check_point[y_axis]) < index_distances.min_distance)
+                {
+                  find_closest_points_recursive(check_point,mid+1,right,!y_axis,index_distances);
+                }
+            }
+        }
+      else
+        {
+          // Traverse right child
+          if (right>mid)
+            find_closest_points_recursive(check_point,mid+1,right,!y_axis,index_distances);
+
+          // Compare node's point to current closest point
+          double distance = sqrt((nodes[mid][0]-check_point[0])*(nodes[mid][0]-check_point[0])
+                                 +(nodes[mid][1]-check_point[1])*(nodes[mid][1]-check_point[1]));
+          if (index_distances.min_distance > distance)
+            {
+              index_distances.min_index = mid;
+              index_distances.min_distance = distance;
+            }
+
+          index_distances.vector.push_back({mid, distance});
+
+          // Traverse left child
+          if (left<mid)
+            if ((nodes[mid][y_axis]-check_point[y_axis]) < index_distances.min_distance)
+              find_closest_points_recursive(check_point,left,mid-1,!y_axis,index_distances);
+        }
+    }
+  }
+}

--- a/tests/unit_tests/kd_tree.cc
+++ b/tests/unit_tests/kd_tree.cc
@@ -1,0 +1,214 @@
+/*
+  Copyright (C) 2022 by the authors of the World Builder code.
+
+  This file is part of the World Builder.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+
+#include "world_builder/kd_tree.h"
+#include "world_builder/coordinate_system.h"
+#include "doctest.h"
+
+#include <iostream>
+
+using namespace WorldBuilder::KDTree;
+using doctest::Approx;
+
+/**
+ * Compare the given two std::array<double,3> entries with an epsilon (using Catch::Approx)
+ */
+inline void compare_node_trees(
+  const std::vector<Node> &computed,
+  const std::vector<Node> &expected)
+{
+  for (size_t i = 0; i < computed.size(); ++i)
+    {
+      CHECK(computed[i].index == expected[i].index);
+      CHECK(computed[i].x == Approx(expected[i].x));
+      CHECK(computed[i].y == Approx(expected[i].y));
+    }
+}
+
+TEST_CASE("create kd-tree: 15 nodes")
+{
+  std::vector<Node> reference = {Node(8,2,3),Node(4,4,4),Node(9,5,2),
+                                 Node(2,1,5),Node(10,2,9),Node(5,5,8),
+                                 Node(11,6,7),Node(1,7,3),Node(12,9,2.5),
+                                 Node(6,10,2),Node(13,11.5,1),Node(3,11,4),
+                                 Node(14,8,6),Node(7,9,7),Node(15,11,8)
+                                };
+  {
+    std::vector<Node> nodes = {Node(1,7,3),Node(2,1,5),Node(3,11,4),
+                               Node(4,4,4),Node(5,5,8),Node(6,10,2),
+                               Node(7,9,7),Node(8,2,3),Node(9,5,2),
+                               Node(10,2,9),Node(11,6,7),Node(12,9,2.5),
+                               Node(13,11.5,1),Node(14,8,6),Node(15,11,8)
+                              };
+
+    KDTree tree = KDTree(nodes);
+
+    tree.create_tree(0, nodes.size()-1, false);
+
+    compare_node_trees(tree.get_nodes(), reference);
+  }
+
+  {
+    // shuffle nodes
+    std::vector<Node> nodes = {Node(2,1,5),Node(3,11,4),Node(9,5,2),
+                               Node(4,4,4),Node(1,7,3),Node(5,5,8),
+                               Node(7,9,7),Node(8,2,3),Node(11,6,7),
+                               Node(10,2,9),Node(12,9,2.5),Node(14,8,6),
+                               Node(13,11.5,1),Node(6,10,2),Node(15,11,8)
+                              };
+
+    KDTree tree = KDTree(nodes);
+
+    tree.create_tree(0, nodes.size()-1, false);
+
+    compare_node_trees(tree.get_nodes(), reference);
+  }
+}
+
+
+TEST_CASE("create kd-tree: 6 nodes")
+{
+  std::vector<Node> reference = {Node(4,4,2),Node(5,2,6),Node(2,7,6),
+                                 Node(1,9,2),Node(6,12,3),Node(3,11,6)
+                                };
+  {
+    std::vector<Node> nodes = {Node(1,9,2),Node(2,7,6),Node(3,11,6),
+                               Node(4,4,2),Node(5,2,6),Node(6,12,3)
+                              };
+
+    KDTree tree = KDTree(nodes);
+
+    tree.create_tree(0, nodes.size()-1, false);
+
+    compare_node_trees(tree.get_nodes(), reference);
+  }
+
+  {
+    // shuffle nodes
+    std::vector<Node> nodes = {Node(5,2,6),Node(2,7,6),Node(1,9,2),
+                               Node(6,12,3),Node(4,4,2),Node(3,11,6)
+                              };
+
+    KDTree tree = KDTree(nodes);
+
+    tree.create_tree(0, nodes.size()-1, false);
+
+    compare_node_trees(tree.get_nodes(), reference);
+  }
+}
+
+
+TEST_CASE("create kd-tree: 10 nodes")
+{
+  std::vector<Node> reference = {Node(3,2,1),Node(1,4,2),Node(4,1,4),
+                                 Node(7,3,6),Node(0,7,3),Node(5,9,2),
+                                 Node(8,11,1),Node(2,12,3),Node(9,10,5),
+                                 Node(6,11,6)
+                                };
+  {
+    std::vector<Node> nodes = {Node(0,7,3),Node(1,4,2),Node(2,12,3),
+                               Node(3,2,1),Node(4,1,4),Node(5,9,2),
+                               Node(7,3,6),Node(6,11,6),Node(9,10,5),
+                               Node(8,11,1)
+                              };
+
+    KDTree tree = KDTree(nodes);
+
+    tree.create_tree(0, nodes.size()-1, false);
+
+    compare_node_trees(tree.get_nodes(), reference);
+
+    // check some values
+    using namespace WorldBuilder;
+    std::vector<Point<2>> check_points = {Point<2>(7,2,CoordinateSystem::cartesian),
+                                          Point<2>(8,2,CoordinateSystem::cartesian),
+                                          Point<2>(9,2,CoordinateSystem::cartesian),
+                                          Point<2>(8,2.5001,CoordinateSystem::cartesian),
+                                          Point<2>(8,2.4999,CoordinateSystem::cartesian),
+                                          Point<2>(7,3,CoordinateSystem::cartesian),
+                                          Point<2>(11,1.5,CoordinateSystem::cartesian),
+                                          Point<2>(10,2,CoordinateSystem::cartesian),
+                                          Point<2>(12,2,CoordinateSystem::cartesian),
+                                          Point<2>(11,0.5,CoordinateSystem::cartesian),
+                                          Point<2>(9.25,1.75,CoordinateSystem::cartesian),
+                                          Point<2>(11,3.5,CoordinateSystem::cartesian),
+                                          Point<2>(10.5,4,CoordinateSystem::cartesian),
+                                          Point<2>(9.5,4,CoordinateSystem::cartesian),
+                                          Point<2>(9.5,5.5,CoordinateSystem::cartesian),
+                                          Point<2>(10.75,5.5,CoordinateSystem::cartesian),
+                                          Point<2>(11.75,5.5,CoordinateSystem::cartesian),
+                                          Point<2>(5,1,CoordinateSystem::cartesian),
+                                          Point<2>(3,1,CoordinateSystem::cartesian),
+                                          Point<2>(1,1,CoordinateSystem::cartesian),
+                                          Point<2>(2,3,CoordinateSystem::cartesian),
+                                          Point<2>(0.5,3,CoordinateSystem::cartesian),
+                                          Point<2>(0.5,5,CoordinateSystem::cartesian),
+                                          Point<2>(2,4.5,CoordinateSystem::cartesian),
+                                          Point<2>(3,5,CoordinateSystem::cartesian),
+                                          Point<2>(3,7,CoordinateSystem::cartesian)
+                                         };
+
+    std::vector<size_t> index_results = {4,5,5,4,5,4,6,5,7,6,5,7,8,8,8,9,9,1,0,0,2,2,2,2,3,3};
+
+    for (size_t i = 0; i < check_points.size(); ++i)
+      {
+        IndexDistance index_distance = tree.find_closest_point(check_points[i]);
+
+        CHECK(index_distance.index == index_results[i]);
+      }
+
+    std::vector<std::vector<size_t> > index_distances_results =
+    {
+      {5,7,8,4,3,2,1,0},{5,7,4,3,2,1,0},{6,5,7,4,3,2,1},{5,6,7,8,4,3,2,1,0},
+      {5,6,7,8,4,3,2,1,0},{8,9,7,5,6,4,},{6,5,7,4,0,1},{6,5,7,4,3,2,1,0},
+      {6,5,7,4,3,2,1,0},{6,5,7,4,0,1},{6,5,7,4,0,1,3,2},{9,8,7,6,5,4,3,2,1,0},
+      {9,8,7,6,5,4,3,2,1,0},{8,9,7,6,5,4,3,2,1,0},{8,9,7,6,5,4,3,2,1,0},
+      {9,8,7,6,5,4,3,2,1,0},{9,8,7,6,5,4,3,2,1,0},{0,1,3,2,4},{0,1,4},{0,1,4},
+      {3,2,1,0,4},{2,3,1,0,4},{2,3,1,0,4},{3,2,1,0,4},{3,2,1,0,4},{3,2,1,0,4}
+    };
+
+    for (size_t i = 0; i < check_points.size(); ++i)
+      {
+        IndexDistances index_distances = tree.find_closest_points(check_points[i]);
+        CHECK(index_distances.min_index == index_results[i]);
+
+        for (size_t j = 0; j < index_distances.vector.size(); ++j)
+          {
+            CHECK(index_distances.vector[j].index == index_distances_results[i][j]);
+          }
+      }
+  }
+
+  {
+    // shuffle nodes
+    std::vector<Node> nodes = {Node(3,2,1),Node(4,1,4),Node(5,9,2),
+                               Node(0,7,3),Node(6,11,6),Node(2,12,3),
+                               Node(7,3,6),Node(9,10,5),Node(1,4,2),
+                               Node(8,11,1)
+                              };
+
+    KDTree tree = KDTree(nodes);
+
+    tree.create_tree(0, nodes.size()-1, false);
+
+    compare_node_trees(tree.get_nodes(), reference);
+  }
+}


### PR DESCRIPTION
This is the first part of add the option for min and max depth variable on position in plate (#366). This pull request add a compact kd-tree. It is based on the algorithm as implemented in the Templatized Geometry Library (TGL) (https://web.cs.ucdavis.edu/~okreylos/ResDev/Geometry/index.html) as send to me by the creator Oliver Kreylos @Doc-Ok, but re-implemented from scratch optimized for a very specific purpose. 

The unit tests are based on hand drawn examples I made before implementing the examples. I had a slightly different indexing scheme (if there is an even number of points, choose the one with the highest x/y), which for an odd number of points results in the same result node vector, but for even numbers there is a difference in the order. The algorithm of Oliver has the advantage that indexing is simpler, cheaper (single bitwise operation) and seems to be more contiguous to me when transversing the tree, so I decided to go with that.

The most important thing which is missing is a function which return the closest points. TGL contains such a function, but it is not clear to me what it exactly returns, so I have to look a bit more into that. 

@Doc-Ok, can you confirm that this is ok to use these algorithms in the world builder (LGPL license)? I will be happy to add you as contributor in the AUTHORS file.