### PR TITLE
Reorganize the implementation of the mass conserving temperature prof…

### DIFF
--- a/include/world_builder/features/subducting_plate_models/temperature/mass_conserving.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/mass_conserving.h
@@ -91,6 +91,18 @@ namespace WorldBuilder
                                    const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes,
                                    const AdditionalParameters &additional_parameters) const override final;
 
+            /**
+             * Returns a temperature based on the given heat content, temperatures, effective plate age,
+             * and adjusted distance to the coldest point in the slab. The temperature is formulated by
+             * the analytical solutions.
+             */
+            double get_temperature_analytic(const double top_heat_content,
+                                            const double min_temperature,
+                                            const double background_temperature,
+                                            const double temperature_,
+                                            const double effective_plate_age,
+                                            const double adjusted_distance) const;
+
 
           private:
             //  temperature submodule parameters
@@ -116,6 +128,7 @@ namespace WorldBuilder
               plate_model
             };
             ReferenceModelName reference_model_name;
+            const int plate_model_summation_number = 100; // for the plate model
         };
       } // namespace Temperature
     } // namespace SubductingPlateModels


### PR DESCRIPTION
I add a small new function "get_temperature_analytic" to extract the calculation of the temperature from the analytic solution in the slab mass-conserving temperature profile.

If the top heat content and the adjusted distance are computed elsewhere. Then only one more line is needed to compute the temperature:

    temperature = get_temperature_analytic(top_heat_content, min_temperature, background_temperature, temperature_, effective_plate_age, adjusted_distance);

This would make further implementation of splining the temperature profile easier

While doing this, I migrate the plate model summation number as a separate constant variable in the file include/world_builder/features/subducting_plate_models/temperature/mass_conserving.h

    const int plate_model_summation_number = 100;

@mibillen and  @MFraters , could you give a review on this?
