### PR TITLE
Continue to the next slab when the current slab length is zero.

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1167,6 +1167,10 @@ namespace WorldBuilder
               double interpolated_segment_length     = plane_segment_lengths[original_current_section][current_segment]
                                                        + fraction_CPL_P1P2 * (plane_segment_lengths[original_next_section][current_segment]
                                                                               - plane_segment_lengths[original_current_section][current_segment]);
+
+              if (interpolated_segment_length < 1e-14)
+                continue;
+
               WBAssert(!std::isnan(interpolated_angle_top),
                        "Internal error: The interpolated_angle_top variable is not a number: " << interpolated_angle_top);
 

--- a/tests/app/cartesian_slab_spline_complex.wb
+++ b/tests/app/cartesian_slab_spline_complex.wb
@@ -8,7 +8,8 @@
        "coordinates":[[450e3,450e3],[550e3,550e3],[10e3,250e3]], 
        "segments":
        [
-         {"length":350e3, "thickness":[100e3], "angle":[45]}
+         {"length":350e3, "thickness":[100e3], "angle":[45]},
+         {"length":0, "thickness":[100e3], "angle":[45]}
        ],
        "temperature models":[{"model":"uniform", "temperature":600}],
        "composition models":[{"model":"uniform", "compositions":[0,1], "fractions":[0.25,0.75]}]

--- a/tests/visualization/fault.wb
+++ b/tests/visualization/fault.wb
@@ -10,6 +10,7 @@
        "segments":
        [
          {"length":200e3, "thickness":[100e3, 50e3], "angle":[0,45]},
+         {"length":0, "thickness":[100e3, 50e3], "angle":[0,45]},
          {
            "length":400e3, "thickness":[50e3, 100e3], "angle":[45,0],
            "composition models":
@@ -26,6 +27,7 @@
            "segments":
             [
               {"length":200e3, "thickness":[100e3, 50e3], "angle":[0,45]},
+              {"length":0, "thickness":[100e3, 50e3], "angle":[0,45]},
               {"length":200e3, "thickness":[50e3], "angle":[45], "temperature models":[{"model":"uniform", "temperature":650}]}
             ],
             "temperature models":[{"model":"linear", "max distance fault center":100e3, "center temperature":650, "side temperature":550}]


### PR DESCRIPTION
This is both an optimization and prevents an assert later in the code (in certain cases).