### PR TITLE
Improve efficiency of github actions workflows

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,10 @@ name: benchmarks
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.actor }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmarks:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,15 @@
 name: tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'main'
+      - 'GWB-*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.actor }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test_indentation:


### PR DESCRIPTION
This change improves the efficiency of the world builder testers by taking over the following changes from workflows of other CIG software:
1. Only execute tests when pushing to the main branch (=merging) or pushing to an open pull request. Do not execute when pushing to private branches on github forks.
2. Cancel in progress tester runs if a new commit is pushed to a pull request. Since a new run has to be done anyway, there is no point in finishing running tests.


Since WB testers are fast there is not much gained in terms of development speed, but this will save some energy somewhere in the cloud.