### PR TITLE
Only read world build file on one MPI rank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added some tips and tricks in the doc/sphinx/developer_manual/contributing_to_the_code/tips_and_tricks.md file. \[Haoyuan Li; 2023-02-09; [#472](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/472)]
 - Added operation options `add`, `substract` and `replace defined only` to the the composition plugins \[Menno Fraters; 2023-02-17; [#474](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/474)\]
 - Added a new compositional model for subducting slab models such that ensures a smooth transition of compositional value from one part of a compositional layer to the other side of the layer. This is based on Arushi Saxena's fault composition plugin with the same name ([#356](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/356)) \[Menno Fraters; 2023-02-18; [#477](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/356)\]
- 
+- If World Builder is configured with MPI it now reads input files on a single process and distributes them via MPI to other processes to reduce I/O load. This can be extended in the future to other input files. \[Rene Gassmoeller; 2023-04-13; [#480](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/480)\]
+
 ### Changed
 - The World Builder Visualizer will now use zlib compression for vtu files by default. If zlib is not available binary output will be used. \[Menno Fraters; 2021-06-26; [#282](github.com/GeodynamicWorldBuilder/WorldBuilder/pull/282)\]
 - The return argument type of the distance_point_from_curved_planes function has been converted from a map to a struct, requiring a change in the plugin interfaces for 'fault_models' and 'subducting_plate_models', but significantly increasing the speed of the function and all functions that access its returned values. \[Rene Gassmoeller; 2021-06-27; [#289](github.com/GeodynamicWorldBuilder/WorldBuilder/issues/289)\]

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -416,6 +416,16 @@ namespace WorldBuilder
      */
     std::array<std::array<double,3>,3>
     euler_angles_to_rotation_matrix(double phi1, double theta, double phi2);
+
+    /**
+     * Read a file and distribute the content over all MPI processes.
+     * If WB_WITH_MPI is not defined, this function will just read the file.
+     *
+     * @param filename The name of the file to read.
+     * @return The content of the file.
+    */
+    std::string
+    read_and_distribute_file_content(const std::string &filename);
   } // namespace Utilities
 } // namespace WorldBuilder
 

--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -107,16 +107,9 @@ namespace WorldBuilder
       }
 
     path_level =0;
-    // Now read in the world builder file into a file stream and
-    // put it into a the rapidjason document
-    std::ifstream json_input_stream(filename.c_str());
-
-    // Get world builder file and check whether it exists
-    WBAssertThrow(json_input_stream.good(),
-                  "Could not find the world builder file at the specified location: " + filename);
-
-    WBAssert(json_input_stream, "Could not read the world builder file.");
-
+    // Now read in the world builder file into a stringstream and
+    // put it into a the rapidjson document
+    std::stringstream json_input_stream(WorldBuilder::Utilities::read_and_distribute_file_content(filename));
     rapidjson::IStreamWrapper isw(json_input_stream);
 
     // relaxing sytax by allowing comments () for now, maybe also allow trailing commas and (kParseTrailingCommasFlag) and nan's, inf etc (kParseNanAndInfFlag)?
@@ -147,7 +140,6 @@ namespace WorldBuilder
                                                                             ));
 
     WBAssertThrow(parameters.IsObject(), "World builder file is is not an object.");
-    json_input_stream.close();
 
 
     SchemaDocument schema(declarations);

--- a/source/world_builder/utilities.cc
+++ b/source/world_builder/utilities.cc
@@ -1111,78 +1111,96 @@ namespace WorldBuilder
       std::string data_string;
 
 #ifdef WB_WITH_MPI
-      const unsigned int invalid_unsigned_int = static_cast<unsigned int>(-1);
-
-      const MPI_Comm comm = MPI_COMM_WORLD;
-      int my_rank = invalid_unsigned_int;
-      MPI_Comm_rank(comm, &my_rank);
-      if (my_rank == 0)
+      int mpi_initialized;
+      MPI_Initialized(&mpi_initialized);
+      if (mpi_initialized != 0)
         {
-          std::size_t filesize;
-          std::ifstream filestream;
-          filestream.open(filename.c_str());
+          const unsigned int invalid_unsigned_int = static_cast<unsigned int>(-1);
 
-          // Need to convert to unsigned int, because MPI_Bcast does not support
-          // size_t or const unsigned int
-          unsigned int invalid_file_size = invalid_unsigned_int;
-
-          if (!filestream)
+          const MPI_Comm comm = MPI_COMM_WORLD;
+          int my_rank = invalid_unsigned_int;
+          MPI_Comm_rank(comm, &my_rank);
+          if (my_rank == 0)
             {
-              // broadcast failure state, then throw
-              const int ierr = MPI_Bcast(&invalid_file_size, 1, MPI_UNSIGNED, 0, comm);
-              WBAssertThrow (ierr,
-                             std::string("Could not open file <") + filename + ">.");
-            }
+              std::size_t filesize;
+              std::ifstream filestream;
+              filestream.open(filename.c_str());
 
-          // Read data from disk
-          std::stringstream datastream;
+              // Need to convert to unsigned int, because MPI_Bcast does not support
+              // size_t or const unsigned int
+              unsigned int invalid_file_size = invalid_unsigned_int;
 
-          try
-            {
-              datastream << filestream.rdbuf();
-            }
-          catch (const std::ios::failure &)
-            {
-              // broadcast failure state, then throw
-              const int ierr = MPI_Bcast(&invalid_file_size, 1, MPI_UNSIGNED, 0, comm);
+              if (!filestream)
+                {
+                  // broadcast failure state, then throw
+                  const int ierr = MPI_Bcast(&invalid_file_size, 1, MPI_UNSIGNED, 0, comm);
+                  WBAssertThrow (ierr,
+                                 std::string("Could not open file <") + filename + ">.");
+                }
+
+              // Read data from disk
+              std::stringstream datastream;
+
+              try
+                {
+                  datastream << filestream.rdbuf();
+                }
+              catch (const std::ios::failure &)
+                {
+                  // broadcast failure state, then throw
+                  const int ierr = MPI_Bcast(&invalid_file_size, 1, MPI_UNSIGNED, 0, comm);
+                  WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+                  WBAssertThrow (false,
+                                 std::string("Could not read file content from <") + filename + ">.");
+                }
+
+              data_string = datastream.str();
+              filesize = data_string.size();
+
+              // Distribute data_size and data across processes
+              int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
               WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
-              WBAssertThrow (false,
-                             std::string("Could not read file content from <") + filename + ">.");
+
+              // Receive and store data
+              ierr = MPI_Bcast(&data_string[0],
+                               filesize,
+                               MPI_CHAR,
+                               0,
+                               comm);
+              WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
             }
+          else
+            {
+              // Prepare for receiving data
+              unsigned int filesize = 0;
+              int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
+              WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+              WBAssertThrow(filesize != invalid_unsigned_int,
+                            std::string("Could not open file <") + filename + ">.");
 
-          data_string = datastream.str();
-          filesize = data_string.size();
+              data_string.resize(filesize);
 
-          // Distribute data_size and data across processes
-          int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
-          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
-
-          // Receive and store data
-          ierr = MPI_Bcast(&data_string[0],
-                           filesize,
-                           MPI_CHAR,
-                           0,
-                           comm);
-          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+              // Receive and store data
+              ierr = MPI_Bcast(&data_string[0],
+                               filesize,
+                               MPI_CHAR,
+                               0,
+                               comm);
+              WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+            }
         }
       else
         {
-          // Prepare for receiving data
-          unsigned int filesize = 0;
-          int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
-          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
-          WBAssertThrow(filesize != invalid_unsigned_int,
-                        std::string("Could not open file <") + filename + ">.");
-
-          data_string.resize(filesize);
-
-          // Receive and store data
-          ierr = MPI_Bcast(&data_string[0],
-                           filesize,
-                           MPI_CHAR,
-                           0,
-                           comm);
-          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+          std::ifstream filestream;
+          filestream.open(filename.c_str());
+          if (!filestream)
+            {
+              WBAssertThrow (false,
+                             std::string("Could not open file <") + filename + ">.");
+            }
+          std::stringstream datastream;
+          datastream << filestream.rdbuf();
+          data_string = datastream.str();
         }
 #else
       std::ifstream filestream;

--- a/source/world_builder/utilities.cc
+++ b/source/world_builder/utilities.cc
@@ -1110,6 +1110,7 @@ namespace WorldBuilder
     {
       std::string data_string;
 
+#ifdef WB_WITH_MPI
       const unsigned int invalid_unsigned_int = static_cast<unsigned int>(-1);
 
       const MPI_Comm comm = MPI_COMM_WORLD;
@@ -1183,6 +1184,18 @@ namespace WorldBuilder
                            comm);
           WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
         }
+#else
+      std::ifstream filestream;
+      filestream.open(filename.c_str());
+      if (!filestream)
+        {
+          WBAssertThrow (false,
+                         std::string("Could not open file <") + filename + ">.");
+        }
+      std::stringstream datastream;
+      datastream << filestream.rdbuf();
+      data_string = datastream.str();
+#endif
 
       return data_string;
     }

--- a/source/world_builder/utilities.cc
+++ b/source/world_builder/utilities.cc
@@ -22,6 +22,13 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <sstream>
+#include <fstream>
+
+#ifdef WB_WITH_MPI
+#define OMPI_SKIP_MPICXX 1
+#include <mpi.h>
+#endif
 
 #include <world_builder/coordinate_system.h>
 #include "world_builder/nan.h"
@@ -1096,6 +1103,88 @@ namespace WorldBuilder
       rot_matrix[2][1] = -sin(theta)*cos(phi1);
       rot_matrix[2][2] = cos(theta);
       return rot_matrix;
+    }
+
+    std::string
+    read_and_distribute_file_content(const std::string &filename)
+    {
+      std::string data_string;
+
+      const unsigned int invalid_unsigned_int = static_cast<unsigned int>(-1);
+
+      const MPI_Comm comm = MPI_COMM_WORLD;
+      int my_rank = invalid_unsigned_int;
+      MPI_Comm_rank(comm, &my_rank);
+      if (my_rank == 0)
+        {
+          std::size_t filesize;
+          std::ifstream filestream;
+          filestream.open(filename.c_str());
+
+          // Need to convert to unsigned int, because MPI_Bcast does not support
+          // size_t or const unsigned int
+          unsigned int invalid_file_size = invalid_unsigned_int;
+
+          if (!filestream)
+            {
+              // broadcast failure state, then throw
+              const int ierr = MPI_Bcast(&invalid_file_size, 1, MPI_UNSIGNED, 0, comm);
+              WBAssertThrow (ierr,
+                             std::string("Could not open file <") + filename + ">.");
+            }
+
+          // Read data from disk
+          std::stringstream datastream;
+
+          try
+            {
+              datastream << filestream.rdbuf();
+            }
+          catch (const std::ios::failure &)
+            {
+              // broadcast failure state, then throw
+              const int ierr = MPI_Bcast(&invalid_file_size, 1, MPI_UNSIGNED, 0, comm);
+              WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+              WBAssertThrow (false,
+                             std::string("Could not read file content from <") + filename + ">.");
+            }
+
+          data_string = datastream.str();
+          filesize = data_string.size();
+
+          // Distribute data_size and data across processes
+          int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
+          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+
+          // Receive and store data
+          ierr = MPI_Bcast(&data_string[0],
+                           filesize,
+                           MPI_CHAR,
+                           0,
+                           comm);
+          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+        }
+      else
+        {
+          // Prepare for receiving data
+          unsigned int filesize = 0;
+          int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
+          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+          WBAssertThrow(filesize != invalid_unsigned_int,
+                        std::string("Could not open file <") + filename + ">.");
+
+          data_string.resize(filesize);
+
+          // Receive and store data
+          ierr = MPI_Bcast(&data_string[0],
+                           filesize,
+                           MPI_CHAR,
+                           0,
+                           comm);
+          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+        }
+
+      return data_string;
     }
 
     template std::array<double,2> convert_point_to_array<2>(const Point<2> &point_);


### PR DESCRIPTION
Same PR as geodynamics/aspect#5132. This avoids opening the world builder input file on every MPI rank. Instead it is only opened and read on the first rank and then broadcast via MPI to all processes. This is very useful for large-scale run on HPC clusters, because the file system can easily get overwhelmed when tens of thousands of MPI processes access the same file.