### PR TITLE
RTD do not fail on warnings anymore.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: doc/sphinx/conf.py
-   fail_on_warning: True
+   fail_on_warning: False
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:


### PR DESCRIPTION
#504 didn't fix the issue. The local pull request docs builds without warning, but the release version does give warnings. This is prevent it from showing the correct documentation. So disabling it for now.