### PR TITLE
Prevent accidental canceling of tester runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,7 +3,7 @@ name: benchmarks
 on: [pull_request]
 
 concurrency:
-  group: ${{ github.actor }}-${{ github.ref }}
+  group: ${{ github.actor }}-${{ github.ref }}-benchmarks
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.actor }}-${{ github.ref }}
+  group: ${{ github.actor }}-${{ github.ref }}-test
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Fix a mistake introduced in #561. Because benchmarks and tests had the same 'group' one of the two workflows would be cancelled if the other was running. Give them two different tags to distinguish between them.