### PR TITLE
Fix link to WB matrix room in documentation

### DIFF
--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -71,6 +71,6 @@ GWB_parameter_listings/visualization_grid_file/index.md
 
    GitHub <https://github.com/GeodynamicWorldBuilder/WorldBuilder/>
    Doxygen <https://codedocs.xyz/GeodynamicWorldBuilder/WorldBuilder/index.html>
-   Chat <https://app.element.io/#/room/#gwb:matrix.org>
+   Chat <https://app.element.io/%23/room/%23gwb:matrix.org>
 ```
 


### PR DESCRIPTION
For some reason this link doesnt show up correctly in the documentation. This is an attempt to fix it. Dont merge until I have checked the documentation tester.