### PR TITLE
Add WORLD_BUILDER_VERSION_GTE macro to config.h

### DIFF
--- a/include/world_builder/config.h.in
+++ b/include/world_builder/config.h.in
@@ -28,6 +28,19 @@
 #define WORLD_BUILDER_VERSION_PATCH @WORLD_BUILDER_VERSION_PATCH@
 #define WORLD_BUILDER_VERSION_LABEL @WORLD_BUILDER_VERSION_LABEL@
 
+/**
+ * Returns true if the used World Builder version is greater or equal than the
+ * version specified by the three arguments. The internal implementation
+ * assumes that the number of minor and subminor versions is not larger
+ * than 100.
+ */
+#define WORLD_BUILDER_VERSION_GTE(major,minor,patch) \
+ ((@WORLD_BUILDER_VERSION_MAJOR@ * 10000 + \
+    @WORLD_BUILDER_VERSION_MINOR@ * 100 + \
+     @WORLD_BUILDER_VERSION_PATCH@) \
+    >=  \
+    (major)*10000 + (minor)*100 + (patch))
+
 namespace WorldBuilder
 {
   namespace Version


### PR DESCRIPTION
This add a macro function `WORLD_BUILDER_VERSION_GTE(major,minor,patch)`, which works the same as the  deal.ii macro function `DEAL_II_VERSION_GTE(major,minor,subminor)` (see https://github.com/dealii/dealii/blob/38cf3f584366bb27d2d94dd994675011842e8fac/include/deal.II/base/config.h.in). I think 100 patch version and 100 minor releases per major version should be sufficient for the time being... 

It doesn't do anything with the label (`-pre,-rc1,etc.`), but that is probably for the better since I think pre-releases should be treated as a full release of that version.

related to #444. @bangerth 