### PR TITLE
Remove dev docs tip and tricks.

### DIFF
--- a/doc/sphinx/developer_manual/contributing_to_the_documentation/index.md
+++ b/doc/sphinx/developer_manual/contributing_to_the_documentation/index.md
@@ -13,6 +13,5 @@ building_documentation
 important_syntax
 documentation_style_guide
 documentation_testing
-tips_and_tricks
 review_process
 ```

--- a/doc/sphinx/developer_manual/contributing_to_the_documentation/tips_and_tricks.md
+++ b/doc/sphinx/developer_manual/contributing_to_the_documentation/tips_and_tricks.md
@@ -1,7 +1,0 @@
-(part:dev_manual:chap:contribute_to_doc:sec:tips_and_tricks)=
-Tips and tricks
-================
-
-```{todo}
-Explain how to make useful, easy to read and good looking documentation.
-```


### PR DESCRIPTION
I can't really think of anyting which can't also be mentioned in `Important syntax` and `Documentation style guide`. So I think it is best to just remove this page.