### PR TITLE
json schema: allow $schema

### DIFF
--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -106,6 +106,8 @@ namespace WorldBuilder
 
       prm.declare_entry("version", Types::String(""),"The major and minor version number for which the input file was written.");
 
+      prm.declare_entry("$schema", Types::String(""),"The optional filename or https address to a JSON schema file");
+
       prm.declare_entry("cross section", Types::Array(Types::Point<2>(),2,2),"This is an array of two points along where the cross section is taken");
 
       prm.declare_entry("potential mantle temperature", Types::Double(1600),

--- a/tests/gwb-dat/world_builder_declarations.schema.json
+++ b/tests/gwb-dat/world_builder_declarations.schema.json
@@ -12,6 +12,11 @@
             "type": "string",
             "documentation": "The major and minor version number for which the input file was written."
         },
+        "$schema": {
+            "default value": "",
+            "type": "string",
+            "documentation": "The optional filename or https address to a JSON schema file"
+        },
         "cross section": {
             "type": "array",
             "minItems": 2,

--- a/tests/gwb-dat/world_builder_declarations_closed.md
+++ b/tests/gwb-dat/world_builder_declarations_closed.md
@@ -15,6 +15,14 @@
 - **documentation**:The major and minor version number for which the input file was written.
 ::::::::::::::::::::::::
 
+::::::::::::::::::::::::{dropdown} /$schema
+:name: closed_$schema
+
+- **default value**:
+- **type**:string
+- **documentation**:The optional filename or https address to a JSON schema file
+::::::::::::::::::::::::
+
 ::::::::::::::::::::::::{dropdown} /cross section
 :name: closed_cross-section
 

--- a/tests/gwb-dat/world_builder_declarations_open.md
+++ b/tests/gwb-dat/world_builder_declarations_open.md
@@ -16,6 +16,15 @@
 - **documentation**:The major and minor version number for which the input file was written.
 ::::::::::::::::::::::::
 
+::::::::::::::::::::::::{dropdown} /$schema
+:open:
+:name: open_$schema
+
+- **default value**:
+- **type**:string
+- **documentation**:The optional filename or https address to a JSON schema file
+::::::::::::::::::::::::
+
 ::::::::::::::::::::::::{dropdown} /cross section
 :open:
 :name: open_cross-section


### PR DESCRIPTION
VSCode can parse embedded URLs to a schema file if there is a top level ``$schema`` value. Our schema needs to allow this.