### PR TITLE
vscode: add wb format and schema

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "files.associations": {
+        "*.wb": "jsonc"
+    },
+    "json.validate.enable": true,
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "*.wb"
+            ],
+            "url": "./doc/world_builder_declarations.schema.json"
+        }
+    ],
+}


### PR DESCRIPTION
add VSCode workspace settings file containing:
1. Association that .wb files are "JSON with comments"
2. Specify the link to the schema under /doc/