### PR TITLE
Fix date for v0.5.0 in citation

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -25,7 +25,7 @@ DOI = {10.5194/se-10-1785-2019}
   author       = {Menno Fraters and
                   others},
   month        = jun,
-  year         = 2021,
+  year         = 2023,
   DOI          = {10.5281/zenodo.7998525},
   URL          = {https://doi.org/10.5281/zenodo.7998525},
 }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Fraters, M., Thieulot, C., van den Berg, A., and Spakman, W.: The Geodynamic Wor
 
 And cite the specific version of the software used. Version 0.5.0 can be cited as:
 
-Menno Fraters and others. 2021, June 22. The Geodynamic World Builder v0.5.0. Zenodo. [https://doi.org/10.5281/zenodo.7998525](https://doi.org/10.5281/zenodo.7998525).
+Menno Fraters and others. 2023, June 6. The Geodynamic World Builder v0.5.0. Zenodo. [https://doi.org/10.5281/zenodo.7998525](https://doi.org/10.5281/zenodo.7998525).
 
 ### How can I follow the progress of this project?
 There are multiple ways in which you can follow this project:


### PR DESCRIPTION
Fixes the year for the citation to the software for v0.5.0 to 2023.

Also changes the day of the month to align with the citation on Zenodo.

This may not change everywhere where the citation is incorrect. Only the places I noticed  :) 