### PR TITLE
Upgrade ubuntu 18 tester to 20.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -385,7 +385,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-18.04']
+        os: ['ubuntu-20.04']
         build_type: ['Debug']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The ubuntu 18 tester no longer seems pick up the work, and it reaches end of support soon anyway (31 May). So upgrading the old version tester to ubuntu 20.