### PR TITLE
fix a cookbook

### DIFF
--- a/cookbooks/3d_cartesian_curved_subduction/3d_cartesian_curved_subduction.wb
+++ b/cookbooks/3d_cartesian_curved_subduction/3d_cartesian_curved_subduction.wb
@@ -3,7 +3,6 @@
   "potential mantle temperature":1500,
   "thermal expansion coefficient":2.0e-5,
   "maximum distance between coordinates":100000,
-  "interpolation":"monotone spline",
   "surface temperature":293.15,
   "force surface temperature":true,
   "coordinate system":{"model":"cartesian"},

--- a/cookbooks/3d_spherical_subduction/3d_spherical_subduction.wb
+++ b/cookbooks/3d_spherical_subduction/3d_spherical_subduction.wb
@@ -3,7 +3,6 @@
   "coordinate system":{"model":"spherical", "depth method":"begin segment"},
   "cross section":[[0,0],[10,0]],
   "maximum distance between coordinates":0.01,
-  //"interpolation":"monotone spline",
   "features":
   [
     {"model":"mantle layer", "name":"upper mantle", "min depth":95e3, "max depth":660e3, "coordinates":[[-1,-1],[41,-1],[41,-1],[-1,-1]],


### PR DESCRIPTION
gwb-grid fails without this change

@MFraters should the tester catch this? where is the logic that runs the ``./cookbooks/``?