### PR TITLE
Remove extra_navbar from sphinx conf.py

### DIFF
--- a/doc/sphinx/conf.in.py
+++ b/doc/sphinx/conf.in.py
@@ -78,7 +78,6 @@ html_theme_options = {
     "use_edit_page_button": True,
     "use_issues_button": True,
     "home_page_in_toc":False,
-    "extra_navbar": "",
     "extra_footer":"Built with <a href='https://www.sphinx-doc.org/'>Sphinx</a> using a theme provided by <a href='https://ebp.jupyterbook.org/'>Executable Book Project</a>",
 }
 

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -77,7 +77,6 @@ html_theme_options = {
     "use_edit_page_button": True,
     "use_issues_button": True,
     "home_page_in_toc":False,
-    "extra_navbar": "",
     "extra_footer":"Built with <a href='https://www.sphinx-doc.org/'>Sphinx</a> using a theme provided by <a href='https://ebp.jupyterbook.org/'>Executable Book Project</a>",
 }
 


### PR DESCRIPTION
`extra_navbar` was removed in https://github.com/executablebooks/sphinx-book-theme/pull/640, and now throws a warning. Since warning are turned in to errors by the settings, we probably need to remove this setting. I will see how the results look like online and see if it need tweaks.