### PR TITLE
json schema: do not output NaN

### DIFF
--- a/source/world_builder/types/double.cc
+++ b/source/world_builder/types/double.cc
@@ -19,6 +19,7 @@
 #include "world_builder/types/double.h"
 
 #include "world_builder/parameters.h"
+#include <cmath>
 
 namespace WorldBuilder
 {
@@ -54,7 +55,11 @@ namespace WorldBuilder
       Document &declarations = prm.declarations;
       const std::string base = prm.get_full_json_path() + "/" + name;
 
-      Pointer((base + "/default value").c_str()).Set(declarations,default_value);
+      if (std::isnan(default_value))
+        Pointer((base + "/default value").c_str()).Set(declarations,"NaN");
+      else
+        Pointer((base + "/default value").c_str()).Set(declarations,default_value);
+
       Pointer((base + "/type").c_str()).Set(declarations,"number");
       Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
     }


### PR DESCRIPTION
This trips up VSCode otherwise because ``NaN`` is not valid json. We could also remove the offending parameter:
https://github.com/GeodynamicWorldBuilder/WorldBuilder/blob/a01bf98bec4de35811e8ff11c463ce8197924a5b/source/world_builder/features/subducting_plate_models/temperature/plate_model.cc#L78

(this is the only one)

Thoughts?

part of #552 