### PR TITLE
Add rank to local random number seed.

### DIFF
--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -250,7 +250,7 @@ namespace WorldBuilder
     const int local_seed = prm.get<int>("random number seed");
 
     if (local_seed>=0)
-      random_number_engine.seed(local_seed);
+      random_number_engine.seed(local_seed+MPI_RANK);
 
     /**
      * Now load the features. Some features use for example temperature values,


### PR DESCRIPTION
When looking at #651, I realized that we are not using the mpi rank to seed in case of a local seed. This add the MPI Rank, so that different mpi thread will produce different deterministic random numbers per rank. 