### PR TITLE
Fixes cmake policy CMP0058 on byproducts when using ninja in ASPECT.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,7 @@ if(MAKE_PYTHON_WRAPPER)
   # Install target to call setup.py
   add_custom_target(install-python
           DEPENDS _gwb
+          BYPRODUCTS _gwb
           COMMAND ${Python_EXECUTABLE} ${SETUP_PY_OUT} install)
 endif()
 


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/policy/CMP0058.html for more info. Without this change a there is a large warning when setting up the GWB cmake project as a cmake subdirectory

```
...
-- ===== Configuring ASPECT documentation =============
-- Parameter GUI not found: install and provide a hint using -D PARAMETER_GUI_DIR or set -D PARAMETER_GUI_EXECUTABLE directly.
-- Writing configuration details into detailed.log...
-- Run  $ ninja info  to print a detailed help message
-- Configuring done (3.5s)
-- Generating done (0.1s)
CMake Warning (dev):
  Policy CMP0058 is not set: Ninja requires custom command byproducts to be
  explicit.  Run "cmake --help-policy CMP0058" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  This project specifies custom command DEPENDS on files in the build tree
  that are not specified as the OUTPUT or BYPRODUCTS of any
  add_custom_command or add_custom_target:

   world_builder/_gwb

  For compatibility with versions of CMake that did not have the BYPRODUCTS
  option, CMake is generating phony rules for such files to convince 'ninja'
  to build.

  Project authors should add the missing BYPRODUCTS or OUTPUT options to the
  custom commands that produce these files.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Build files have been written to: ...
```

This change gets rid of that warning.

related to #493 