### PR TITLE
Expand compiler warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,14 +365,14 @@ if (NOT MSVC AND NOT APPLE)
       # Preventing issues with older cmake compilers (<2.8.12) which do not support VERSION_GREATER_EQUAL
       # cmake vesrion 3.12.0 introduces COMPILE_LANGUAGE:FORTAN, otherwise this would be >=2.8.12
       if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
-        SET(WB_COMPILER_OPTIONS_PRIVATE -pedantic -fPIC -Wall -Wextra  $<$<COMPILE_LANGUAGE:CXX>:-std=c++14 -Wpointer-arith -Wwrite-strings -Wsynth -Wsign-compare -Woverloaded-virtual -Wno-placement-new -Wno-literal-suffix -Wno-parentheses -Wno-unused-local-typedefs -Wcast-qual -fstrict-aliasing -Wmaybe-uninitialized -Werror=maybe-uninitialized -Wparentheses -Wfloat-equal -Wundef -Wcast-align -Wlogical-op -Wmissing-declarations -Wredundant-decls -Wdiv-by-zero -Wdisabled-optimization -Wswitch-default -Wno-unused>)
+        SET(WB_COMPILER_OPTIONS_PRIVATE -pedantic -fPIC -Wall -Wextra  $<$<COMPILE_LANGUAGE:CXX>:-std=c++14 -Wunused-variable -Wpointer-arith -Wwrite-strings -Wsynth -Wsign-compare -Woverloaded-virtual -Wno-placement-new -Wno-literal-suffix -Wno-parentheses -Wno-unused-local-typedefs -Wcast-qual -fstrict-aliasing -Wmaybe-uninitialized -Werror=maybe-uninitialized -Wparentheses -Wfloat-equal -Wundef -Wcast-align -Wlogical-op -Wmissing-declarations -Wredundant-decls -Wdiv-by-zero -Wdisabled-optimization -Wswitch-default -Wno-unused>)
 
         if (${FORCE_COLORED_OUTPUT})
           SET(WB_COMPILER_OPTIONS_PRIVATE -fdiagnostics-color=always ${WB_COMPILER_OPTIONS_PRIVATE})
         endif()
 
       else()
-        SET(WB_COMPILER_OPTIONS_PRIVATE "-std=c++14 -pedantic -fPIC -Wall -Wextra -Wpointer-arith -Wwrite-strings -Wsynth -Wsign-compare -Woverloaded-virtual -Wno-placement-new -Wno-literal-suffix -Wno-parentheses -Wno-unused-local-typedefs -Wcast-qual -fstrict-aliasing -Wmaybe-uninitialized -Werror=maybe-uninitialized -Wparentheses -Wfloat-equal -Wundef -Wcast-align -Wlogical-op -Wmissing-declarations -Wredundant-decls -Wdiv-by-zero -Wdisabled-optimization -Wswitch-default -Wno-unused>")
+        SET(WB_COMPILER_OPTIONS_PRIVATE "-std=c++14 -pedantic -fPIC -Wall -Wextra -Wunused-variable -Wpointer-arith -Wwrite-strings -Wsynth -Wsign-compare -Woverloaded-virtual -Wno-placement-new -Wno-literal-suffix -Wno-parentheses -Wno-unused-local-typedefs -Wcast-qual -fstrict-aliasing -Wmaybe-uninitialized -Werror=maybe-uninitialized -Wparentheses -Wfloat-equal -Wundef -Wcast-align -Wlogical-op -Wmissing-declarations -Wredundant-decls -Wdiv-by-zero -Wdisabled-optimization -Wswitch-default -Wno-unused>")
 
         if (${FORCE_COLORED_OUTPUT})
           SET(WB_COMPILER_OPTIONS_PRIVATE "-fdiagnostics-color=always ${WB_COMPILER_OPTIONS_PRIVATE}")

--- a/source/gwb-dat/main.cc
+++ b/source/gwb-dat/main.cc
@@ -93,8 +93,8 @@ int main(int argc, char **argv)
     }
 
   int MPI_RANK = 0;
-  int MPI_SIZE = 1;
 #ifdef WB_WITH_MPI
+  int MPI_SIZE = 1;
   MPI_Init(&argc,&argv);
   MPI_Comm_rank(MPI_COMM_WORLD, &MPI_RANK);
   MPI_Comm_size(MPI_COMM_WORLD, &MPI_SIZE);

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -209,7 +209,6 @@ int main(int argc, char **argv)
 
   size_t dim = 3;
   size_t compositions = 0;
-  double gravity = 10;
 
   //commmon
   std::string grid_type = "chunk";

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -5670,8 +5670,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   natural_coordinate = Objects::NaturalCoordinate(position,
                                                   *cartesian_system);
 
-  Utilities::InterpolationType interpolation_type = Utilities::InterpolationType::ContinuousMonotoneSpline;
-
   Utilities::interpolation x_spline;
   Utilities::interpolation y_spline;
 
@@ -7067,8 +7065,6 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   double starting_radius = 10;
   Utilities::interpolation x_spline;
   Utilities::interpolation y_spline;
-  Utilities::InterpolationType interpolation_type = Utilities::InterpolationType::ContinuousMonotoneSpline;
-
 
   std::vector<double> x_list = {0.,10 * dtr};
   std::vector<double> y_list = {10 * dtr,10 * dtr};


### PR DESCRIPTION
For some reason the Wall flag, which should include the Wunused-variable flag (see https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html), but for soem reason it doesn't activate it on my system. I even checked that Wall is included in the compilation, but only adding Wunused-variable seems to help.So this pull request does that and fixes the found unused variables. 