### PR TITLE
Add gdb and valgrind testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -436,3 +436,75 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: ctest -VV -C ${{ matrix.build_type }}
+
+
+  linux-gdb-valgrind:
+    needs: [test_indentation]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-22.04']
+        build_type: ['Debug']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name:  Install optional dependencies
+      run:   |
+         if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt update;
+            sudo apt install gfortran swig python3-setuptools gdb valgrind
+         elif [ "$RUNNER_OS" == "macOS" ]; then
+            sudo brew install open-mpi || true
+         else
+            echo "$RUNNER_OS not supported"
+            exit 1
+         fi
+      shell: bash
+
+    - name: CMake version
+      run: cmake --version
+
+    - name: GCC version
+      run: gcc --version
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      run: |
+            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS=-Werror -DWB_RUN_TESTS_WITH_GDB=ON  -DWB_RUN_TESTS_WITH_VALGRIND=OFF;
+            cat ${{github.workspace}}/build/CMakeFiles/CMakeError.log ||:;
+
+    - name: Build gwb
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Install gwb Linux and macOS
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: sudo cmake --install . --config ${{ matrix.build_type }}
+
+    - name: Test gwb normal and gdb
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: ctest -VV -C ${{ matrix.build_type }}
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      run: |
+            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_FLAGS=-Werror -DWB_RUN_TESTS_WITH_GDB=OFF  -DWB_RUN_TESTS_WITH_VALGRIND=ON;
+            cat ${{github.workspace}}/build/CMakeFiles/CMakeError.log ||:;
+
+
+    - name: Test gwb valgrind
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: ctest -VV -C ${{ matrix.build_type }} -R _valgrind
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,12 @@ ENDIF()
 SET(WB_INCLUDE_UNIT_TEST ON
 CACHE BOOL "Whether to include unit tests or not in the build.")
 
+SET(WB_RUN_TESTS_WITH_GDB OFF
+CACHE BOOL "Whether to also run the test with GDB")
+
+SET(WB_RUN_TESTS_WITH_VALGRIND OFF
+CACHE BOOL "Whether to also run the test with Valgrind")
+
 if(WB_INCLUDE_UNIT_TEST)
   file(GLOB_RECURSE UNIT_TEST_SOURCES_CXX "unit_tests/*.cc")
 
@@ -69,6 +75,18 @@ if(WB_INCLUDE_UNIT_TEST)
   add_test(NAME ${test_name}
            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
            COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${test_name})
+
+  if(WB_RUN_TESTS_WITH_GDB)
+    add_test(NAME ${test_name}_gdb
+             WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+             COMMAND gdb --ex r --ex bt -ex "set confirm off" --ex exit($_exitcode) --args ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${test_name})
+  endif()
+
+  if(WB_RUN_TESTS_WITH_VALGRIND)
+    add_test(NAME ${test_name}_valgrind
+             WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+             COMMAND valgrind -v --leak-check=full --error-exitcode=1  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${test_name})
+  endif()
 endif()
 # App testing
 IF(WB_RUN_APP_TESTS)
@@ -143,6 +161,18 @@ IF(WB_RUN_APP_TESTS)
              -D TEST_DIFF=${TEST_DIFF}
   	         -P ${CMAKE_SOURCE_DIR}/tests/gwb-dat/run_gwb-dat_tests.cmake
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/gwb-dat/)
+
+  if(WB_RUN_TESTS_WITH_GDB)
+    add_test(NAME ${test_name}_gdb
+             WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+             COMMAND gdb --return-child-result --ex "set confirm off" --ex r  --ex bt --ex exit  --args ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gwb-dat${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_SOURCE_DIR}/tests/gwb-dat/${test_name}.wb ${CMAKE_SOURCE_DIR}/tests/gwb-dat/${test_name}.dat --limit-debug-consistency-checks)
+  endif()
+
+  if(WB_RUN_TESTS_WITH_VALGRIND)
+    add_test(NAME ${test_name}_valgrind
+             WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+             COMMAND valgrind -v --leak-check=full --error-exitcode=1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gwb-dat${CMAKE_EXECUTABLE_SUFFIX}  ${CMAKE_SOURCE_DIR}/tests/gwb-dat/${test_name}.wb ${CMAKE_SOURCE_DIR}/tests/gwb-dat/${test_name}.dat --limit-debug-consistency-checks)
+  endif()
   endforeach(test_source)
 ENDIF()
 
@@ -164,6 +194,18 @@ foreach(test_source ${VISU_TEST_SOURCES})
 	         -D TEST_REFERENCE=${CMAKE_CURRENT_SOURCE_DIR}/gwb-grid/${test_name}.vtu
 	         -P ${CMAKE_SOURCE_DIR}/tests/gwb-grid/run_gwb-grid_tests.cmake
                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/gwb-grid/)
+
+  if(WB_RUN_TESTS_WITH_GDB)
+   add_test(NAME ${test_name}_gdb
+            WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+            COMMAND gdb --return-child-result --ex "set confirm off" --ex r  --ex bt --ex exit  --args ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gwb-grid${CMAKE_EXECUTABLE_SUFFIX} ${CMAKE_SOURCE_DIR}/tests/gwb-grid/${test_name}.wb ${CMAKE_SOURCE_DIR}/tests/gwb-grid/${test_name}.grid)
+  endif()
+
+  if(WB_RUN_TESTS_WITH_VALGRIND)
+    add_test(NAME ${test_name}_valgrind
+             WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+             COMMAND valgrind -v --leak-check=full --error-exitcode=1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gwb-grid${CMAKE_EXECUTABLE_SUFFIX}  ${CMAKE_SOURCE_DIR}/tests/gwb-grid/${test_name}.wb ${CMAKE_SOURCE_DIR}/tests/gwb-grid/${test_name}.grid)
+  endif()
 endforeach(test_source)
 
 add_custom_target(update_test_references 


### PR DESCRIPTION
Adding gdb and valgrind as extra testers will help finding problems faster and more easily. This allow to run the tester with either or both gdb and valgrind. This pull requests also adds a github action tester which tests both of them. They fail if they find an issue.