### PR TITLE
Loosen tolerances

### DIFF
--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -44,7 +44,7 @@ namespace WorldBuilder
      * performance critical parts where this could matter, a fast
      * version could be added.
      */
-    inline bool approx(double a, double b, double error_factor=1.0)
+    inline bool approx(double a, double b, double error_factor=1e4)
     {
       return std::abs(a-b)<std::abs(std::min(a,b))*std::numeric_limits<double>::epsilon()*
              error_factor;

--- a/source/world_builder/objects/surface.cc
+++ b/source/world_builder/objects/surface.cc
@@ -102,7 +102,7 @@ namespace WorldBuilder
                               const Point<2> check_point,
                               double &interpolate_value) const
     {
-      double factor = 20.;
+      double factor = 1e4;
       // based on https://stackoverflow.com/questions/2049582/how-to-determine-if-a-point-is-in-a-2d-triangle
       // compute s, t and area
       const double s_no_area = -(points[0][1]*points[2][0] - points[0][0]*points[2][1] + (points[2][1] - points[0][1])*check_point[0] + (points[0][0] - points[2][0])*check_point[1]);


### PR DESCRIPTION
Some of the tolerances to compare points are set way to strict. This gave me issues with a comparison passing on one computer, but not on anther. This sets the (defaut) tolerances to more reasonable values. 