### PR TITLE
re-enabling 2D for chunk. not clear why this option was removed.

### DIFF
--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -778,7 +778,7 @@ int main(int argc, char **argv)
           const double inner_radius = z_min;
           const double outer_radius = z_max;
 
-          WBAssertThrow(dim ==3, "2D is currently not supported for the chunk.");
+          // WBAssertThrow(dim ==3, "2D is currently not supported for the chunk.");
           WBAssertThrow(x_min <= x_max, "The minimum longitude must be less than the maximum longitude.");
           WBAssertThrow(y_min <= y_max, "The minimum latitude must be less than the maximum latitude.");
           WBAssertThrow(inner_radius < outer_radius, "The inner radius must be less than the outer radius.");

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -778,7 +778,6 @@ int main(int argc, char **argv)
           const double inner_radius = z_min;
           const double outer_radius = z_max;
 
-          // WBAssertThrow(dim ==3, "2D is currently not supported for the chunk.");
           WBAssertThrow(x_min <= x_max, "The minimum longitude must be less than the maximum longitude.");
           WBAssertThrow(y_min <= y_max, "The minimum latitude must be less than the maximum latitude.");
           WBAssertThrow(inner_radius < outer_radius, "The inner radius must be less than the outer radius.");


### PR DESCRIPTION
This option existed before May 2023. It is not clear why it was removed and the assert added. However, Magali and Becky both use this option in the previous version (0.5 to check input structure before running in Aspect), without any problems and can't change to the new version without it.  So, since we don't currently know what the problem is, I have removed the assert for now to allow the 2D option to be used with the chunk option and the grid input file. 