### PR TITLE
MPI: exclude mpich cxx wrappers

### DIFF
--- a/source/gwb-dat/main.cc
+++ b/source/gwb-dat/main.cc
@@ -27,6 +27,9 @@
 #include "world_builder/world.h"
 
 #ifdef WB_WITH_MPI
+// we don't need the c++ MPI wrappers
+#define OMPI_SKIP_MPICXX 1
+#define MPICH_SKIP_MPICXX
 #include <mpi.h>
 #endif
 

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -41,6 +41,9 @@
 #undef min
 
 #ifdef WB_WITH_MPI
+// we don't need the c++ MPI wrappers
+#define OMPI_SKIP_MPICXX 1
+#define MPICH_SKIP_MPICXX
 #include <mpi.h>
 #endif
 

--- a/source/world_builder/utilities.cc
+++ b/source/world_builder/utilities.cc
@@ -26,7 +26,9 @@
 #include <sstream>
 
 #ifdef WB_WITH_MPI
+// we don't need the c++ MPI wrappers
 #define OMPI_SKIP_MPICXX 1
+#define MPICH_SKIP_MPICXX
 #include <mpi.h>
 #endif
 

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -36,7 +36,9 @@
 #include <world_builder/objects/distance_from_surface.h>
 
 #ifdef WB_WITH_MPI
+// we don't need the c++ MPI wrappers
 #define OMPI_SKIP_MPICXX 1
+#define MPICH_SKIP_MPICXX
 #include <mpi.h>
 #endif
 

--- a/tests/CPP_MPI/example.cpp
+++ b/tests/CPP_MPI/example.cpp
@@ -2,6 +2,10 @@
 #include "world_builder/world.h"
 
 #include <stdio.h>
+
+// we don't need the c++ MPI wrappers
+#define OMPI_SKIP_MPICXX 1
+#define MPICH_SKIP_MPICXX
 #include <mpi.h>
 
 int main(int argc, char *argv[]) {

--- a/tests/CPP_MPI/test.cpp
+++ b/tests/CPP_MPI/test.cpp
@@ -1,4 +1,8 @@
 #include <stdio.h>
+
+// we don't need the c++ MPI wrappers
+#define OMPI_SKIP_MPICXX 1
+#define MPICH_SKIP_MPICXX
 #include <mpi.h>
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
these are not needed and give compile warnings for me when including GWB inside ASPECT.