### PR TITLE
Update name of python package

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-sphinx_book_theme
+sphinx-book-theme
 myst-parser
 sphinx-copybutton
 sphinx-design


### PR DESCRIPTION
It looks like sphinx_book_theme is actually sphinx-book-theme, see https://pypi.org/project/sphinx-book-theme/. Maybe it changed its name. Let's wait for the documentation tester before merging this to make sure the new version still works.