### PR TITLE
[WIP] Optimize bezier curve find closest point

### DIFF
--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -358,7 +358,8 @@ namespace WorldBuilder
         }
       else
         {
-          for ( size_t cp_i = 0; cp_i < control_points.size(); ++cp_i)
+          const size_t max_cp_i = 1; //control_points.size();
+          for ( size_t cp_i = 0; cp_i < max_cp_i; ++cp_i)
             {
               const Point<2> &p1 = points[cp_i];
               const Point<2> &p2 = points[cp_i+1];

--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -389,7 +389,7 @@ namespace WorldBuilder
 
               if (min_squared_distance_cartesian_temp_dg < minimal_distance)
                 {
-                  minimal_distance = distance;
+                  minimal_distance = min_squared_distance_cartesian_temp_dg;
                   closest_segment = cp_i;
                   best_estimate = est;
                 }

--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -396,191 +396,191 @@ namespace WorldBuilder
             }
 
           // Second: Find the closest point on the segment
-            {
-              const size_t cp_i = closest_segment;
-              const Point<2> &p1 = points[cp_i];
-              const Point<2> &p2 = points[cp_i+1];
-              // Getting an estimate for where the closest point is with a linear approximation
-              Point<2> P1P2 = p2-p1;
-              Point<2> P1Pc = check_point-p1;
+          {
+            const size_t cp_i = closest_segment;
+            const Point<2> &p1 = points[cp_i];
+            const Point<2> &p2 = points[cp_i+1];
+            // Getting an estimate for where the closest point is with a linear approximation
+            Point<2> P1P2 = p2-p1;
+            Point<2> P1Pc = check_point-p1;
 
-              const double P2P2_dot = P1P2*P1P2;
+            const double P2P2_dot = P1P2*P1P2;
 
-              // est=estimate of solution
-              double est =  P2P2_dot > 0.0 ? std::min(1.,std::max(0.,(P1Pc*P1P2) / P2P2_dot)) : 1.0; 
-              bool found = false;
+            // est=estimate of solution
+            double est =  P2P2_dot > 0.0 ? std::min(1.,std::max(0.,(P1Pc*P1P2) / P2P2_dot)) : 1.0;
+            bool found = false;
 #ifndef NDEBUG
-              std::stringstream output;
+            std::stringstream output;
 #endif
-              Point<2> a = 3.*control_points[cp_i][0]-3.*control_points[cp_i][1]+points[cp_i+1]-points[cp_i];
-              Point<2> b = 3.*points[cp_i] - 6.*control_points[cp_i][0]+3.*control_points[cp_i][1];
-              Point<2> c = -3.*points[cp_i] + 3.*control_points[cp_i][0];
-              Point<2> d = points[cp_i];
+            Point<2> a = 3.*control_points[cp_i][0]-3.*control_points[cp_i][1]+points[cp_i+1]-points[cp_i];
+            Point<2> b = 3.*points[cp_i] - 6.*control_points[cp_i][0]+3.*control_points[cp_i][1];
+            Point<2> c = -3.*points[cp_i] + 3.*control_points[cp_i][0];
+            Point<2> d = points[cp_i];
 
-              Point<2> estimate_point = a*est*est*est+b*est*est+c*est+d;
-              const double cos_cp_lat = cos(cp[1]);
+            Point<2> estimate_point = a*est*est*est+b*est*est+c*est+d;
+            const double cos_cp_lat = cos(cp[1]);
 #ifndef NDEBUG
-              const double cos_lat_dg = cos(estimate_point[1]);
-              const double sin_d_long_h_dg = sin((estimate_point[0]-cp[0])*0.5);
-              const double sin_d_lat_h_dg = sin((estimate_point[1]-cp[1])*0.5);
-              const double min_squared_distance_cartesian_temp_dg = sin_d_lat_h_dg*sin_d_lat_h_dg+sin_d_long_h_dg*sin_d_long_h_dg*cos_cp_lat*cos_lat_dg;
-              output << "cp_i=" << cp_i << ", init est = " << est << ", min_squared_distance = " << min_squared_distance << ", min_squared_distance_cartesian_temp_dg: " << min_squared_distance_cartesian_temp_dg << ", p1: " << p1 << ", p2: " << p2 << std::endl;
-              output  << std::setprecision(6) << "  wolfram: sin((" << a[1] << "*x^3+" << b[1] << "*x^2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << ")*.5)^2+sin((" << a[0] << "*x^3+" << b[0] << "*x^2+"<< c[0] << "*x+" << d[0] << "-" << cp[0] << ")*.5)^2*cos(" << cp[1] << ")*cos(" << a[1] << "*x^3+" << b[1] << "*x^2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << ") with x=" << est << std::endl;
-              output  << std::setprecision(10) << "  python: y=np.sin((" << a[1] << "*x**3+" << b[1] << "*x**2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << ")*.5)**2+np.sin((" << a[0] << "*x**3+" << b[0] << "*x**2+"<< c[0] << "*x+" << d[0] << "-" << cp[0] << ")*.5)**2*np.cos(" << cp[1] << ")*np.cos(" << a[1] << "*x**3+" << b[1] << "*x**2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << "); x=" << est << std::endl;
+            const double cos_lat_dg = cos(estimate_point[1]);
+            const double sin_d_long_h_dg = sin((estimate_point[0]-cp[0])*0.5);
+            const double sin_d_lat_h_dg = sin((estimate_point[1]-cp[1])*0.5);
+            const double min_squared_distance_cartesian_temp_dg = sin_d_lat_h_dg*sin_d_lat_h_dg+sin_d_long_h_dg*sin_d_long_h_dg*cos_cp_lat*cos_lat_dg;
+            output << "cp_i=" << cp_i << ", init est = " << est << ", min_squared_distance = " << min_squared_distance << ", min_squared_distance_cartesian_temp_dg: " << min_squared_distance_cartesian_temp_dg << ", p1: " << p1 << ", p2: " << p2 << std::endl;
+            output  << std::setprecision(6) << "  wolfram: sin((" << a[1] << "*x^3+" << b[1] << "*x^2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << ")*.5)^2+sin((" << a[0] << "*x^3+" << b[0] << "*x^2+"<< c[0] << "*x+" << d[0] << "-" << cp[0] << ")*.5)^2*cos(" << cp[1] << ")*cos(" << a[1] << "*x^3+" << b[1] << "*x^2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << ") with x=" << est << std::endl;
+            output  << std::setprecision(10) << "  python: y=np.sin((" << a[1] << "*x**3+" << b[1] << "*x**2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << ")*.5)**2+np.sin((" << a[0] << "*x**3+" << b[0] << "*x**2+"<< c[0] << "*x+" << d[0] << "-" << cp[0] << ")*.5)**2*np.cos(" << cp[1] << ")*np.cos(" << a[1] << "*x**3+" << b[1] << "*x**2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << "); x=" << est << std::endl;
 #endif
-              for (size_t newton_i = 0; newton_i < 150; newton_i++)
-                {
-                  // based on https://stackoverflow.com/questions/2742610/closest-point-on-a-cubic-bezier-curve
-                  estimate_point = a*est*est*est+b*est*est+c*est+d;
+            for (size_t newton_i = 0; newton_i < 150; newton_i++)
+              {
+                // based on https://stackoverflow.com/questions/2742610/closest-point-on-a-cubic-bezier-curve
+                estimate_point = a*est*est*est+b*est*est+c*est+d;
 
-                  double sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
-                  double sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
-                  const double cos_d_lat = cos(estimate_point[1]-cp[1]);
-                  const double squared_distance_cartesian = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos_d_lat;
+                double sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
+                double sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
+                const double cos_d_lat = cos(estimate_point[1]-cp[1]);
+                const double squared_distance_cartesian = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos_d_lat;
 
-                  if (squared_distance_cartesian > min_squared_distance * 1.33)
+                if (squared_distance_cartesian > min_squared_distance * 1.33)
                   {
                     found = true;
                     break;
                   }
 
-                  double sin_dlat = sin(estimate_point[1]-cp[1]);
-                  double cos_dlong_h = cos(0.5*(estimate_point[0]-cp[0]));
-                  double cos_dlat_h = cos(0.5*(estimate_point[1]-cp[1]));
-                  double deriv_long = (3.0*a[0]*est*est+2.0*b[0]*est+c[0]);
-                  double deriv_lat = (3.0*a[1]*est*est+2.0*b[1]*est+c[1]);
+                double sin_dlat = sin(estimate_point[1]-cp[1]);
+                double cos_dlong_h = cos(0.5*(estimate_point[0]-cp[0]));
+                double cos_dlat_h = cos(0.5*(estimate_point[1]-cp[1]));
+                double deriv_long = (3.0*a[0]*est*est+2.0*b[0]*est+c[0]);
+                double deriv_lat = (3.0*a[1]*est*est+2.0*b[1]*est+c[1]);
 
-                  const double squared_distance_cartesian_derivative = cos_cp_lat*(-deriv_lat)*sin_d_long_h*sin_d_long_h*sin_dlat+cos_cp_lat*deriv_long*sin_d_long_h*cos_dlong_h*cos_d_lat+deriv_lat*sin_d_lat_h*cos_dlat_h;
-                  double update = NaN::DSNAN;
-                  if (std::fabs(squared_distance_cartesian_derivative) > 1e-16)
-                    {
-                      const double squared_distance_cartesian_second_derivative = cos_cp_lat*cos_d_lat*(-0.5*deriv_long*deriv_long*sin_d_long_h*sin_d_long_h+0.5*deriv_long*deriv_long*cos_dlong_h*cos_dlong_h+(6.0*a[0]*est+2.0*b[0])*sin_d_long_h*cos_dlong_h)+cos_cp_lat*sin_d_long_h*sin_d_long_h*(deriv_lat*deriv_lat*(-cos_d_lat)-(6.0*a[1]*est+2.0*b[1])*sin_dlat)-2.0*cos_cp_lat*deriv_long*deriv_lat*sin_d_long_h*cos_dlong_h*sin_dlat-0.5*deriv_lat*deriv_lat*sin_d_lat_h*sin_d_lat_h+0.5*deriv_lat*deriv_lat*cos_dlat_h*cos_dlat_h+(6.0*a[1]*est+2.0*b[1])*sin_d_lat_h*cos_dlat_h;
-
-#ifndef NDEBUG
-                      const double squared_distance_cartesian_full = sin((a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*0.5)*sin((a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*0.5)+sin((a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])*0.5)*sin((a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])*0.5)*cos(cp[1])*cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]);
-                      double cos_dlong = cos(estimate_point[0]-cp[0]);
-                      const double squared_distance_cartesian_derivative_full = cos(cp[1])*(-(3.0*a[1]*est*est+2.0*b[1]*est+c[1]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])+cos(cp[1])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])+(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]));
-                      const double squared_distance_cartesian_second_derivative_full = cos(cp[1])*cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*(-0.5*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))+0.5*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))+(6.0*a[0]*est+2.0*b[0])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])))+cos(cp[1])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*((3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(-cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))-(6.0*a[1]*est+2.0*b[1])*sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))-2.0*cos(cp[1])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])-0.5*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))+0.5*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))+(6.0*a[1]*est+2.0*b[1])*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]));
-                      output <<"sqd = " << squared_distance_cartesian <<":" << squared_distance_cartesian_full << ", diff=" << squared_distance_cartesian-squared_distance_cartesian_full << ", sqdd: " << squared_distance_cartesian_derivative <<":" << squared_distance_cartesian_derivative_full << ", diff="<< squared_distance_cartesian_derivative-squared_distance_cartesian_derivative_full << ", sqdd: " << squared_distance_cartesian_second_derivative << ":" << squared_distance_cartesian_second_derivative_full << ", diff= " << squared_distance_cartesian_second_derivative-squared_distance_cartesian_second_derivative_full << ", est: " << est << std::endl;
-#endif
-                      // the local minimum is where  squared_distance_cartesian_derivative=0 and squared_distance_cartesian_derivative>=0
-                      update = std::min(0.5,std::max(-0.5,squared_distance_cartesian_derivative/std::fabs(squared_distance_cartesian_second_derivative)));
-                      double line_search = 1.;
-                      double est_test = est-update*line_search;
-                      double squared_distance_cartesian_test = squared_distance_cartesian;
-                      double squared_distance_cartesian_test_previous = squared_distance_cartesian;
-                      double line_search_step = 2./3.;
-
-                      for (unsigned int i = 0; i < 10; i++)
-                        {
-                          est_test = est-update*line_search;
-                          estimate_point = a*est_test*est_test*est_test+b*est_test*est_test+c*est_test+d;
-
-                          sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
-                          sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
-                          squared_distance_cartesian_test = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos(estimate_point[1]-cp[1]);
+                const double squared_distance_cartesian_derivative = cos_cp_lat*(-deriv_lat)*sin_d_long_h*sin_d_long_h*sin_dlat+cos_cp_lat*deriv_long*sin_d_long_h*cos_dlong_h*cos_d_lat+deriv_lat*sin_d_lat_h*cos_dlat_h;
+                double update = NaN::DSNAN;
+                if (std::fabs(squared_distance_cartesian_derivative) > 1e-16)
+                  {
+                    const double squared_distance_cartesian_second_derivative = cos_cp_lat*cos_d_lat*(-0.5*deriv_long*deriv_long*sin_d_long_h*sin_d_long_h+0.5*deriv_long*deriv_long*cos_dlong_h*cos_dlong_h+(6.0*a[0]*est+2.0*b[0])*sin_d_long_h*cos_dlong_h)+cos_cp_lat*sin_d_long_h*sin_d_long_h*(deriv_lat*deriv_lat*(-cos_d_lat)-(6.0*a[1]*est+2.0*b[1])*sin_dlat)-2.0*cos_cp_lat*deriv_long*deriv_lat*sin_d_long_h*cos_dlong_h*sin_dlat-0.5*deriv_lat*deriv_lat*sin_d_lat_h*sin_d_lat_h+0.5*deriv_lat*deriv_lat*cos_dlat_h*cos_dlat_h+(6.0*a[1]*est+2.0*b[1])*sin_d_lat_h*cos_dlat_h;
 
 #ifndef NDEBUG
-                          sin_dlat = sin(estimate_point[1]-cp[1]);
-                          cos_dlong = cos(estimate_point[0]-cp[0]);
-                          deriv_long = (3.0*a[0]*est_test*est_test+2.0*b[0]*est_test+c[0]);
-                          deriv_lat = (3.0*a[1]*est_test*est_test+2.0*b[1]*est_test+c[1]);
-                          const double squared_distance_cartesian_derivative_test = cos_cp_lat*(-deriv_lat)*sin_d_long_h*sin_d_long_h*sin_dlat+cos_cp_lat*deriv_long*sin_d_long_h*cos_dlong_h*cos_d_lat+deriv_lat*sin_d_lat_h*cos_dlat_h;
-                          const double squared_distance_cartesian_second_derivative_test = cos_cp_lat*cos_d_lat*(-0.5*deriv_long*deriv_long*sin_d_long_h*sin_d_long_h+0.5*deriv_long*deriv_long*cos_dlong_h*cos_dlong_h+(6.0*a[0]*est_test+2.0*b[0])*sin_d_long_h*cos_dlong_h)+cos_cp_lat*sin_d_long_h*sin_d_long_h*(deriv_lat*deriv_lat*(-cos_d_lat)-(6.0*a[1]*est_test+2.0*b[1])*sin_dlat)-2.0*cos_cp_lat*deriv_long*deriv_lat*sin_d_long_h*cos_dlong_h*sin_dlat-0.5*deriv_lat*deriv_lat*sin_d_lat_h*sin_d_lat_h+0.5*deriv_lat*deriv_lat*cos_dlat_h*cos_dlat_h+(6.0*a[1]*est_test+2.0*b[1])*sin_d_lat_h*cos_dlat_h;
-                          output << "    i: " << cp_i << ", ni: " << newton_i<< ", lsi: " << i << ", line_search_step=" << line_search_step << ": squared_distance_cartesian_test = " << squared_distance_cartesian_test << ", diff= " << squared_distance_cartesian_test-squared_distance_cartesian << ", tests: " << (squared_distance_cartesian_test_previous < squared_distance_cartesian ? "true" : "false") << ":" << (squared_distance_cartesian_test > squared_distance_cartesian_test_previous ? "true" : "false") << ", est_test=" << est_test << ", update=" << update << ", ls=" << line_search << ", up*ls=" << update *line_search << ", test deriv =" << squared_distance_cartesian_derivative_test  << ", test upate=" << squared_distance_cartesian_derivative_test/fabs(squared_distance_cartesian_second_derivative_test) << ", p1=" << p1 << ", p2= " << p2 << ", poc= " << a *est_test *est_test *est_test+b *est_test *est_test+c *est_test+d << ", cp= " <<  check_point << ", ds:" << ((a*est_test*est_test*est_test+b*est_test*est_test+c*est_test+d)-check_point).norm_square() << ":" << min_squared_distance_cartesian_temp_dg << ", diff = " << squared_distance_cartesian_test-min_squared_distance_cartesian_temp_dg<< std::endl;
+                    const double squared_distance_cartesian_full = sin((a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*0.5)*sin((a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*0.5)+sin((a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])*0.5)*sin((a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])*0.5)*cos(cp[1])*cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]);
+                    double cos_dlong = cos(estimate_point[0]-cp[0]);
+                    const double squared_distance_cartesian_derivative_full = cos(cp[1])*(-(3.0*a[1]*est*est+2.0*b[1]*est+c[1]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])+cos(cp[1])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])+(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]));
+                    const double squared_distance_cartesian_second_derivative_full = cos(cp[1])*cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*(-0.5*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))+0.5*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))+(6.0*a[0]*est+2.0*b[0])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])))+cos(cp[1])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*((3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(-cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))-(6.0*a[1]*est+2.0*b[1])*sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))-2.0*cos(cp[1])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])-0.5*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))+0.5*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))+(6.0*a[1]*est+2.0*b[1])*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]));
+                    output <<"sqd = " << squared_distance_cartesian <<":" << squared_distance_cartesian_full << ", diff=" << squared_distance_cartesian-squared_distance_cartesian_full << ", sqdd: " << squared_distance_cartesian_derivative <<":" << squared_distance_cartesian_derivative_full << ", diff="<< squared_distance_cartesian_derivative-squared_distance_cartesian_derivative_full << ", sqdd: " << squared_distance_cartesian_second_derivative << ":" << squared_distance_cartesian_second_derivative_full << ", diff= " << squared_distance_cartesian_second_derivative-squared_distance_cartesian_second_derivative_full << ", est: " << est << std::endl;
 #endif
-                          if (i > 0 && (squared_distance_cartesian_test > squared_distance_cartesian_test_previous))
-                            {
-                              if (squared_distance_cartesian_test_previous-squared_distance_cartesian < 0)
-                                {
-                                  line_search *= 1/line_search_step;
-                                  break;
-                                }
-                              if (i> 1)
-                                {
-                                  line_search *= (1/line_search_step)*(1/line_search_step);
-                                  est_test = est-update*line_search;
-                                  estimate_point = a*est_test*est_test*est_test+b*est_test*est_test+c*est_test+d;
+                    // the local minimum is where  squared_distance_cartesian_derivative=0 and squared_distance_cartesian_derivative>=0
+                    update = std::min(0.5,std::max(-0.5,squared_distance_cartesian_derivative/std::fabs(squared_distance_cartesian_second_derivative)));
+                    double line_search = 1.;
+                    double est_test = est-update*line_search;
+                    double squared_distance_cartesian_test = squared_distance_cartesian;
+                    double squared_distance_cartesian_test_previous = squared_distance_cartesian;
+                    double line_search_step = 2./3.;
 
-                                  sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
-                                  sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
-                                  squared_distance_cartesian_test_previous = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos(estimate_point[1]-cp[1]);
-                                  line_search_step = std::min(line_search_step*(11./10.),0.95);
-                                  continue;
-                                }
-                            }
-                          squared_distance_cartesian_test_previous = squared_distance_cartesian_test;
-
-                          line_search *= line_search_step;
-                        }
-#ifndef NDEBUG
-                      output << "    i: " << cp_i << ", ni: " << newton_i<< ", est= " << est-update *line_search << ", ls:" << line_search << ": squared_distance_cartesian_test = " << squared_distance_cartesian_test << ", diff= " << squared_distance_cartesian_test-squared_distance_cartesian << std::endl;
-#endif
-                      est -= update*line_search;
-                    }
-
-                  if (std::fabs(squared_distance_cartesian_derivative) <= 1e-16 || std::fabs(update) < 1e-4 || est < -0.1 || est > 1.1)
-                    {
-                      found = true;
-                      break;
-                    }
-                }
-
-#ifndef NDEBUG
-              WBAssertThrow(found, "Could not find a good solution. " << output.str());
-#else
-              WBAssertThrow(found, "Could not find a good solution. Enable debug mode for more info.");
-#endif
-
-              estimate_point = a*est*est*est+b*est*est+c*est+d;
-
-              const double sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
-              const double sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
-
-              const double min_squared_distance_cartesian_temp = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos(estimate_point[1]-cp[1]);
-
-              if (min_squared_distance_cartesian_temp < min_squared_distance)
-                {
-                  if (est >= -1e-8 && est-1. <= 1e-8)
-                    {
-                      min_squared_distance = min_squared_distance_cartesian_temp;
-                      const Point<2> point_on_curve = a*est*est*est+b*est*est+c*est+d;
-
-                      // the sign is rotating the derivative by 90 degrees.
-                      // When moving in the direction of increasing t, left is positve and right is negative.
-                      // https://www.wolframalpha.com/input?i=d%2Fdt+%281-t%29*%281-t%29*%281-t%29*a+%2B+3*%281-t%29*%281-t%29*t*b+%2B+3.*%281-t%29*t*t*c%2Bt*t*t*d
-                      const Point<2> derivative_point = points[cp_i]*((6.-3.*est)*est-3.) + control_points[cp_i][0]*(est*(9*est-12)+3)
-                                                        + control_points[cp_i][1]*(6.-9.*est)*est + points[cp_i+1]*3.*est*est;
-                      //https://www.wolframalpha.com/input?i=d%2Fdt+d%2Fdt+%281-t%29*%281-t%29*%281-t%29*a+%2B+3*%281-t%29*%281-t%29*t*b+%2B+3.*%281-t%29*t*t*c%2Bt*t*t*d
-                      const Point<2> second_derivative_point = points[cp_i]*(6-6*est) + control_points[cp_i][0]*(18*est-12)
-                                                               + control_points[cp_i][1]*-18*est+ points[cp_i+1]*6*est;
-
-                      Point<2> tangent_point = derivative_point - point_on_curve;
-                      // if angle between check point and tangent point is larget than 90 degrees, return a negative distance
-                      const double dot_product = (tangent_point*(check_point-point_on_curve));
-                      const double sign = dot_product < 0. ? -1. : 1.;
-                      tangent_point = Point<2>(-tangent_point[1],tangent_point[0],tangent_point.get_coordinate_system());
-
-                      closest_point_on_curve.distance = sign*std::sqrt(min_squared_distance);
-                      closest_point_on_curve.parametric_fraction = est;
-                      closest_point_on_curve.interpolation_fraction = NaN::DSNAN; //arc_length(i,real_roots[root_i])/lengths[i];
-                      closest_point_on_curve.index = cp_i;
-                      closest_point_on_curve.point = point_on_curve;
-                      Point<2> normal = point_on_curve;
+                    for (unsigned int i = 0; i < 10; i++)
                       {
-                        Point<2> derivative = a*est*est+b*est+c;
-                        normal=derivative;
-                        double normal_size = derivative.norm();
-                        if (normal_size > 0.)
+                        est_test = est-update*line_search;
+                        estimate_point = a*est_test*est_test*est_test+b*est_test*est_test+c*est_test+d;
+
+                        sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
+                        sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
+                        squared_distance_cartesian_test = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos(estimate_point[1]-cp[1]);
+
+#ifndef NDEBUG
+                        sin_dlat = sin(estimate_point[1]-cp[1]);
+                        cos_dlong = cos(estimate_point[0]-cp[0]);
+                        deriv_long = (3.0*a[0]*est_test*est_test+2.0*b[0]*est_test+c[0]);
+                        deriv_lat = (3.0*a[1]*est_test*est_test+2.0*b[1]*est_test+c[1]);
+                        const double squared_distance_cartesian_derivative_test = cos_cp_lat*(-deriv_lat)*sin_d_long_h*sin_d_long_h*sin_dlat+cos_cp_lat*deriv_long*sin_d_long_h*cos_dlong_h*cos_d_lat+deriv_lat*sin_d_lat_h*cos_dlat_h;
+                        const double squared_distance_cartesian_second_derivative_test = cos_cp_lat*cos_d_lat*(-0.5*deriv_long*deriv_long*sin_d_long_h*sin_d_long_h+0.5*deriv_long*deriv_long*cos_dlong_h*cos_dlong_h+(6.0*a[0]*est_test+2.0*b[0])*sin_d_long_h*cos_dlong_h)+cos_cp_lat*sin_d_long_h*sin_d_long_h*(deriv_lat*deriv_lat*(-cos_d_lat)-(6.0*a[1]*est_test+2.0*b[1])*sin_dlat)-2.0*cos_cp_lat*deriv_long*deriv_lat*sin_d_long_h*cos_dlong_h*sin_dlat-0.5*deriv_lat*deriv_lat*sin_d_lat_h*sin_d_lat_h+0.5*deriv_lat*deriv_lat*cos_dlat_h*cos_dlat_h+(6.0*a[1]*est_test+2.0*b[1])*sin_d_lat_h*cos_dlat_h;
+                        output << "    i: " << cp_i << ", ni: " << newton_i<< ", lsi: " << i << ", line_search_step=" << line_search_step << ": squared_distance_cartesian_test = " << squared_distance_cartesian_test << ", diff= " << squared_distance_cartesian_test-squared_distance_cartesian << ", tests: " << (squared_distance_cartesian_test_previous < squared_distance_cartesian ? "true" : "false") << ":" << (squared_distance_cartesian_test > squared_distance_cartesian_test_previous ? "true" : "false") << ", est_test=" << est_test << ", update=" << update << ", ls=" << line_search << ", up*ls=" << update *line_search << ", test deriv =" << squared_distance_cartesian_derivative_test  << ", test upate=" << squared_distance_cartesian_derivative_test/fabs(squared_distance_cartesian_second_derivative_test) << ", p1=" << p1 << ", p2= " << p2 << ", poc= " << a *est_test *est_test *est_test+b *est_test *est_test+c *est_test+d << ", cp= " <<  check_point << ", ds:" << ((a*est_test*est_test*est_test+b*est_test*est_test+c*est_test+d)-check_point).norm_square() << ":" << min_squared_distance_cartesian_temp_dg << ", diff = " << squared_distance_cartesian_test-min_squared_distance_cartesian_temp_dg<< std::endl;
+#endif
+                        if (i > 0 && (squared_distance_cartesian_test > squared_distance_cartesian_test_previous))
                           {
-                            normal[0] = derivative[1]/normal_size;
-                            normal[1] = -derivative[0]/normal_size;
+                            if (squared_distance_cartesian_test_previous-squared_distance_cartesian < 0)
+                              {
+                                line_search *= 1/line_search_step;
+                                break;
+                              }
+                            if (i> 1)
+                              {
+                                line_search *= (1/line_search_step)*(1/line_search_step);
+                                est_test = est-update*line_search;
+                                estimate_point = a*est_test*est_test*est_test+b*est_test*est_test+c*est_test+d;
+
+                                sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
+                                sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
+                                squared_distance_cartesian_test_previous = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos(estimate_point[1]-cp[1]);
+                                line_search_step = std::min(line_search_step*(11./10.),0.95);
+                                continue;
+                              }
                           }
+                        squared_distance_cartesian_test_previous = squared_distance_cartesian_test;
+
+                        line_search *= line_search_step;
                       }
-                      closest_point_on_curve.normal = normal;
+#ifndef NDEBUG
+                    output << "    i: " << cp_i << ", ni: " << newton_i<< ", est= " << est-update *line_search << ", ls:" << line_search << ": squared_distance_cartesian_test = " << squared_distance_cartesian_test << ", diff= " << squared_distance_cartesian_test-squared_distance_cartesian << std::endl;
+#endif
+                    est -= update*line_search;
+                  }
+
+                if (std::fabs(squared_distance_cartesian_derivative) <= 1e-16 || std::fabs(update) < 1e-4 || est < -0.1 || est > 1.1)
+                  {
+                    found = true;
+                    break;
+                  }
+              }
+
+#ifndef NDEBUG
+            WBAssertThrow(found, "Could not find a good solution. " << output.str());
+#else
+            WBAssertThrow(found, "Could not find a good solution. Enable debug mode for more info.");
+#endif
+
+            estimate_point = a*est*est*est+b*est*est+c*est+d;
+
+            const double sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
+            const double sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
+
+            const double min_squared_distance_cartesian_temp = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos(estimate_point[1]-cp[1]);
+
+            if (min_squared_distance_cartesian_temp < min_squared_distance)
+              {
+                if (est >= -1e-8 && est-1. <= 1e-8)
+                  {
+                    min_squared_distance = min_squared_distance_cartesian_temp;
+                    const Point<2> point_on_curve = a*est*est*est+b*est*est+c*est+d;
+
+                    // the sign is rotating the derivative by 90 degrees.
+                    // When moving in the direction of increasing t, left is positve and right is negative.
+                    // https://www.wolframalpha.com/input?i=d%2Fdt+%281-t%29*%281-t%29*%281-t%29*a+%2B+3*%281-t%29*%281-t%29*t*b+%2B+3.*%281-t%29*t*t*c%2Bt*t*t*d
+                    const Point<2> derivative_point = points[cp_i]*((6.-3.*est)*est-3.) + control_points[cp_i][0]*(est*(9*est-12)+3)
+                                                      + control_points[cp_i][1]*(6.-9.*est)*est + points[cp_i+1]*3.*est*est;
+                    //https://www.wolframalpha.com/input?i=d%2Fdt+d%2Fdt+%281-t%29*%281-t%29*%281-t%29*a+%2B+3*%281-t%29*%281-t%29*t*b+%2B+3.*%281-t%29*t*t*c%2Bt*t*t*d
+                    const Point<2> second_derivative_point = points[cp_i]*(6-6*est) + control_points[cp_i][0]*(18*est-12)
+                                                             + control_points[cp_i][1]*-18*est+ points[cp_i+1]*6*est;
+
+                    Point<2> tangent_point = derivative_point - point_on_curve;
+                    // if angle between check point and tangent point is larget than 90 degrees, return a negative distance
+                    const double dot_product = (tangent_point*(check_point-point_on_curve));
+                    const double sign = dot_product < 0. ? -1. : 1.;
+                    tangent_point = Point<2>(-tangent_point[1],tangent_point[0],tangent_point.get_coordinate_system());
+
+                    closest_point_on_curve.distance = sign*std::sqrt(min_squared_distance);
+                    closest_point_on_curve.parametric_fraction = est;
+                    closest_point_on_curve.interpolation_fraction = NaN::DSNAN; //arc_length(i,real_roots[root_i])/lengths[i];
+                    closest_point_on_curve.index = cp_i;
+                    closest_point_on_curve.point = point_on_curve;
+                    Point<2> normal = point_on_curve;
+                    {
+                      Point<2> derivative = a*est*est+b*est+c;
+                      normal=derivative;
+                      double normal_size = derivative.norm();
+                      if (normal_size > 0.)
+                        {
+                          normal[0] = derivative[1]/normal_size;
+                          normal[1] = -derivative[0]/normal_size;
+                        }
                     }
-                }
-            }
+                    closest_point_on_curve.normal = normal;
+                  }
+              }
+          }
 
         }
       return closest_point_on_curve;

--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -381,10 +381,10 @@ namespace WorldBuilder
               const Point<2> d = points[cp_i];
 
               const Point<2> estimate_point = a*est*est*est + b*est*est + c*est + d;
-              const double cos_cp_lat = cos(cp[1]);
-              const double cos_lat_dg = cos(estimate_point[1]);
-              const double sin_d_long_h_dg = sin((estimate_point[0]-cp[0])*0.5);
-              const double sin_d_lat_h_dg = sin((estimate_point[1]-cp[1])*0.5);
+              const double cos_cp_lat = FT::cos(cp[1]);
+              const double cos_lat_dg = FT::cos(estimate_point[1]);
+              const double sin_d_long_h_dg = FT::sin((estimate_point[0]-cp[0])*0.5);
+              const double sin_d_lat_h_dg = FT::sin((estimate_point[1]-cp[1])*0.5);
               const double min_squared_distance_cartesian_temp_dg = sin_d_lat_h_dg*sin_d_lat_h_dg + sin_d_long_h_dg*sin_d_long_h_dg*cos_cp_lat*cos_lat_dg;
 
               if (min_squared_distance_cartesian_temp_dg < minimal_distance)
@@ -418,11 +418,11 @@ namespace WorldBuilder
             Point<2> d = points[cp_i];
 
             Point<2> estimate_point = a*est*est*est+b*est*est+c*est+d;
-            const double cos_cp_lat = cos(cp[1]);
+            const double cos_cp_lat = FT::cos(cp[1]);
 #ifndef NDEBUG
-            const double cos_lat_dg = cos(estimate_point[1]);
-            const double sin_d_long_h_dg = sin((estimate_point[0]-cp[0])*0.5);
-            const double sin_d_lat_h_dg = sin((estimate_point[1]-cp[1])*0.5);
+            const double cos_lat_dg = FT::cos(estimate_point[1]);
+            const double sin_d_long_h_dg = FT::sin((estimate_point[0]-cp[0])*0.5);
+            const double sin_d_lat_h_dg = FT::sin((estimate_point[1]-cp[1])*0.5);
             const double min_squared_distance_cartesian_temp_dg = sin_d_lat_h_dg*sin_d_lat_h_dg+sin_d_long_h_dg*sin_d_long_h_dg*cos_cp_lat*cos_lat_dg;
             output << "cp_i=" << cp_i << ", init est = " << est << ", min_squared_distance = " << min_squared_distance << ", min_squared_distance_cartesian_temp_dg: " << min_squared_distance_cartesian_temp_dg << ", p1: " << p1 << ", p2: " << p2 << std::endl;
             output  << std::setprecision(6) << "  wolfram: sin((" << a[1] << "*x^3+" << b[1] << "*x^2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << ")*.5)^2+sin((" << a[0] << "*x^3+" << b[0] << "*x^2+"<< c[0] << "*x+" << d[0] << "-" << cp[0] << ")*.5)^2*cos(" << cp[1] << ")*cos(" << a[1] << "*x^3+" << b[1] << "*x^2+"<< c[1] << "*x+" << d[1] << "-" << cp[1] << ") with x=" << est << std::endl;
@@ -433,14 +433,14 @@ namespace WorldBuilder
                 // based on https://stackoverflow.com/questions/2742610/closest-point-on-a-cubic-bezier-curve
                 estimate_point = a*est*est*est+b*est*est+c*est+d;
 
-                double sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
-                double sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
-                const double cos_d_lat = cos(estimate_point[1]-cp[1]);
+                double sin_d_long_h = FT::sin((estimate_point[0]-cp[0])*0.5);
+                double sin_d_lat_h = FT::sin((estimate_point[1]-cp[1])*0.5);
+                const double cos_d_lat = FT::cos(estimate_point[1]-cp[1]);
                 const double squared_distance_cartesian = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos_d_lat;
 
-                double sin_dlat = sin(estimate_point[1]-cp[1]);
-                double cos_dlong_h = cos(0.5*(estimate_point[0]-cp[0]));
-                double cos_dlat_h = cos(0.5*(estimate_point[1]-cp[1]));
+                double sin_dlat = FT::sin(estimate_point[1]-cp[1]);
+                double cos_dlong_h = FT::cos(0.5*(estimate_point[0]-cp[0]));
+                double cos_dlat_h = FT::cos(0.5*(estimate_point[1]-cp[1]));
                 double deriv_long = (3.0*a[0]*est*est+2.0*b[0]*est+c[0]);
                 double deriv_lat = (3.0*a[1]*est*est+2.0*b[1]*est+c[1]);
 
@@ -451,10 +451,10 @@ namespace WorldBuilder
                     const double squared_distance_cartesian_second_derivative = cos_cp_lat*cos_d_lat*(-0.5*deriv_long*deriv_long*sin_d_long_h*sin_d_long_h+0.5*deriv_long*deriv_long*cos_dlong_h*cos_dlong_h+(6.0*a[0]*est+2.0*b[0])*sin_d_long_h*cos_dlong_h)+cos_cp_lat*sin_d_long_h*sin_d_long_h*(deriv_lat*deriv_lat*(-cos_d_lat)-(6.0*a[1]*est+2.0*b[1])*sin_dlat)-2.0*cos_cp_lat*deriv_long*deriv_lat*sin_d_long_h*cos_dlong_h*sin_dlat-0.5*deriv_lat*deriv_lat*sin_d_lat_h*sin_d_lat_h+0.5*deriv_lat*deriv_lat*cos_dlat_h*cos_dlat_h+(6.0*a[1]*est+2.0*b[1])*sin_d_lat_h*cos_dlat_h;
 
 #ifndef NDEBUG
-                    const double squared_distance_cartesian_full = sin((a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*0.5)*sin((a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*0.5)+sin((a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])*0.5)*sin((a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])*0.5)*cos(cp[1])*cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]);
-                    double cos_dlong = cos(estimate_point[0]-cp[0]);
-                    const double squared_distance_cartesian_derivative_full = cos(cp[1])*(-(3.0*a[1]*est*est+2.0*b[1]*est+c[1]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])+cos(cp[1])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])+(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]));
-                    const double squared_distance_cartesian_second_derivative_full = cos(cp[1])*cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*(-0.5*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))+0.5*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))+(6.0*a[0]*est+2.0*b[0])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])))+cos(cp[1])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*((3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(-cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))-(6.0*a[1]*est+2.0*b[1])*sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))-2.0*cos(cp[1])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])-0.5*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))+0.5*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))+(6.0*a[1]*est+2.0*b[1])*sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]));
+                    const double squared_distance_cartesian_full = FT::sin((a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*0.5)*FT::sin((a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*0.5)+FT::sin((a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])*0.5)*FT::sin((a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])*0.5)*FT::cos(cp[1])*FT::cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]);
+                    double cos_dlong = FT::cos(estimate_point[0]-cp[0]);
+                    const double squared_distance_cartesian_derivative_full = FT::cos(cp[1])*(-(3.0*a[1]*est*est+2.0*b[1]*est+c[1]))*FT::sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])+FT::cos(cp[1])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*FT::sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])+(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*FT::sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*FT::cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]));
+                    const double squared_distance_cartesian_second_derivative_full = FT::cos(cp[1])*FT::cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])*(-0.5*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*FT::sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))+0.5*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*FT::cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))+(6.0*a[0]*est+2.0*b[0])*FT::sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0])))+FT::cos(cp[1])*FT::sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*((3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(-FT::cos(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))-(6.0*a[1]*est+2.0*b[1])*FT::sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))-2.0*FT::cos(cp[1])*(3.0*a[0]*est*est+2.0*b[0]*est+c[0])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*FT::sin(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::cos(0.5*(a[0]*est*est*est+b[0]*est*est+c[0]*est+d[0]-cp[0]))*FT::sin(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1])-0.5*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*FT::sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*FT::sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))+0.5*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*(3.0*a[1]*est*est+2.0*b[1]*est+c[1])*FT::cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*FT::cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))+(6.0*a[1]*est+2.0*b[1])*FT::sin(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]))*FT::cos(0.5*(a[1]*est*est*est+b[1]*est*est+c[1]*est+d[1]-cp[1]));
                     output <<"sqd = " << squared_distance_cartesian <<":" << squared_distance_cartesian_full << ", diff=" << squared_distance_cartesian-squared_distance_cartesian_full << ", sqdd: " << squared_distance_cartesian_derivative <<":" << squared_distance_cartesian_derivative_full << ", diff="<< squared_distance_cartesian_derivative-squared_distance_cartesian_derivative_full << ", sqdd: " << squared_distance_cartesian_second_derivative << ":" << squared_distance_cartesian_second_derivative_full << ", diff= " << squared_distance_cartesian_second_derivative-squared_distance_cartesian_second_derivative_full << ", est: " << est << std::endl;
 #endif
                     // the local minimum is where  squared_distance_cartesian_derivative=0 and squared_distance_cartesian_derivative>=0
@@ -470,13 +470,13 @@ namespace WorldBuilder
                         est_test = est-update*line_search;
                         estimate_point = a*est_test*est_test*est_test+b*est_test*est_test+c*est_test+d;
 
-                        sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
-                        sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
-                        squared_distance_cartesian_test = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos(estimate_point[1]-cp[1]);
+                        sin_d_long_h = FT::sin((estimate_point[0]-cp[0])*0.5);
+                        sin_d_lat_h = FT::sin((estimate_point[1]-cp[1])*0.5);
+                        squared_distance_cartesian_test = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*FT::cos(estimate_point[1]-cp[1]);
 
 #ifndef NDEBUG
-                        sin_dlat = sin(estimate_point[1]-cp[1]);
-                        cos_dlong = cos(estimate_point[0]-cp[0]);
+                        sin_dlat = FT::sin(estimate_point[1]-cp[1]);
+                        cos_dlong = FT::cos(estimate_point[0]-cp[0]);
                         deriv_long = (3.0*a[0]*est_test*est_test+2.0*b[0]*est_test+c[0]);
                         deriv_lat = (3.0*a[1]*est_test*est_test+2.0*b[1]*est_test+c[1]);
                         const double squared_distance_cartesian_derivative_test = cos_cp_lat*(-deriv_lat)*sin_d_long_h*sin_d_long_h*sin_dlat+cos_cp_lat*deriv_long*sin_d_long_h*cos_dlong_h*cos_d_lat+deriv_lat*sin_d_lat_h*cos_dlat_h;
@@ -496,9 +496,9 @@ namespace WorldBuilder
                                 est_test = est-update*line_search;
                                 estimate_point = a*est_test*est_test*est_test+b*est_test*est_test+c*est_test+d;
 
-                                sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
-                                sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
-                                squared_distance_cartesian_test_previous = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos(estimate_point[1]-cp[1]);
+                                sin_d_long_h = FT::sin((estimate_point[0]-cp[0])*0.5);
+                                sin_d_lat_h = FT::sin((estimate_point[1]-cp[1])*0.5);
+                                squared_distance_cartesian_test_previous = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*FT::cos(estimate_point[1]-cp[1]);
                                 line_search_step = std::min(line_search_step*(11./10.),0.95);
                                 continue;
                               }
@@ -522,10 +522,10 @@ namespace WorldBuilder
 
             estimate_point = a*est*est*est+b*est*est+c*est+d;
 
-            const double sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);
-            const double sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
+            const double sin_d_long_h = FT::sin((estimate_point[0]-cp[0])*0.5);
+            const double sin_d_lat_h = FT::sin((estimate_point[1]-cp[1])*0.5);
 
-            const double min_squared_distance_cartesian_temp = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos(estimate_point[1]-cp[1]);
+            const double min_squared_distance_cartesian_temp = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*FT::cos(estimate_point[1]-cp[1]);
 
             if (min_squared_distance_cartesian_temp < min_squared_distance)
               {

--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -438,12 +438,6 @@ namespace WorldBuilder
                 const double cos_d_lat = cos(estimate_point[1]-cp[1]);
                 const double squared_distance_cartesian = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos_d_lat;
 
-                if (squared_distance_cartesian > min_squared_distance * 1.33)
-                  {
-                    found = true;
-                    break;
-                  }
-
                 double sin_dlat = sin(estimate_point[1]-cp[1]);
                 double cos_dlong_h = cos(0.5*(estimate_point[0]-cp[0]));
                 double cos_dlat_h = cos(0.5*(estimate_point[1]-cp[1]));

--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -526,12 +526,6 @@ namespace WorldBuilder
                   }
               }
 
-#ifndef NDEBUG
-            WBAssertThrow(found, "Could not find a good solution. " << output.str());
-#else
-            WBAssertThrow(found, "Could not find a good solution. Enable debug mode for more info.");
-#endif
-
             estimate_point = a*est*est*est+b*est*est+c*est+d;
 
             const double sin_d_long_h = sin((estimate_point[0]-cp[0])*0.5);

--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -358,7 +358,7 @@ namespace WorldBuilder
         }
       else
         {
-          const size_t max_cp_i = 1; //control_points.size();
+          const size_t max_cp_i = control_points.size();
           for ( size_t cp_i = 0; cp_i < max_cp_i; ++cp_i)
             {
               const Point<2> &p1 = points[cp_i];
@@ -399,6 +399,12 @@ namespace WorldBuilder
                   double sin_d_lat_h = sin((estimate_point[1]-cp[1])*0.5);
                   const double cos_d_lat = cos(estimate_point[1]-cp[1]);
                   const double squared_distance_cartesian = sin_d_lat_h*sin_d_lat_h+sin_d_long_h*sin_d_long_h*cos_cp_lat*cos_d_lat;
+
+                  if (squared_distance_cartesian > min_squared_distance * 1.33)
+                  {
+                    found = true;
+                    break;
+                  }
 
                   double sin_dlat = sin(estimate_point[1]-cp[1]);
                   double cos_dlong_h = cos(0.5*(estimate_point[0]-cp[0]));


### PR DESCRIPTION
This is probably the most controversial of my changes and needs further testing.

All in all this speeds up the `closest_point_on_curve_segment` function by about a factor of 15 by two changes:
- A factor of 5 is contributed by the switch to approximate fast sine and cosine functions. This should be less problematic as long as the Newton iteration converges properly, because we are dealing with guesses for points most of the time anyway (do I need to use the accurate sin/cos function to compute the final residual in the newton iteration?)
- A factor of 3 can be gained by a change to the algorithm. Instead of running a Newton iteration on every bezier segment I can use the estimated point to find the the most likely closest segment first, then determine the closest  point with the newton iteration only on the closest segment. There is theoretically a risk that the estimated point is not accurate enough to find the closest segment. This will probably depend on how "smooth" the bezier curves are.

@alarshi this is the change we talked about today, could you check if you can see any differences between your branch and this branch?