### PR TITLE
Update and unify copyright year

### DIFF
--- a/doc/sphinx/conf.in.py
+++ b/doc/sphinx/conf.in.py
@@ -18,9 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Geodynamic World Builder'
-copyright = '2022, The authors of the Geodynamic World Builder'
-#author = 'The authors of the Geodynamic World Builder'
-#Built with [Sphinx](https://www.sphinx-doc.org/) using a theme provided by [Executable Book Project](https://ebp.jupyterbook.org/)
+copyright = '2024, The authors of the Geodynamic World Builder'
 # The full version, including alpha/beta/rc tags
 release = '@WORLD_BUILDER_VERSION@'
 html_title = "Manual GWB @WORLD_BUILDER_VERSION@"

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -18,9 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Geodynamic World Builder'
-copyright = '2022, The authors of the Geodynamic World Builder'
-#author = 'The authors of the Geodynamic World Builder'
-#Built with [Sphinx](https://www.sphinx-doc.org/) using a theme provided by [Executable Book Project](https://ebp.jupyterbook.org/)
+copyright = '2024, The authors of the Geodynamic World Builder'
 # The full version, including alpha/beta/rc tags
 release = '0.6.0-pre'
 html_title = "Manual GWB 0.6.0-pre"

--- a/include/world_builder/assert.h
+++ b/include/world_builder/assert.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/config.h.in
+++ b/include/world_builder/config.h.in
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/consts.h
+++ b/include/world_builder/consts.h
@@ -1,14 +1,18 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
+
   This file is part of the World Builder.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU Lesser General Public License as published
    by the Free Software Foundation, either version 2 of the License, or
    (at your option) any later version.
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU Lesser General Public License for more details.
+
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */

--- a/include/world_builder/coordinate_system.h
+++ b/include/world_builder/coordinate_system.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/coordinate_systems/cartesian.h
+++ b/include/world_builder/coordinate_systems/cartesian.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/coordinate_systems/invalid.h
+++ b/include/world_builder/coordinate_systems/invalid.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/coordinate_systems/spherical.h
+++ b/include/world_builder/coordinate_systems/spherical.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/composition/interface.h
+++ b/include/world_builder/features/continental_plate_models/composition/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/composition/random.h
+++ b/include/world_builder/features/continental_plate_models/composition/random.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2024 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/composition/uniform.h
+++ b/include/world_builder/features/continental_plate_models/composition/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/grains/interface.h
+++ b/include/world_builder/features/continental_plate_models/grains/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/grains/uniform.h
+++ b/include/world_builder/features/continental_plate_models/grains/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/continental_plate_models/temperature/adiabatic.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/temperature/interface.h
+++ b/include/world_builder/features/continental_plate_models/temperature/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/temperature/linear.h
+++ b/include/world_builder/features/continental_plate_models/temperature/linear.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/continental_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/continental_plate_models/temperature/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/composition/interface.h
+++ b/include/world_builder/features/fault_models/composition/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/composition/smooth.h
+++ b/include/world_builder/features/fault_models/composition/smooth.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 - 2022 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/composition/uniform.h
+++ b/include/world_builder/features/fault_models/composition/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/grains/interface.h
+++ b/include/world_builder/features/fault_models/grains/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/grains/uniform.h
+++ b/include/world_builder/features/fault_models/grains/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/temperature/adiabatic.h
+++ b/include/world_builder/features/fault_models/temperature/adiabatic.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/temperature/interface.h
+++ b/include/world_builder/features/fault_models/temperature/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/temperature/linear.h
+++ b/include/world_builder/features/fault_models/temperature/linear.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/fault_models/temperature/uniform.h
+++ b/include/world_builder/features/fault_models/temperature/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/feature_utilities.h
+++ b/include/world_builder/features/feature_utilities.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/composition/interface.h
+++ b/include/world_builder/features/mantle_layer_models/composition/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/composition/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/composition/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/grains/interface.h
+++ b/include/world_builder/features/mantle_layer_models/grains/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/grains/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/grains/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/adiabatic.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/temperature/interface.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/temperature/linear.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/linear.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/mantle_layer_models/temperature/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/composition/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/composition/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/grains/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/grains/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/adiabatic.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/temperature/half_space_model.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/half_space_model.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/temperature/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/temperature/linear.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/linear.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/plate_model.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/temperature/plate_model_constant_age.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/plate_model_constant_age.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/plume.h
+++ b/include/world_builder/features/plume.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/plume_models/composition/interface.h
+++ b/include/world_builder/features/plume_models/composition/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/plume_models/composition/uniform.h
+++ b/include/world_builder/features/plume_models/composition/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/plume_models/grains/interface.h
+++ b/include/world_builder/features/plume_models/grains/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/plume_models/grains/uniform.h
+++ b/include/world_builder/features/plume_models/grains/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/plume_models/temperature/gaussian.h
+++ b/include/world_builder/features/plume_models/temperature/gaussian.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/plume_models/temperature/interface.h
+++ b/include/world_builder/features/plume_models/temperature/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/plume_models/temperature/uniform.h
+++ b/include/world_builder/features/plume_models/temperature/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/composition/interface.h
+++ b/include/world_builder/features/subducting_plate_models/composition/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/composition/smooth.h
+++ b/include/world_builder/features/subducting_plate_models/composition/smooth.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 - 2022 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/composition/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/composition/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/grains/interface.h
+++ b/include/world_builder/features/subducting_plate_models/grains/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/grains/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/grains/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/adiabatic.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/temperature/interface.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/temperature/linear.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/linear.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/temperature/mass_conserving.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/mass_conserving.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/plate_model.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/features/subducting_plate_models/temperature/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/grains.h
+++ b/include/world_builder/grains.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/gravity_model/interface.h
+++ b/include/world_builder/gravity_model/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/gravity_model/uniform.h
+++ b/include/world_builder/gravity_model/uniform.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/kd_tree.h
+++ b/include/world_builder/kd_tree.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2022 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/nan.h
+++ b/include/world_builder/nan.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/objects/bezier_curve.h
+++ b/include/world_builder/objects/bezier_curve.h
@@ -1,20 +1,20 @@
 /*
-Copyright (C) 2018 - 2023 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
-This file is part of the World Builder.
+  This file is part of the World Builder.
 
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Lesser General Public License as published
- by the Free Software Foundation, either version 2 of the License, or
- (at your option) any later version.
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Lesser General Public License for more details.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
 
- You should have received a copy of the GNU Lesser General Public License
- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #ifndef WORLD_BUILDER_OBJECTS_BEZIER_CURVE_H

--- a/include/world_builder/objects/closest_point_on_curve.h
+++ b/include/world_builder/objects/closest_point_on_curve.h
@@ -1,20 +1,20 @@
 /*
-Copyright (C) 2018 - 2022 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
-This file is part of the World Builder.
+  This file is part of the World Builder.
 
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Lesser General Public License as published
- by the Free Software Foundation, either version 2 of the License, or
- (at your option) any later version.
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Lesser General Public License for more details.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
 
- You should have received a copy of the GNU Lesser General Public License
- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #ifndef WORLD_BUILDER_OBJECTS_CLOSEST_POINT_ON_CURVE_H

--- a/include/world_builder/objects/distance_from_surface.h
+++ b/include/world_builder/objects/distance_from_surface.h
@@ -1,20 +1,20 @@
 /*
-Copyright (C) 2018 - 2022 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
-This file is part of the World Builder.
+  This file is part of the World Builder.
 
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Lesser General Public License as published
- by the Free Software Foundation, either version 2 of the License, or
- (at your option) any later version.
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Lesser General Public License for more details.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
 
- You should have received a copy of the GNU Lesser General Public License
- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #ifndef WORLD_BUILDER_OBJECTS_DISTANCE_FROM_SURFACE_H

--- a/include/world_builder/objects/natural_coordinate.h
+++ b/include/world_builder/objects/natural_coordinate.h
@@ -1,20 +1,20 @@
 /*
-Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
-This file is part of the World Builder.
+  This file is part of the World Builder.
 
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Lesser General Public License as published
- by the Free Software Foundation, either version 2 of the License, or
- (at your option) any later version.
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Lesser General Public License for more details.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
 
- You should have received a copy of the GNU Lesser General Public License
- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #ifndef WORLD_BUILDER_OBJECTS_NATURAL_COORDINATE_H

--- a/include/world_builder/objects/segment.h
+++ b/include/world_builder/objects/segment.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2023 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/objects/surface.h
+++ b/include/world_builder/objects/surface.h
@@ -1,22 +1,20 @@
-
-
 /*
-Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
-This file is part of the World Builder.
+  This file is part of the World Builder.
 
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Lesser General Public License as published
- by the Free Software Foundation, either version 2 of the License, or
- (at your option) any later version.
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
 
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Lesser General Public License for more details.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
 
- You should have received a copy of the GNU Lesser General Public License
- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #ifndef WORLD_BUILDER_OBJECTS_SURFACE_H

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/point.h
+++ b/include/world_builder/point.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/array.h
+++ b/include/world_builder/types/array.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/bool.h
+++ b/include/world_builder/types/bool.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/double.h
+++ b/include/world_builder/types/double.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/int.h
+++ b/include/world_builder/types/int.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/interface.h
+++ b/include/world_builder/types/interface.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/object.h
+++ b/include/world_builder/types/object.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/one_of.h
+++ b/include/world_builder/types/one_of.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/plugin_system.h
+++ b/include/world_builder/types/plugin_system.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/point.h
+++ b/include/world_builder/types/point.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/segment.h
+++ b/include/world_builder/types/segment.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/string.h
+++ b/include/world_builder/types/string.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/unsigned_int.h
+++ b/include/world_builder/types/unsigned_int.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/types/value_at_points.h
+++ b/include/world_builder/types/value_at_points.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/wrapper_c.h
+++ b/include/world_builder/wrapper_c.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/include/world_builder/wrapper_cpp.h
+++ b/include/world_builder/wrapper_cpp.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/coordinate_systems/cartesian.cc
+++ b/source/world_builder/coordinate_systems/cartesian.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/coordinate_systems/interface.cc
+++ b/source/world_builder/coordinate_systems/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/coordinate_systems/invalid.cc
+++ b/source/world_builder/coordinate_systems/invalid.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/coordinate_systems/spherical.cc
+++ b/source/world_builder/coordinate_systems/spherical.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate.cc
+++ b/source/world_builder/features/continental_plate.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 
@@ -32,8 +32,6 @@
 #include "world_builder/types/plugin_system.h"
 #include "world_builder/types/value_at_points.h"
 #include "world_builder/world.h"
-
-#include "world_builder/kd_tree.h"
 
 #include <iostream>
 

--- a/source/world_builder/features/continental_plate_models/composition/interface.cc
+++ b/source/world_builder/features/continental_plate_models/composition/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/composition/random.cc
+++ b/source/world_builder/features/continental_plate_models/composition/random.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2024 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/composition/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/grains/interface.cc
+++ b/source/world_builder/features/continental_plate_models/grains/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/grains/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/grains/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/temperature/adiabatic.cc
+++ b/source/world_builder/features/continental_plate_models/temperature/adiabatic.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/temperature/interface.cc
+++ b/source/world_builder/features/continental_plate_models/temperature/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/temperature/linear.cc
+++ b/source/world_builder/features/continental_plate_models/temperature/linear.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/continental_plate_models/temperature/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/temperature/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault.cc
+++ b/source/world_builder/features/fault.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/composition/interface.cc
+++ b/source/world_builder/features/fault_models/composition/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/composition/smooth.cc
+++ b/source/world_builder/features/fault_models/composition/smooth.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 - 2022 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/composition/uniform.cc
+++ b/source/world_builder/features/fault_models/composition/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/grains/interface.cc
+++ b/source/world_builder/features/fault_models/grains/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/fault_models/grains/random_uniform_distribution.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/grains/uniform.cc
+++ b/source/world_builder/features/fault_models/grains/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/temperature/adiabatic.cc
+++ b/source/world_builder/features/fault_models/temperature/adiabatic.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/temperature/interface.cc
+++ b/source/world_builder/features/fault_models/temperature/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/temperature/linear.cc
+++ b/source/world_builder/features/fault_models/temperature/linear.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/fault_models/temperature/uniform.cc
+++ b/source/world_builder/features/fault_models/temperature/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/feature_utilities.cc
+++ b/source/world_builder/features/feature_utilities.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/interface.cc
+++ b/source/world_builder/features/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/mantle_layer.cc
+++ b/source/world_builder/features/mantle_layer.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/mantle_layer_models/composition/interface.cc
+++ b/source/world_builder/features/mantle_layer_models/composition/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/mantle_layer_models/composition/uniform.cc
+++ b/source/world_builder/features/mantle_layer_models/composition/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/mantle_layer_models/grains/interface.cc
+++ b/source/world_builder/features/mantle_layer_models/grains/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 
@@ -29,7 +29,6 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 namespace WorldBuilder

--- a/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 
@@ -29,7 +29,6 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 namespace WorldBuilder

--- a/source/world_builder/features/mantle_layer_models/grains/uniform.cc
+++ b/source/world_builder/features/mantle_layer_models/grains/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/mantle_layer_models/temperature/adiabatic.cc
+++ b/source/world_builder/features/mantle_layer_models/temperature/adiabatic.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 
@@ -26,7 +26,6 @@
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 

--- a/source/world_builder/features/mantle_layer_models/temperature/interface.cc
+++ b/source/world_builder/features/mantle_layer_models/temperature/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/mantle_layer_models/temperature/linear.cc
+++ b/source/world_builder/features/mantle_layer_models/temperature/linear.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 
@@ -26,7 +26,6 @@
 #include "world_builder/types/object.h"
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/value_at_points.h"
-#include "world_builder/utilities.h"
 #include "world_builder/world.h"
 
 

--- a/source/world_builder/features/mantle_layer_models/temperature/uniform.cc
+++ b/source/world_builder/features/mantle_layer_models/temperature/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate.cc
+++ b/source/world_builder/features/oceanic_plate.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/composition/interface.cc
+++ b/source/world_builder/features/oceanic_plate_models/composition/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/composition/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/grains/interface.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/grains/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/adiabatic.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/adiabatic.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/half_space_model.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/half_space_model.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/interface.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/linear.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/linear.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/plate_model.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/plate_model.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/plate_model_constant_age.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/plate_model_constant_age.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/oceanic_plate_models/temperature/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/temperature/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/plume.cc
+++ b/source/world_builder/features/plume.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/plume_models/composition/interface.cc
+++ b/source/world_builder/features/plume_models/composition/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/plume_models/composition/uniform.cc
+++ b/source/world_builder/features/plume_models/composition/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/plume_models/grains/interface.cc
+++ b/source/world_builder/features/plume_models/grains/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/plume_models/grains/uniform.cc
+++ b/source/world_builder/features/plume_models/grains/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/plume_models/temperature/gaussian.cc
+++ b/source/world_builder/features/plume_models/temperature/gaussian.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/plume_models/temperature/interface.cc
+++ b/source/world_builder/features/plume_models/temperature/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/plume_models/temperature/uniform.cc
+++ b/source/world_builder/features/plume_models/temperature/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate.cc
+++ b/source/world_builder/features/subducting_plate.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/composition/interface.cc
+++ b/source/world_builder/features/subducting_plate_models/composition/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/composition/smooth.cc
+++ b/source/world_builder/features/subducting_plate_models/composition/smooth.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 - 2022 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/subducting_plate_models/composition/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/grains/interface.cc
+++ b/source/world_builder/features/subducting_plate_models/grains/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/grains/uniform.cc
+++ b/source/world_builder/features/subducting_plate_models/grains/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/temperature/adiabatic.cc
+++ b/source/world_builder/features/subducting_plate_models/temperature/adiabatic.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/temperature/interface.cc
+++ b/source/world_builder/features/subducting_plate_models/temperature/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/temperature/linear.cc
+++ b/source/world_builder/features/subducting_plate_models/temperature/linear.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/temperature/mass_conserving.cc
+++ b/source/world_builder/features/subducting_plate_models/temperature/mass_conserving.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/temperature/plate_model.cc
+++ b/source/world_builder/features/subducting_plate_models/temperature/plate_model.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/features/subducting_plate_models/temperature/uniform.cc
+++ b/source/world_builder/features/subducting_plate_models/temperature/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/grains.cc
+++ b/source/world_builder/grains.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/gravity_model/interface.cc
+++ b/source/world_builder/gravity_model/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/gravity_model/uniform.cc
+++ b/source/world_builder/gravity_model/uniform.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/kd_tree.cc
+++ b/source/world_builder/kd_tree.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2022 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -1,20 +1,20 @@
 /*
-Copyright (C) 2018 - 2023 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
-This file is part of the World Builder.
+  This file is part of the World Builder.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published
-by the Free Software Foundation, either version 2 of the License, or
-(at your option) any later version.
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include "world_builder/assert.h"
 #include "world_builder/nan.h"

--- a/source/world_builder/objects/distance_from_surface.cc
+++ b/source/world_builder/objects/distance_from_surface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2022 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/objects/natural_coordinate.cc
+++ b/source/world_builder/objects/natural_coordinate.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/objects/segment.cc
+++ b/source/world_builder/objects/segment.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2023 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/objects/surface.cc
+++ b/source/world_builder/objects/surface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/point.cc
+++ b/source/world_builder/point.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/array.cc
+++ b/source/world_builder/types/array.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/bool.cc
+++ b/source/world_builder/types/bool.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/double.cc
+++ b/source/world_builder/types/double.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/int.cc
+++ b/source/world_builder/types/int.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/interface.cc
+++ b/source/world_builder/types/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018-2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/object.cc
+++ b/source/world_builder/types/object.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/one_of.cc
+++ b/source/world_builder/types/one_of.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/plugin_system.cc
+++ b/source/world_builder/types/plugin_system.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/point.cc
+++ b/source/world_builder/types/point.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/segment.cc
+++ b/source/world_builder/types/segment.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/string.cc
+++ b/source/world_builder/types/string.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/unsigned_int.cc
+++ b/source/world_builder/types/unsigned_int.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/types/value_at_points.cc
+++ b/source/world_builder/types/value_at_points.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/utilities.cc
+++ b/source/world_builder/utilities.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/wrapper_c.cc
+++ b/source/world_builder/wrapper_c.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/wrapper_cpp.cc
+++ b/source/world_builder/wrapper_cpp.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
 
   This file is part of the World Builder.
 

--- a/source/world_builder/wrapper_fortran.f90
+++ b/source/world_builder/wrapper_fortran.f90
@@ -1,20 +1,21 @@
 !!
-!!  Copyright (C) 2018-2021 by the authors of the World Builder code.
+!!  Copyright (C) 2018-2024 by the authors of the World Builder code.
 !!
 !!  This file is part of the World Builder.
 !!
-!!   This program is free software: you can redistribute it and/or modify
-!!   it under the terms of the GNU Lesser General Public License as published
-!!   by the Free Software Foundation, either version 2 of the License, or
-!!   (at your option) any later version.
+!!  This program is free software: you can redistribute it and/or modify
+!!  it under the terms of the GNU Lesser General Public License as published
+!!  by the Free Software Foundation, either version 2 of the License, or
+!!  (at your option) any later version.
 !!
-!!   This program is distributed in the hope that it will be useful,
-!!   but WITHOUT ANY WARRANTY; without even the implied warranty of
-!!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-!!   GNU Lesser General Public License for more details.
+!!  This program is distributed in the hope that it will be useful,
+!!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!!  GNU Lesser General Public License for more details.
 !!
-!!   You should have received a copy of the GNU Lesser General Public License
-!!   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!!  You should have received a copy of the GNU Lesser General Public License
+!!  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!!
 
 MODULE WorldBuilder
 USE, INTRINSIC :: ISO_C_BINDING!, ONLY: C_PTR


### PR DESCRIPTION
This update the copyright year of the sphinx docs and it updates and unifies the copyright notice of all world builder header and source files using regex: `((.|\n)*)Copyright \(C\) [0-9- ]* by the authors of the World Builder code.((.|\n)*) If not, see <https://www.gnu.org/licenses/>.`

Some removal of headers from #680 where apparently not saved and got mingled in here. I don't think that is really an issue as long as the testers pass. Related to #670 