### PR TITLE
assert height depth inconsistencies in spherical coordinates

### DIFF
--- a/app/main.cc
+++ b/app/main.cc
@@ -54,6 +54,7 @@ int main(int argc, char **argv)
   unsigned int grain_compositions = 0;
   size_t number_of_grains = 0;
   bool convert_spherical = false;
+  bool limit_debug_consistency_checks = true;
 
   if (find_command_line_option(argv, argv+argc, "-h") || find_command_line_option(argv, argv+argc, "--help"))
     {
@@ -63,6 +64,9 @@ int main(int argc, char **argv)
                 << "-h or --help to get this help screen." << std::endl;
       return 0;
     }
+
+  if (find_command_line_option(argv, argv+argc, "-ldcc") || find_command_line_option(argv, argv+argc, "--limit-debug-consistency-checks"))
+    limit_debug_consistency_checks = false;
 
   if (argc == 1)
     {
@@ -79,9 +83,11 @@ int main(int argc, char **argv)
       return 0;
     }
 
-  if (argc != 3)
+  if ((argc == 3 && limit_debug_consistency_checks) || argc > 4)
     {
-      std::cout << "Only two command line arguments may be given, which should be the world builder file location and the data file location (in that order). " << std::endl;
+      std::cout << "Only exactly two command line arguments may be given, which should be the world builder file location and the data file location (in that order) "
+                << "or exactly three command line arguments, which should be the world builder file location, the data file location and --limit-debug-consistency-checks (in that order). "
+                << ", argc = " << argc << ", limit_debug_consistency_checks = " << (limit_debug_consistency_checks ? "true" : "false") << std::endl;
       return 0;
     }
 
@@ -105,7 +111,7 @@ int main(int argc, char **argv)
       //try
       {
         std::string output_dir = wb_file.substr(0,wb_file.find_last_of("/\\") + 1);
-        world = std::make_unique<WorldBuilder::World>(wb_file, true, output_dir);
+        world = std::make_unique<WorldBuilder::World>(wb_file, true, output_dir,1,limit_debug_consistency_checks);
       }
       /*catch (std::exception &e)
         {

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -57,7 +57,7 @@ namespace WorldBuilder
        * documented algorithm), we can test the results and they should be the same even for different
        * compilers and machines.
        */
-      World(std::string filename, bool has_output_dir = false, const std::string &output_dir = "", unsigned long random_number_seed = 1);
+      World(std::string filename, bool has_output_dir = false, const std::string &output_dir = "", unsigned long random_number_seed = 1, const bool limit_debug_consistency_checks = false);
 
       /**
        * Destructor
@@ -220,6 +220,15 @@ namespace WorldBuilder
        * random number generator engine
        */
       std::mt19937 random_number_engine;
+
+      /**
+       * limits some of the consitency checks in debug mode.
+       * Current only prevents a check whether depth in spherical
+       * coordinates is consistent with the computed depth from
+       * x,y,z and provided radius.
+       * Note: Recommended to keep it at false, unless you know what you are doing.
+       */
+      bool limit_debug_consistency_checks;
 
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,20 @@ IF(WB_RUN_APP_TESTS)
      -D TEST_DIFF=${TEST_DIFF}
   	 -P ${CMAKE_SOURCE_DIR}/tests/app/run_app_tests.cmake
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/app/)
+
+
+  # Test two many arguments provided 
+  set(TEST_ARGUMENTS "${CMAKE_SOURCE_DIR}/tests/app/${test_name}.wb\;${CMAKE_SOURCE_DIR}/tests/app/${test_name}.dat\;lalala\;nonono")
+  add_test(testing_too_many_arguments
+  ${CMAKE_COMMAND} 
+    -D TEST_NAME=testing_too_many_arguments 
+    -D TEST_PROGRAM=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WorldBuilderApp${CMAKE_EXECUTABLE_SUFFIX} 
+    -D TEST_ARGS=${TEST_ARGUMENTS}
+    -D TEST_OUTPUT=${CMAKE_BINARY_DIR}/tests/app/testing_too_many_arguments/screen-output.log 
+    -D TEST_REFERENCE=${CMAKE_CURRENT_SOURCE_DIR}/app/testing_too_many_arguments/screen-output.log
+    -D TEST_DIFF=${TEST_DIFF}
+    -P ${CMAKE_SOURCE_DIR}/tests/app/run_app_tests.cmake
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/app/)
   
   #find all the integration test files
   file(GLOB_RECURSE APP_TEST_SOURCES "app/*.wb")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,7 +118,7 @@ IF(WB_RUN_APP_TESTS)
   # Run through each sourceUforeach(test_source ${APP_TEST_SOURCES})
   foreach(test_source ${APP_TEST_SOURCES})
           get_filename_component(test_name ${test_source} NAME_WE)
-  	set(TEST_ARGUMENTS "${CMAKE_SOURCE_DIR}/tests/app/${test_name}.wb\;${CMAKE_SOURCE_DIR}/tests/app/${test_name}.dat")
+          set(TEST_ARGUMENTS "${CMAKE_SOURCE_DIR}/tests/app/${test_name}.wb\;${CMAKE_SOURCE_DIR}/tests/app/${test_name}.dat\;--limit-debug-consistency-checks")
           add_test(${test_name}
                    ${CMAKE_COMMAND} 
   	         -D TEST_NAME=${test_name}

--- a/tests/app/testing_too_many_arguments/screen-output.log
+++ b/tests/app/testing_too_many_arguments/screen-output.log
@@ -1,0 +1,1 @@
+Only exactly two command line arguments may be given, which should be the world builder file location and the data file location (in that order) or exactly three command line arguments, which should be the world builder file location, the data file location and --limit-debug-consistency-checks (in that order). , argc = 5, limit_debug_consistency_checks = true


### PR DESCRIPTION
assert height depth inconsistencies in spherical coordinates, while allowing for an opt-out of the check. May break programs which probably did something wrong already.