### PR TITLE
fix oceanic half space temperature model for age zero.

### DIFF
--- a/source/features/oceanic_plate_models/temperature/half_space_model.cc
+++ b/source/features/oceanic_plate_models/temperature/half_space_model.cc
@@ -228,7 +228,7 @@ namespace WorldBuilder
 
                   double  temperature = bottom_temperature_local;
 
-                  temperature = temperature + (top_temperature - bottom_temperature_local)*std::erfc(depth/(2*std::sqrt(thermal_diffusivity*age)));
+                  temperature = temperature + (age > 0 ? (top_temperature - bottom_temperature_local)*std::erfc(depth/(2*std::sqrt(thermal_diffusivity*age))) : 0.);
 
                   WBAssert(!std::isnan(temperature), "Temperature inside half-space cooling model is not a number: " << temperature
                            << ". Relevant variables: bottom_temperature_local = " << bottom_temperature_local


### PR DESCRIPTION
Trey found an issue with the half space temperature model when the age is zero. This pull request fixes that. When the age gets close to zero, the the value inside erfc becomes very large, which makes erfc return zero. Or in other words, the ridge has the bottom temperature.