### PR TITLE
Remove unused header files.

### DIFF
--- a/source/world_builder/features/continental_plate_models/composition/random.cc
+++ b/source/world_builder/features/continental_plate_models/composition/random.cc
@@ -28,12 +28,8 @@
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
 #include "world_builder/world.h"
-#include "world_builder/utilities.h"
-#include <algorithm>
 #include <random>
 
-
-#include "world_builder/kd_tree.h"
 
 
 namespace WorldBuilder

--- a/source/world_builder/features/continental_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/composition/uniform.cc
@@ -27,9 +27,6 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
-
-#include "world_builder/kd_tree.h"
 
 
 namespace WorldBuilder

--- a/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution.cc
@@ -29,10 +29,7 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
-
-#include "world_builder/kd_tree.h"
 
 namespace WorldBuilder
 {

--- a/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -29,10 +29,7 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
-
-#include "world_builder/kd_tree.h"
 
 namespace WorldBuilder
 {

--- a/source/world_builder/features/continental_plate_models/grains/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/grains/uniform.cc
@@ -29,8 +29,6 @@
 #include "world_builder/types/value_at_points.h"
 #include "world_builder/utilities.h"
 
-#include "world_builder/kd_tree.h"
-
 namespace WorldBuilder
 {
 

--- a/source/world_builder/features/continental_plate_models/temperature/adiabatic.cc
+++ b/source/world_builder/features/continental_plate_models/temperature/adiabatic.cc
@@ -26,10 +26,7 @@
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
-
-#include "world_builder/kd_tree.h"
 
 namespace WorldBuilder
 {

--- a/source/world_builder/features/continental_plate_models/temperature/linear.cc
+++ b/source/world_builder/features/continental_plate_models/temperature/linear.cc
@@ -26,10 +26,8 @@
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
-#include "world_builder/kd_tree.h"
 
 namespace WorldBuilder
 {

--- a/source/world_builder/features/continental_plate_models/temperature/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/temperature/uniform.cc
@@ -26,9 +26,6 @@
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
-
-#include "world_builder/kd_tree.h"
 
 namespace WorldBuilder
 {

--- a/source/world_builder/features/mantle_layer.cc
+++ b/source/world_builder/features/mantle_layer.cc
@@ -24,7 +24,6 @@
 #include "world_builder/features/mantle_layer_models/grains/interface.h"
 #include "world_builder/features/mantle_layer_models/temperature/interface.h"
 #include "world_builder/features/feature_utilities.h"
-#include "world_builder/kd_tree.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"

--- a/source/world_builder/features/mantle_layer_models/temperature/uniform.cc
+++ b/source/world_builder/features/mantle_layer_models/temperature/uniform.cc
@@ -26,7 +26,6 @@
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/world_builder/features/oceanic_plate.cc
+++ b/source/world_builder/features/oceanic_plate.cc
@@ -23,7 +23,6 @@
 #include "world_builder/features/oceanic_plate_models/grains/interface.h"
 #include "world_builder/features/oceanic_plate_models/temperature/interface.h"
 #include "world_builder/features/feature_utilities.h"
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"

--- a/source/world_builder/features/oceanic_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/composition/uniform.cc
@@ -19,8 +19,6 @@
 
 #include "world_builder/features/oceanic_plate_models/composition/uniform.h"
 
-
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
@@ -28,7 +26,6 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
@@ -30,7 +29,6 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 namespace WorldBuilder

--- a/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -21,7 +21,6 @@
 
 #include <algorithm>
 
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/bool.h"
@@ -30,7 +29,6 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 namespace WorldBuilder

--- a/source/world_builder/features/oceanic_plate_models/grains/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/uniform.cc
@@ -20,7 +20,6 @@
 #include "world_builder/features/oceanic_plate_models/grains/uniform.h"
 
 
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"

--- a/source/world_builder/features/oceanic_plate_models/temperature/adiabatic.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/adiabatic.cc
@@ -20,14 +20,12 @@
 #include "world_builder/features/oceanic_plate_models/temperature/adiabatic.h"
 
 
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/half_space_model.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/half_space_model.cc
@@ -21,7 +21,6 @@
 
 
 #include "world_builder/consts.h"
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"

--- a/source/world_builder/features/oceanic_plate_models/temperature/linear.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/linear.cc
@@ -19,15 +19,12 @@
 
 #include "world_builder/features/oceanic_plate_models/temperature/linear.h"
 
-
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/plate_model.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/plate_model.cc
@@ -19,8 +19,6 @@
 
 #include "world_builder/features/oceanic_plate_models/temperature/plate_model.h"
 
-
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"

--- a/source/world_builder/features/oceanic_plate_models/temperature/plate_model_constant_age.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/plate_model_constant_age.cc
@@ -19,8 +19,6 @@
 
 #include "world_builder/features/oceanic_plate_models/temperature/plate_model_constant_age.h"
 
-
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
@@ -28,7 +26,6 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/point.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/uniform.cc
@@ -19,15 +19,12 @@
 
 #include "world_builder/features/oceanic_plate_models/temperature/uniform.h"
 
-
-#include "world_builder/kd_tree.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 
 
 namespace WorldBuilder

--- a/source/world_builder/features/plume.cc
+++ b/source/world_builder/features/plume.cc
@@ -33,8 +33,6 @@
 #include "world_builder/types/value_at_points.h"
 #include "world_builder/world.h"
 
-#include "world_builder/kd_tree.h"
-
 #include <iostream>
 #include <algorithm>
 

--- a/source/world_builder/features/plume_models/composition/uniform.cc
+++ b/source/world_builder/features/plume_models/composition/uniform.cc
@@ -27,9 +27,6 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
-
-#include "world_builder/kd_tree.h"
 
 
 namespace WorldBuilder

--- a/source/world_builder/features/plume_models/grains/uniform.cc
+++ b/source/world_builder/features/plume_models/grains/uniform.cc
@@ -29,8 +29,6 @@
 #include "world_builder/types/value_at_points.h"
 #include "world_builder/utilities.h"
 
-#include "world_builder/kd_tree.h"
-
 namespace WorldBuilder
 {
 

--- a/source/world_builder/features/plume_models/temperature/gaussian.cc
+++ b/source/world_builder/features/plume_models/temperature/gaussian.cc
@@ -20,11 +20,9 @@
 #include "world_builder/features/plume_models/temperature/gaussian.h"
 
 
-#include "world_builder/nan.h"
 #include "world_builder/types/double.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/array.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 #include <algorithm>

--- a/source/world_builder/features/plume_models/temperature/uniform.cc
+++ b/source/world_builder/features/plume_models/temperature/uniform.cc
@@ -26,9 +26,6 @@
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
-
-#include "world_builder/kd_tree.h"
 
 namespace WorldBuilder
 {

--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -19,7 +19,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "world_builder/assert.h"
 #include "world_builder/nan.h"
 #include "world_builder/objects/bezier_curve.h"
-#include "world_builder/utilities.h"
 
 #include <cmath>
 #include <cstddef>

--- a/source/world_builder/objects/surface.cc
+++ b/source/world_builder/objects/surface.cc
@@ -18,7 +18,6 @@
 */
 #include "world_builder/assert.h"
 #include "world_builder/objects/surface.h"
-#include "world_builder/utilities.h"
 
 #include <iostream>
 

--- a/source/world_builder/types/segment.cc
+++ b/source/world_builder/types/segment.cc
@@ -16,7 +16,6 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include <utility>
 
 #include "world_builder/types/segment.h"
 


### PR DESCRIPTION
I tried to do this both through clang-tidy and include-what-you-use, but both also just include a whole lot of other include files and seem to clutter more than they cleanup. Here I used clangd and just went from file to file to find the unneeded includes.

related to #670 