### PR TITLE
json schema: use description

### DIFF
--- a/source/world_builder/types/array.cc
+++ b/source/world_builder/types/array.cc
@@ -68,7 +68,7 @@ namespace WorldBuilder
       Pointer((base + "/minItems").c_str()).Set(declarations,min_items);
       Pointer((base + "/maxItems").c_str()).Set(declarations,max_items);
       Pointer((base + "/uniqueItems").c_str()).Set(declarations,unique_items);
-      Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
+      Pointer((base + "/description").c_str()).Set(declarations,documentation.c_str());
 
       prm.enter_subsection(name);
       {

--- a/source/world_builder/types/bool.cc
+++ b/source/world_builder/types/bool.cc
@@ -55,7 +55,7 @@ namespace WorldBuilder
 
       Pointer((base + "/default value").c_str()).Set(declarations,default_value);
       Pointer((base + "/type").c_str()).Set(declarations,"boolean");
-      Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
+      Pointer((base + "/description").c_str()).Set(declarations,documentation.c_str());
     }
   } // namespace Types
 } // namespace WorldBuilder

--- a/source/world_builder/types/double.cc
+++ b/source/world_builder/types/double.cc
@@ -56,7 +56,7 @@ namespace WorldBuilder
 
       Pointer((base + "/default value").c_str()).Set(declarations,default_value);
       Pointer((base + "/type").c_str()).Set(declarations,"number");
-      Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
+      Pointer((base + "/description").c_str()).Set(declarations,documentation.c_str());
     }
   } // namespace Types
 } // namespace WorldBuilder

--- a/source/world_builder/types/object.cc
+++ b/source/world_builder/types/object.cc
@@ -63,7 +63,7 @@ namespace WorldBuilder
         const std::string path = prm.get_full_json_path();
 
         Pointer((path + "/type").c_str()).Set(declarations,"object");
-        Pointer((path + "/documentation").c_str()).Set(declarations,documentation.c_str());
+        Pointer((path + "/description").c_str()).Set(declarations,documentation.c_str());
         Pointer((path + "/additionalProperties").c_str()).Set(declarations,additional_properties);
 
         if (!required.empty())

--- a/source/world_builder/types/one_of.cc
+++ b/source/world_builder/types/one_of.cc
@@ -57,7 +57,7 @@ namespace WorldBuilder
 
       prm.enter_subsection(name);
       {
-        Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
+        Pointer((base + "/description").c_str()).Set(declarations,documentation.c_str());
         prm.enter_subsection("oneOf");
         {
           for (size_t i = 0; i < inner_types_ptr.size(); i++)

--- a/source/world_builder/types/plugin_system.cc
+++ b/source/world_builder/types/plugin_system.cc
@@ -63,7 +63,7 @@ namespace WorldBuilder
       prm.enter_subsection(name);
       {
         const std::string path = prm.get_full_json_path();
-        Pointer((path + "/documentation").c_str()).Set(prm.declarations,documentation.c_str());
+        Pointer((path + "/description").c_str()).Set(prm.declarations,documentation.c_str());
         Pointer((path + "/default value").c_str()).Set(prm.declarations,default_value.c_str());
 
         if (allow_multiple)

--- a/source/world_builder/types/point.cc
+++ b/source/world_builder/types/point.cc
@@ -86,7 +86,7 @@ namespace WorldBuilder
       Pointer((base + "/type").c_str()).Set(declarations,"array");
       Pointer((base + "/minItems").c_str()).Set(declarations,dim);
       Pointer((base + "/maxItems").c_str()).Set(declarations,dim);
-      Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
+      Pointer((base + "/description").c_str()).Set(declarations,documentation.c_str());
       Pointer((base + "/items/type").c_str()).Set(declarations,"number");
       // todo: default value
     }

--- a/source/world_builder/types/segment.cc
+++ b/source/world_builder/types/segment.cc
@@ -117,7 +117,7 @@ namespace WorldBuilder
 
         Pointer((base + "/type").c_str()).Set(declarations,"object");
         Pointer((base + "/additionalProperties").c_str()).Set(declarations,false);
-        Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
+        Pointer((base + "/description").c_str()).Set(declarations,documentation.c_str());
         std::vector<std::string> restricted_values = {"length", "thickness", "angle"};
         for (unsigned int i = 0; i < restricted_values.size(); ++i)
           {

--- a/source/world_builder/types/string.cc
+++ b/source/world_builder/types/string.cc
@@ -95,7 +95,7 @@ namespace WorldBuilder
       const std::string base = prm.get_full_json_path() + "/" + name;
       Pointer((base + "/default value").c_str()).Set(declarations,default_value.c_str());
       Pointer((base + "/type").c_str()).Set(declarations,"string");
-      Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
+      Pointer((base + "/description").c_str()).Set(declarations,documentation.c_str());
       for (unsigned int i = 0; i < restricted_values.size(); ++i)
         {
           if (!restricted_values[i].empty())

--- a/source/world_builder/types/unsigned_int.cc
+++ b/source/world_builder/types/unsigned_int.cc
@@ -56,7 +56,7 @@ namespace WorldBuilder
       const std::string base = prm.get_full_json_path() + "/" + name;
       Pointer((base + "/default value").c_str()).Set(declarations,default_value);
       Pointer((base + "/type").c_str()).Set(declarations,"integer");
-      Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
+      Pointer((base + "/description").c_str()).Set(declarations,documentation.c_str());
 
     }
   } // namespace Types

--- a/source/world_builder/types/value_at_points.cc
+++ b/source/world_builder/types/value_at_points.cc
@@ -68,7 +68,7 @@ namespace WorldBuilder
         Pointer((base + "/additionalProperties").c_str()).Set(declarations,false);
         Pointer((base + "/minItems").c_str()).Set(declarations,1);
         Pointer((base + "/maxItems").c_str()).Set(declarations,2);
-        Pointer((base + "/documentation").c_str()).Set(declarations,documentation.c_str());
+        Pointer((base + "/description").c_str()).Set(declarations,documentation.c_str());
 
         {
           Pointer((base + "/items/anyOf/0/type").c_str()).Set(declarations,"number");


### PR DESCRIPTION
VSCode uses "description" to show documentation and not "documentation". This seems to be the correct convention, see
https://json-schema.org/learn/miscellaneous-examples for example.

part of #552