### PR TITLE
Add option (on by default) to check for fpe's.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,18 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 message(STATUS "Building the Geodynamic World Builder version ${WORLD_BUILDER_VERSION} in ${CMAKE_BUILD_TYPE} mode")
 
+
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(feenableexcept fenv.h HAVE_DECL_FEENABLEEXCEPT)
+check_cxx_symbol_exists(feclearexcept fenv.h HAVE_DECL_FECLEAREXCEPT)
+
+IF(HAVE_DECL_FEENABLEEXCEPT AND HAVE_DECL_FECLEAREXCEPT)
+  SET(WB_USE_FP_EXCEPTIONS TRUE CACHE BOOL "Whether to turn on floating point exceptions in debug mode.")
+  MESSAGE(STATUS "Using Floating Point Exceptions if in Debug mode.")
+ELSE()
+  MESSAGE(STATUS "Not using Floating Point Exceptions.")
+ENDIF()
+
 set (WORLD_BUILDER_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 
 # generate version.cc
@@ -438,6 +450,10 @@ else()
     target_link_options(gwb-dat INTERFACE ${WB_LINKER_OPTIONS} )
     target_link_options(gwb-grid INTERFACE ${WB_LINKER_OPTIONS})
     target_link_options(gwb-grid PRIVATE  ${WB_VISU_LINKER_OPTIONS})
+endif()
+
+if(${WB_USE_FP_EXCEPTIONS})
+  add_definitions(-DWB_USE_FP_EXCEPTIONS)
 endif()
 
 if(${USE_MPI})

--- a/include/delaunator-cpp/delaunator.hpp
+++ b/include/delaunator-cpp/delaunator.hpp
@@ -83,14 +83,15 @@ namespace WorldBuilder
         const double cl = ex * ex + ey * ey;
         const double d = dx * ey - dy * ex;
 
-        const double x = (ey * bl - dy * cl) * 0.5 / d;
-        const double y = (dx * cl - ex * bl) * 0.5 / d;
+        if(d > 0.0 || d < 0.0){
+            const double x = (ey * bl - dy * cl) * 0.5 / d;
+            const double y = (dx * cl - ex * bl) * 0.5 / d;
 
-        if ((bl > 0.0 || bl < 0.0) && (cl > 0.0 || cl < 0.0) && (d > 0.0 || d < 0.0)) {
-            return x * x + y * y;
-        } else {
-            return std::numeric_limits<double>::max();
+            if ((bl > 0.0 || bl < 0.0) && (cl > 0.0 || cl < 0.0) && (d > 0.0 || d < 0.0)) {
+                return x * x + y * y;
+            }
         }
+        return std::numeric_limits<double>::max();
     }
 
     inline bool orient(

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -19,6 +19,7 @@
 
 #ifndef WORLD_BUILDER_POINT_H
 #define WORLD_BUILDER_POINT_H
+#include "nan.h"
 #define _USE_MATH_DEFINES
 #include <array>
 #include <cmath>
@@ -43,8 +44,12 @@ namespace WorldBuilder
      */
     inline double fmod(const double x, const double y)
     {
-      const double x_div_y = x/y;
-      return (x_div_y-static_cast<int>(x_div_y))*y;
+      if (y < 0.0 || y > 0.0)
+        {
+          const double x_div_y = x/y;
+          return (x_div_y-static_cast<int>(x_div_y))*y;
+        }
+      return NaN::DQNAN;
     }
 
     /**

--- a/source/gwb-dat/main.cc
+++ b/source/gwb-dat/main.cc
@@ -35,6 +35,12 @@
 #include <iostream>
 #include <memory>
 
+#ifndef NDEBUG
+#ifdef WB_USE_FP_EXCEPTIONS
+#include <cfenv>
+#endif
+#endif
+
 using namespace WorldBuilder::Utilities;
 
 bool find_command_line_option(char **begin, char **end, const std::string &option)
@@ -44,6 +50,18 @@ bool find_command_line_option(char **begin, char **end, const std::string &optio
 
 int main(int argc, char **argv)
 {
+
+#ifndef NDEBUG
+#ifdef WB_USE_FP_EXCEPTIONS
+  // Some implementations seem to not initialize the floating point exception
+  // bits to zero. Make sure we start from a clean state.
+  feclearexcept(FE_DIVBYZERO|FE_INVALID);
+
+  // enable floating point exceptions
+  feenableexcept(FE_DIVBYZERO|FE_INVALID);
+#endif
+#endif
+
   /**
    * First parse the command line options
    */

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -40,6 +40,12 @@
 #include <mpi.h>
 #endif
 
+#ifndef NDEBUG
+#ifdef WB_USE_FP_EXCEPTIONS
+#include <cfenv>
+#endif
+#endif
+
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -49,7 +55,6 @@
 #include <string>
 #include <thread>
 #include <vector>
-
 
 using namespace WorldBuilder;
 using namespace WorldBuilder::Utilities;
@@ -200,6 +205,18 @@ bool find_command_line_option(char **begin, char **end, const std::string &optio
 
 int main(int argc, char **argv)
 {
+
+#ifndef NDEBUG
+#ifdef WB_USE_FP_EXCEPTIONS
+  // Some implementations seem to not initialize the floating point exception
+  // bits to zero. Make sure we start from a clean state.
+  feclearexcept(FE_DIVBYZERO|FE_INVALID);
+
+  // enable floating point exceptions
+  feenableexcept(FE_DIVBYZERO|FE_INVALID);
+#endif
+#endif
+
   /**
    * First parse the command line options
    */
@@ -502,7 +519,7 @@ int main(int argc, char **argv)
 
 
           double dx = (x_max - x_min) / static_cast<double>(n_cell_x);
-          double dy = (y_max - y_min) / static_cast<double>(n_cell_y);
+          double dy = dim == 2 ? 0 : (y_max - y_min) / static_cast<double>(n_cell_y);
           double dz = (z_max - z_min) / static_cast<double>(n_cell_z);
 
 

--- a/source/world_builder/coordinate_systems/invalid.cc
+++ b/source/world_builder/coordinate_systems/invalid.cc
@@ -55,28 +55,28 @@ namespace WorldBuilder
     std::array<double,3>
     Invalid::cartesian_to_natural_coordinates(const std::array<double,3> &) const
     {
-      return {{NaN::DSNAN,NaN::DSNAN,NaN::DSNAN}};
+      return {{NaN::DQNAN,NaN::DQNAN,NaN::DQNAN}};
     }
 
 
     std::array<double,3>
     Invalid::natural_to_cartesian_coordinates(const std::array<double,3> &) const
     {
-      return {{NaN::DSNAN,NaN::DSNAN,NaN::DSNAN}};
+      return {{NaN::DQNAN,NaN::DQNAN,NaN::DQNAN}};
     }
 
 
     double
     Invalid::distance_between_points_at_same_depth(const Point<3> &, const Point<3> &) const
     {
-      return NaN::DSNAN;
+      return NaN::DQNAN;
     }
 
 
     double
     Invalid::max_model_depth() const
     {
-      return NaN::DSNAN;
+      return NaN::DQNAN;
     }
 
     /**

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -40,6 +40,11 @@
 #include <mpi.h>
 #endif
 
+#ifndef NDEBUG
+#ifdef WB_USE_FP_EXCEPTIONS
+#include <cfenv>
+#endif
+#endif
 
 namespace WorldBuilder
 {
@@ -53,6 +58,18 @@ namespace WorldBuilder
     random_number_engine(random_number_seed),
     limit_debug_consistency_checks(limit_debug_consistency_checks_)
   {
+
+#ifndef NDEBUG
+#ifdef WB_USE_FP_EXCEPTIONS
+    // Some implementations seem to not initialize the floating point exception
+    // bits to zero. Make sure we start from a clean state.
+    feclearexcept(FE_DIVBYZERO|FE_INVALID);
+
+    // enable floating point exceptions
+    feenableexcept(FE_DIVBYZERO|FE_INVALID);
+#endif
+#endif
+
 #ifdef WB_WITH_MPI
     int mpi_initialized;
     MPI_Initialized(&mpi_initialized);

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -7423,6 +7423,6 @@ TEST_CASE("Fast version of fmod")
   CHECK(FT::fmod(5.3,2) == Approx(std::fmod(5.3,2)));
   CHECK(FT::fmod(18.5,4.2) == Approx(std::fmod(18.5,4.2)));
   CHECK(std::isnan(FT::fmod(1,0)));
-  CHECK(std::isnan(std::fmod(1,0)));
+  //CHECK(std::isnan(std::fmod(1,0))); Return a signaling NAN (FE_INVALID is raised)
 }
 


### PR DESCRIPTION
@danieldouglas92 found in #462 that in debug mode floating point exceptions where raised when compiling the world builder with aspect. It turns out that they have a stricter floating point environment set so that signalling NAN's raise an exception, even when a check is being done if they are a NAN. 

This pull request makes the floating point environment stricter for the world Builder, so that it matches ASPECT. It requires that the signalling NAN's that are checked if they are a NAN, need to become quiet NAN's. I still want to have as many of the NAN's signalling so that if they are used before they are set, an exception is raised.