### PR TITLE
Remove bundled libraries from doxygen

### DIFF
--- a/doc/Doxfile.in
+++ b/doc/Doxfile.in
@@ -161,7 +161,12 @@ FILE_PATTERNS          = *.c \
 RECURSIVE              = YES
 EXCLUDE                = 
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = 
+EXCLUDE_PATTERNS       = */ApprovalTests/* \
+                         */delaunator-cpp/* \
+                         */doctest/* \
+                         */glm/* \
+                         */rapidjson/* \
+                         */vtu11/*
 EXCLUDE_SYMBOLS        = 
 EXAMPLE_PATH           = 
 EXAMPLE_PATTERNS       = *

--- a/doc/doxygen_config.dox
+++ b/doc/doxygen_config.dox
@@ -161,7 +161,12 @@ FILE_PATTERNS          = *.c \
 RECURSIVE              = YES
 EXCLUDE                = 
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = 
+EXCLUDE_PATTERNS       = */ApprovalTests/* \
+                         */delaunator-cpp/* \
+                         */doctest/* \
+                         */glm/* \
+                         */rapidjson/* \
+                         */vtu11/*
 EXCLUDE_SYMBOLS        = 
 EXAMPLE_PATH           = 
 EXAMPLE_PATTERNS       = *


### PR DESCRIPTION
Currently all the bundled libraries are included in the doxygen documentation, which means it is hard to find the actual World Builder classes in the doxygen documentation (see https://codedocs.xyz/GeodynamicWorldBuilder/WorldBuilder/annotated.html). This change excludes all non WorldBuilder files from the doxygen documentation.