### PR TITLE
Inline a heavily used function.

### DIFF
--- a/include/world_builder/objects/natural_coordinate.h
+++ b/include/world_builder/objects/natural_coordinate.h
@@ -93,6 +93,32 @@ namespace WorldBuilder
          */
         std::array<double,3> coordinates;
     };
+
+
+    inline
+    double
+    NaturalCoordinate::get_depth_coordinate() const
+    {
+      switch (coordinate_system)
+        {
+          case CoordinateSystem::cartesian:
+          {
+            return coordinates[2];
+            break;
+          }
+
+          case CoordinateSystem::spherical:
+          {
+            return coordinates[0];
+            break;
+          }
+
+          default:
+            WBAssertThrow (false, "Coordinate system not implemented.");
+        }
+
+      return 0;
+    }
   }
 }
 

--- a/source/world_builder/objects/natural_coordinate.cc
+++ b/source/world_builder/objects/natural_coordinate.cc
@@ -101,23 +101,6 @@ namespace WorldBuilder
     }
 
 
-    double NaturalCoordinate::get_depth_coordinate() const
-    {
-      switch (coordinate_system)
-        {
-          case CoordinateSystem::cartesian:
-            return coordinates[2];
-
-          case CoordinateSystem::spherical:
-            return coordinates[0];
-
-          default:
-            WBAssertThrow (false, "Coordinate system not implemented.");
-        }
-
-      return 0;
-    }
-
     double &NaturalCoordinate::get_ref_depth_coordinate()
     {
       switch (coordinate_system)


### PR DESCRIPTION
This function is used frequently in `Features::Fault::properties` and is pretty short. Inlining it significantly reduces the cost of the function (from about 30 to ~5 instructions) and saves on the order of 1% of the world builder time in my model with many faults. Not much, but the change is also small.