### PR TITLE
[WIP] Add water content as a composition to subducting plates

### DIFF
--- a/doc/world_builder_declarations.tex
+++ b/doc/world_builder_declarations.tex
@@ -1,0 +1,7163 @@
+\section{(0) /}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Root object
+\item {\bf additionalProperties}: false
+\item {\bf required}: [version, features]\end{itemize}
+\section{(1) /version}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The major and minor version number for which the input file was written.
+\end{itemize}\section{(1) /$schema}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The optional filename or https address to a JSON schema file
+\end{itemize}\section{(1) /cross section}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf uniqueItems}: false
+\item {\bf description}: This is an array of two points along where the cross section is taken
+\end{itemize}\section{(2) /cross section/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /cross section/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\section{(1) /potential mantle temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1600.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin.
+\end{itemize}\section{(1) /surface temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the surface in Kelvin.
+\end{itemize}\section{(1) /force surface temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: false
+\item {\bf type}: boolean
+\item {\bf description}: Force the provided surface temperature to be set at the surface
+\end{itemize}\section{(1) /thermal expansion coefficient}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.000035
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$.
+\end{itemize}\section{(1) /specific heat}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1250.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}.$
+\end{itemize}\section{(1) /thermal diffusivity}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 8.04e-7
+\item {\bf type}: number
+\item {\bf description}: The thermal diffusivity in $m^{2} s^{-1}$.
+\end{itemize}\section{(1) /maximum distance between coordinates}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: This enforces a maximum distance (in degree for spherical coordinates or meter in cartesian coordinates) between coordinates in the model. If the distance is larger, extra points are added by interpolation. Requires interpolation to be not 'none'.
+\end{itemize}\section{(1) /interpolation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: continuous monotone spline
+\item {\bf type}: string
+\item {\bf description}: What type of interpolation should be used to enforce the minimum points per distance parameter. Options are none, linear, monotone spline and continuous monotone spline interpolation.
+\end{itemize}\section{(1) /coordinate system}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: A coordinate system. Cartesian or spherical.
+\item {\bf default value}: cartesian
+\item {\bf type}: object
+\end{itemize}
+\section{(2) /coordinate system/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: A Cartesian coordinate system. Coordinates are (x,y,z) and extend infinitely in all directions.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsection{(3) /coordinate system/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the coordinate system to use.
+\item {\bf enum}: [cartesian]\end{itemize}\section{(2) /coordinate system/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: A spherical coordinate system. The coordinates are (radius, longitude, latitude). The radius is set in this plugin, the longitude extends at least from -360 to 360 degrees, and the latitude extends from -90 to 90. It is required to choose a depth method. Please see the manual for more information.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, depth method]\end{itemize}
+\subsection{(3) /coordinate system/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the coordinate system to use.
+\item {\bf enum}: [spherical]\end{itemize}\subsection{(3) /coordinate system/oneOf/2/depth method}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: Which depth method to use in the spherical case. The available options are 'starting point', 'begin segment' and 'begin at end segment'. See the manual section on coordinate systems for more info.
+\item {\bf enum}: [starting point, begin segment, begin at end segment, continuous]\end{itemize}\subsection{(3) /coordinate system/oneOf/2/radius}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 6371000.0
+\item {\bf type}: number
+\item {\bf description}: The radius of the sphere.
+\end{itemize}\section{(1) /gravity model}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: A gravity model for the world.
+\item {\bf default value}: uniform
+\item {\bf type}: object
+\end{itemize}
+\section{(2) /gravity model/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform gravity model. It returns the gravity vector in a Cartesian coordinate system at a given position, which has a constant magitude for the whole domain. The vector points down in cartesian coordinates and to the center of the sphere in spherical coordinates.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsection{(3) /gravity model/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the model for the gravity to use.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /gravity model/oneOf/1/magnitude}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 9.81
+\item {\bf type}: number
+\item {\bf description}: The magnitude of the gravity.
+\end{itemize}\section{(1) /features}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: A list of features.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(2) /features/items}
+
+\subsection{(3) /features/items/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Continental plate object. Requires properties `model` and `coordinates`.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The model name of the feature determining its type.
+\item {\bf enum}: [continental plate]\end{itemize}\subsection{(4) /features/items/oneOf/1/name}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name which the user has given to the feature. This is mostly used for documentation purposes, and should in most cases be unique, although this is not enforced.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/tag}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: A tag which can be given to a feature. This is meant to categorize different features. If the tag is not provided or empty, it is set to the model name.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/coordinates}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An array of 2d Points representing an array of coordinates where the feature is located.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/coordinates/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/coordinates/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number
+\end{itemize}\subsection{(4) /features/items/oneOf/1/interpolation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: global
+\item {\bf type}: string
+\item {\bf description}: What type of interpolation should be used to enforce the minimum points per distance parameter. Options are 'global' and 'continuous monotone spline' interpolation. If this value is set to global, the global value for interpolation is used. This option is deprecated and will be removed in a future release.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=4em]\item {\bf description}: The depth from which this feature is present
+\end{itemize}
+\subsection{(5) /features/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(7) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \subsection{(3) /features/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The depth to which this feature is present
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(5) /features/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf temperature models}: \section{(2) /features/items/oneOf/1/3}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: A list of temperature models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsection{(3) /features/items/oneOf/1/3/items}
+
+\subsection{(4) /features/items/oneOf/1/3/items/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsection{(5) /features/items/oneOf/1/3/items/oneOf/1/model}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsection{(5) /features/items/oneOf/1/3/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(5) /features/items/oneOf/1/3/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=5em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(8) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=9em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \subsection{(4) /features/items/oneOf/1/3/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=4em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\subsection{(5) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(7) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/3/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: , number\end{itemize}]]\item {\bf potential mantle temperature}: \subsection{(3) /features/items/oneOf/1/3/items/oneOf/1/3}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\item {\bf thermal expansion coefficient}: \subsection{(3) /features/items/oneOf/1/3/items/oneOf/1/4}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\item {\bf specific heat}: \subsection{(3) /features/items/oneOf/1/3/items/oneOf/1/5}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\section{(1) /features/items/oneOf/1/3/items/oneOf}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max depth]\end{itemize}
+\section{(2) /features/items/oneOf/1/3/items/oneOf/model}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\section{(2) /features/items/oneOf/1/3/items/oneOf/operation}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(2) /features/items/oneOf/1/3/items/oneOf/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf anyOf}: [\end{itemize}\subsection{(5) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(4) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(5) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(1) /features/items/oneOf/1/3/items/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(3) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/3/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf top temperature}: \section{(0) /features/items/oneOf/1/3/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\item {\bf bottom temperature}: \section{(0) /features/items/oneOf/1/3/items}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\section{(0) /features/items/oneOf/1}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\section{(1) /features/items/oneOf/1/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\section{(1) /features/items/oneOf/1/temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}]\item {\bf composition models}: \section{(0) /features/items/oneOf/1}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of composition models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(2) /features/items/oneOf/1/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf anyOf}: [\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(1) /features/items/oneOf/1/items/oneOf/1/3}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/1/3/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf fractions}: \section{(1) /features/items/oneOf/1/items/oneOf/1/4}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/1/4/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf operation}: \section{(1) /features/items/oneOf/1/items/oneOf/1/5}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}]\item {\bf grains models}: \section{(0) /features/items/oneOf/1/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of grains models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf anyOf}: [\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/1/3}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/1/3/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf orientation operation}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/1/4}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\item {\bf grain sizes}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/1/5}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/1/5/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf normalize grain sizes}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/1/6}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/1/6/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf orientation operation}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\item {\bf grain sizes}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf normalize grain sizes}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\item {\bf deflections}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf rotation matrices}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the rotation matrices of the grains which are present there for each compositions.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf Euler angles z-x-z}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf orientation operation}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace, multiply]\end{itemize}\item {\bf grain sizes}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}]\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Fault object. Requires properties `model` and `coordinates`.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The model name of the feature determining its type.
+\item {\bf enum}: [fault]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/name}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name which the user has given to the feature. This is mostly used for documentation purposes, and should in most cases be unique, although this is not enforced.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/tag}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: A tag which can be given to a feature. This is meant to categorize different features. If the tag is not provided or empty, it is set to the model name.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An array of 2d Points representing an array of coordinates where the feature is located.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/interpolation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: global
+\item {\bf type}: string
+\item {\bf description}: What type of interpolation should be used to enforce the minimum points per distance parameter. Options are 'global' and 'continuous monotone spline' interpolation. If this value is set to global, the global value for interpolation is used. This option is deprecated and will be removed in a future release.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/max depth}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/dip point}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/dip point/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: number
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf additionalProperties}: false
+\item {\bf description}: 
+\item {\bf required}: [length, thickness, angle]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/length}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/thickness}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/thickness/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/top truncation}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/top truncation/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/angle}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/angle/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items}
+
+\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/potential mantle temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/thermal expansion coefficient}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/specific heat}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max distance fault center]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The minimum distance to the center of the fault. This determines where the linear temperature starts.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The minimum distance to the center of the fault. This determines where the linear temperature end.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/center temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the center of this feature in degree Kelvin.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/side temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the sides of this feature in degree Kelvin. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items}
+
+\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Compositional model object
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [smooth]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/side distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance over which the composition is reduced from 1 to 0.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/center fractions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the center of the fault.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/center fractions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/side fractions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the sides of this feature.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/side fractions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/2}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/2/fractions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/2/fractions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/composition models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items}
+
+\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/orientation operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/normalize grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/1/normalize grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/orientation operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/normalize grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/normalize grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/deflections}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/2/deflections/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/rotation matrices}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/rotation matrices/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/rotation matrices/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/rotation matrices/items/items/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/Euler angles z-x-z}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/Euler angles z-x-z/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/Euler angles z-x-z/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/orientation operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/grains models/items/oneOf/3/grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: A list of temperature models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items}
+
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/max distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/potential mantle temperature}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/thermal expansion coefficient}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/specific heat}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max distance fault center]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The minimum distance to the center of the fault. This determines where the linear temperature starts.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The minimum distance to the center of the fault. This determines where the linear temperature end.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/2/center temperature}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the center of this feature in degree Kelvin.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/2/side temperature}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the sides of this feature in degree Kelvin. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/3}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/3/operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/3/min distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/3/max distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/3/temperature}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: A list of composition models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items}
+
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Compositional model object
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [smooth]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/side distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance over which the composition is reduced from 1 to 0.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/center fractions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the center of the fault.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/center fractions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/side fractions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the sides of this feature.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/side fractions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/2/fractions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/2/fractions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: A list of grains models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items}
+
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/max distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/orientation operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/grain sizes}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/grain sizes/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/normalize grain sizes}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/normalize grain sizes/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/orientation operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/grain sizes}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/grain sizes/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/normalize grain sizes}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/normalize grain sizes/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/deflections}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/2/deflections/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/min distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/max distance fault center}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/compositions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/compositions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/rotation matrices}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/rotation matrices/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/rotation matrices/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/rotation matrices/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/Euler angles z-x-z}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/Euler angles z-x-z/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/Euler angles z-x-z/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/orientation operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/grain sizes}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/3/grain sizes/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of feature properties for a coordinate.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: object
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/max depth}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/dip point}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/dip point/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: object
+\item {\bf additionalProperties}: false
+\item {\bf description}: 
+\item {\bf required}: [length, thickness, angle]\end{itemize}
+\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/length}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/thickness}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/thickness/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/top truncation}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/top truncation/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/angle}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/angle/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models}
+\begin{itemize}[leftmargin=5em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items}
+
+\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/1}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/1/max distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/1/potential mantle temperature}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/1/thermal expansion coefficient}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/1/specific heat}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/2}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max distance fault center]\end{itemize}
+\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The minimum distance to the center of the fault. This determines where the linear temperature starts.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The minimum distance to the center of the fault. This determines where the linear temperature end.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/2/center temperature}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the center of this feature in degree Kelvin.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/2/side temperature}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the sides of this feature in degree Kelvin. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/3}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/3/operation}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/3/min distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/3/max distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/temperature models/items/oneOf/3/temperature}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models}
+\begin{itemize}[leftmargin=5em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items}
+
+\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: object
+\item {\bf description}: Compositional model object
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [smooth]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/side distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance over which the composition is reduced from 1 to 0.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/center fractions}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the center of the fault.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/center fractions/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/side fractions}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the sides of this feature.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/side fractions/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/2}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/2/fractions}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/2/fractions/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/composition models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models}
+\begin{itemize}[leftmargin=5em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items}
+
+\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/max distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/orientation operation}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/grain sizes}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/grain sizes/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/normalize grain sizes}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/1/normalize grain sizes/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/orientation operation}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/grain sizes}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/grain sizes/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/normalize grain sizes}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/normalize grain sizes/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/deflections}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/2/deflections/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/min distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/max distance fault center}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/compositions}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/compositions/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/rotation matrices}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/rotation matrices/items}
+\begin{itemize}[leftmargin=9em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\paragraph{(10) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/rotation matrices/items/items}
+\begin{itemize}[leftmargin=10em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\paragraph{(11) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/rotation matrices/items/items/items}
+\begin{itemize}[leftmargin=11em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/Euler angles z-x-z}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/Euler angles z-x-z/items}
+\begin{itemize}[leftmargin=9em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\paragraph{(10) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/Euler angles z-x-z/items/items}
+\begin{itemize}[leftmargin=10em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/orientation operation}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/grain sizes}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/segments/items/grains models/items/oneOf/3/grain sizes/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: A list of temperature models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items}
+
+\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/1}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/1/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/1/potential mantle temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/1/thermal expansion coefficient}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/1/specific heat}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/2}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max distance fault center]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The minimum distance to the center of the fault. This determines where the linear temperature starts.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The minimum distance to the center of the fault. This determines where the linear temperature end.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/2/center temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the center of this feature in degree Kelvin.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/2/side temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the sides of this feature in degree Kelvin. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/3}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/3/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/3/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/3/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/temperature models/items/oneOf/3/temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: A list of composition models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items}
+
+\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Compositional model object
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [smooth]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/side distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance over which the composition is reduced from 1 to 0.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/center fractions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the center of the fault.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/center fractions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/side fractions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the sides of this feature.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/side fractions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/2}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/2/fractions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/2/fractions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/composition models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: A list of grains models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items}
+
+\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/orientation operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/normalize grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/1/normalize grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/orientation operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/normalize grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/normalize grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/deflections}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/2/deflections/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/min distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault center in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/max distance fault center}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the fault in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/compositions}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/compositions/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/rotation matrices}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/rotation matrices/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/rotation matrices/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/rotation matrices/items/items/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/Euler angles z-x-z}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/Euler angles z-x-z/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/Euler angles z-x-z/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/orientation operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/grain sizes}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/grains models/items/oneOf/3/grain sizes/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/sections/items/coordinate}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: The coordinate which should be overwritten
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Mantle layer object. Requires properties `model` and `coordinates`.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The model name of the feature determining its type.
+\item {\bf enum}: [mantle layer]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/name}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name which the user has given to the feature. This is mostly used for documentation purposes, and should in most cases be unique, although this is not enforced.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/tag}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: A tag which can be given to a feature. This is meant to categorize different features. If the tag is not provided or empty, it is set to the model name.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An array of 2d Points representing an array of coordinates where the feature is located.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/interpolation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: global
+\item {\bf type}: string
+\item {\bf description}: What type of interpolation should be used to enforce the minimum points per distance parameter. Options are 'global' and 'continuous monotone spline' interpolation. If this value is set to global, the global value for interpolation is used. This option is deprecated and will be removed in a future release.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth from which this feature is present
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth to which this feature is present
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf temperature models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of temperature models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The depth in meters to which the temperature of this feature is present.
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf anyOf}: [\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , number\end{itemize}]]\item {\bf potential mantle temperature}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/3}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\item {\bf thermal expansion coefficient}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/4}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\item {\bf specific heat}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/5}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max depth]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the temperature of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf top temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\item {\bf bottom temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the temperature of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}]\item {\bf composition models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of composition models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf anyOf}: [\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/3}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/3/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf fractions}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/4}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/4/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf operation}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/5}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}]\item {\bf grains models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of grains models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf anyOf}: [\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/3}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/3/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf orientation operation}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/4}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\item {\bf grain sizes}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/5}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/5/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf normalize grain sizes}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/6}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/6/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf orientation operation}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\item {\bf grain sizes}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf normalize grain sizes}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\item {\bf deflections}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf rotation matrices}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf Euler angles z-x-z}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf orientation operation}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\item {\bf grain sizes}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}]\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Oceanic plate object. Requires properties `model` and `coordinates`.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The model name of the feature determining its type.
+\item {\bf enum}: [oceanic plate]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/name}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name which the user has given to the feature. This is mostly used for documentation purposes, and should in most cases be unique, although this is not enforced.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/tag}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: A tag which can be given to a feature. This is meant to categorize different features. If the tag is not provided or empty, it is set to the model name.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An array of 2d Points representing an array of coordinates where the feature is located.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/interpolation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: global
+\item {\bf type}: string
+\item {\bf description}: What type of interpolation should be used to enforce the minimum points per distance parameter. Options are 'global' and 'continuous monotone spline' interpolation. If this value is set to global, the global value for interpolation is used. This option is deprecated and will be removed in a future release.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth from which this feature is present
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth to which this feature is present
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf temperature models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of temperature models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The depth in meters to which the temperature of this feature is present.
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf anyOf}: [\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , number\end{itemize}]]\item {\bf potential mantle temperature}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/3}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\item {\bf thermal expansion coefficient}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/4}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\item {\bf specific heat}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/5}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Half space cooling mode
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, ridge coordinates, spreading velocity, max depth]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [half space model]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the temperature of this feature is present.Because half-space reaches background temperature asymptotically, this value should be ~2 times the nominal plate thickness of 100 km
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf top temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The actual surface temperature in degree Kelvin for this feature.
+\end{itemize}\item {\bf bottom temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The mantle temperature for the half-space cooling modelin degree Kelvin for this feature. If the model has an adiabatic gradientthis should be the mantle potential temperature, and T = Tad + Thalf. 
+\end{itemize}\item {\bf spreading velocity}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The spreading velocity of the plate in meter per year. This is the velocity with which one side moves away from the ridge.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.05
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 0.05
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf ridge coordinates}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An list of ridges. Each ridge is a lists of at least 2 2d points which define the location of the ridge. You need to define at least one ridge.So the an example with two ridges is [[[10,20],[20,30],[10,40]],[[50,10],[60,10]]].
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/items/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max depth]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the temperature of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf top temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\item {\bf bottom temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Plate model.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max depth]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [plate model]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the temperature of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf top temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}\item {\bf bottom temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}\item {\bf spreading velocity}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The spreading velocity of the plate in meter per year. This is the velocity with which one side moves away from the ridge.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.05
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 0.05
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf ridge coordinates}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An list of ridges. Each ridge is a lists of at least 2 2d points which define the location of the ridge. You need to define at least one ridge.So the an example with two ridges is [[[10,20],[20,30],[10,40]],[[50,10],[60,10]]].
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Plate model, but with a fixed age.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max depth]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [plate model constant age]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the temperature of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf top temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}\item {\bf bottom temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}\item {\bf plate age}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 80000.0
+\item {\bf type}: number
+\item {\bf description}: The age of the plate in year. This age is assigned to the whole plate. 
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the temperature of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}]\item {\bf composition models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of composition models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf anyOf}: [\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/3}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/3/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf fractions}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/4}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/4/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf operation}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/5}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}]\item {\bf grains models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of grains models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf anyOf}: [\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/3}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/3/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf orientation operation}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/4}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\item {\bf grain sizes}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/5}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/5/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf normalize grain sizes}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/6}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/6/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf orientation operation}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\item {\bf grain sizes}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf normalize grain sizes}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\item {\bf deflections}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf anyOf}: [\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number\item {\bf default value}: 0.0
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , number\end{itemize}]]\item {\bf max depth}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/1}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf anyOf}: [\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number\item {\bf default value}: 1.7976931348623157e308
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: , number\end{itemize}]]\item {\bf compositions}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\item {\bf rotation matrices}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf Euler angles z-x-z}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf orientation operation}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\item {\bf grain sizes}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}]\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Plume object. Requires properties `model` and `coordinates`.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The model name of the feature determining its type.
+\item {\bf enum}: [plume]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/name}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name which the user has given to the feature. This is mostly used for documentation purposes, and should in most cases be unique, although this is not enforced.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/tag}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: A tag which can be given to a feature. This is meant to categorize different features. If the tag is not provided or empty, it is set to the model name.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An array of 2d Points representing an array of coordinates where the feature is located.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/interpolation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: global
+\item {\bf type}: string
+\item {\bf description}: What type of interpolation should be used to enforce the minimum points per distance parameter. Options are 'global' and 'continuous monotone spline' interpolation. If this value is set to global, the global value for interpolation is used. This option is deprecated and will be removed in a future release.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The depth from which this feature is present, in other words, the depth of the tip of the plume. If the first entry in the cross section depths has a greater depth, an ellipsoidal plume head will be added in between. Units: m.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/max depth}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The depth to which this feature is present. Units: m.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/cross section depths}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The depths of the elliptic cross section of the plume. Units: m.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/cross section depths/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/semi-major axis}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The lengths of the semi-major axes of the elliptic cross sections of the plume. In spherical coordinates, this is in degrees, otherwise in meters.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/semi-major axis/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 100000.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/eccentricity}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The eccentricities of the cross sections.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/eccentricity/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/rotation angles}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The directions that the semi-major axis of the elliptic cross-sections are pointing to, in degrees. This direction is expressed as the angle from geographic North in spherical coordinates, or as the angle from the Y axis (clockwise) in Cartesian coordinates. The angle should be between 0 and 360 degrees.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/rotation angles/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: A list of temperature models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items}
+
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constant value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The depth in meters from which the temperature of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/max depth}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The depth in meters to which the temperature of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/temperature models/items/oneOf/1/temperature}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: A list of composition models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items}
+
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/max depth}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/fractions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/fractions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/composition models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: A list of grains models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items}
+
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/min depth}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The depth in meters from which the grains of this feature are present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/max depth}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The depth in meters to which the grains of this feature are present.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/rotation matrices}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the rotation matrices of the grains which are present there for each compositions.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/rotation matrices/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/rotation matrices/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/rotation matrices/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/Euler angles z-x-z}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/Euler angles z-x-z/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/Euler angles z-x-z/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/orientation operation}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace, multiply]\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/grain sizes}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/grains models/items/oneOf/1/grain sizes/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Subducting slab object. Requires properties `model` and `coordinates`.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The model name of the feature determining its type.
+\item {\bf enum}: [subducting plate]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/name}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name which the user has given to the feature. This is mostly used for documentation purposes, and should in most cases be unique, although this is not enforced.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/tag}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: A tag which can be given to a feature. This is meant to categorize different features. If the tag is not provided or empty, it is set to the model name.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An array of 2d Points representing an array of coordinates where the feature is located.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/coordinates/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/interpolation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: global
+\item {\bf type}: string
+\item {\bf description}: What type of interpolation should be used to enforce the minimum points per distance parameter. Options are 'global' and 'continuous monotone spline' interpolation. If this value is set to global, the global value for interpolation is used. This option is deprecated and will be removed in a future release.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/max depth}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/dip point}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/dip point/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: number
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf additionalProperties}: false
+\item {\bf description}: 
+\item {\bf required}: [length, thickness, angle]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/length}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/thickness}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/thickness/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/top truncation}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/top truncation/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/angle}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/angle/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items}
+
+\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/potential mantle temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/thermal expansion coefficient}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/1/specific heat}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max distance slab top]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/top temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/2/bottom temperature}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the bottom in degree Kelvin of this feature. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: object
+\item {\bf description}: Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, plate velocity]\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [mass conserving]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/operation}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/min distance slab top}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be negative and should be 1.5-2 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle above the slab surface. Also note that the top truncation value for the slab segment needs to have a value of -1, otherwise the temperature above the slab will be cut off at a distance less than the value set here.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/max distance slab top}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/density}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 3300.0
+\item {\bf type}: number
+\item {\bf description}: The reference density of the subducting plate in $kg/m^3$
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity}
+\begin{itemize}[leftmargin=6em]\item {\bf description}: The velocity with which the plate subducts in meters per year. Default is 5 cm/yr
+\end{itemize}
+\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/1}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0.05
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\item {\bf description}: 
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=9em]\item {\bf anyOf}: [\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=9em]\item {\bf type}: number\item {\bf default value}: 0.05
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=9em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\end{itemize}\paragraph{(10) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=10em]\item {\bf type}: , number\end{itemize}]]\item {\bf subducting velocity}: \subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity}
+\begin{itemize}[leftmargin=5em]\item {\bf description}: The velocity with which the ridge is moving through time, and how long the ridge has been moving. First value is the velocity, second is the time. Default is [0 cm/yr, 0 yr]
+\end{itemize}
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/1}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf coupling depth}: \subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf/3}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 100000.0
+\item {\bf type}: number
+\item {\bf description}: The depth at which the slab surface first comes in contact with the hot mantle wedge in meters. Default is 100 km.
+\end{itemize}\item {\bf forearc cooling factor}: \subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items/oneOf}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: Increase the value to create thin (~2 km) cold thermal boundary layer above the slab.Any value greater than 1 does NOT meet the instantaneous conservation of mass, but does allow one to account for the history of insulating the forearc from heating up to this point in time. Note younger subducting lithosphere provides less insulation, while thicker, older slabs provide more insulation. Values up to 10 to 30 have been tested and don't cause any other extraneous effects. The larger th value the more you are not meeting the mass conserving criteria, so you don't want to see this affecting the temperature beyond the coupling depth as it will increase the mass of the slab and affect how it sinks.  If you use higher values, you will start to see that this creates a very thick cool layer above the entire slab - if you see this extending beyond the coupling zone reduce the value. You should use a value of 1 first and then only increase as little as possible to cool just the forearc region. Please examine the output temperature carefully. 
+\end{itemize}\item {\bf thermal conductivity}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models/items}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 3.3
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\item {\bf thermal expansion coefficient}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items/temperature models}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansivity of the subducting plate material in $K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf specific heat}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments/items}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf thermal diffusivity}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/segments}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\item {\bf adiabatic heating}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: Whether adiabatic heating should be used for the slab.
+\end{itemize}\item {\bf taper distance}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 100000.0
+\item {\bf type}: number
+\item {\bf description}: Distance over which to taper the slab tip.tapers the initial heat content to zero and the minimum temperature to the background temperature.
+\end{itemize}\item {\bf potential mantle temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf ridge coordinates}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An list of ridges. Each ridge is a lists of at least 2 2d points which define the location of the ridge. You need to define at least one ridge.So the an example with two ridges is [[[10,20],[20,30],[10,40]],[[50,10],[60,10]]].
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/items/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\item {\bf reference model name}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: half space model
+\item {\bf type}: string
+\item {\bf description}: The type of thermal model to use in the mass conserving model of slab temperature. Options are half space model and plate model
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Plate model (based on McKenzie, 1970).
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, plate velocity]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [plate model]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/max distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/density}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 3300.0
+\item {\bf type}: number
+\item {\bf description}: The reference density of the subducting plate in $kg/m^3$
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/plate velocity}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: NaN
+\item {\bf type}: number
+\item {\bf description}: The velocity in meters per year with which the plate subducts in meters per year.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/thermal conductivity}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 2.0
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/thermal expansion coefficient}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansivity of the subducting plate material in $K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/specific heat}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/adiabatic heating}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: Whether adiabatic heating should be used for the slab. Setting the parameter to false leads to equation 26 from McKenzie (1970),which is the result obtained from McKenzie 1969.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/potential mantle temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If smaller than zero, the global value is used.
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/min distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/max distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/items/temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}]\item {\bf composition models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Compositional model object
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [smooth]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this layer is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this layer is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/top fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the top of the slab (layer).
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/top fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/bottom fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the bottom of the slab (layer).
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/bottom fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/2/fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/2/fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\item {\bf grains models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/normalize grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/1/normalize grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/normalize grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/normalize grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/deflections}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/2/deflections/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/rotation matrices}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/rotation matrices/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/rotation matrices/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/rotation matrices/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/Euler angles z-x-z}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/Euler angles z-x-z/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/Euler angles z-x-z/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/min depth/oneOf/items/oneOf/3/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf temperature models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of temperature models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/1/potential mantle temperature}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/1/thermal expansion coefficient}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/1/specific heat}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max distance slab top]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/2/top temperature}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/2/bottom temperature}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the bottom in degree Kelvin of this feature. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, plate velocity]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [mass conserving]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be negative and should be 1.5-2 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle above the slab surface. Also note that the top truncation value for the slab segment needs to have a value of -1, otherwise the temperature above the slab will be cut off at a distance less than the value set here.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/density}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 3300.0
+\item {\bf type}: number
+\item {\bf description}: The reference density of the subducting plate in $kg/m^3$
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The velocity with which the plate subducts in meters per year. Default is 5 cm/yr
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.05
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.05
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf subducting velocity}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The velocity with which the ridge is moving through time, and how long the ridge has been moving. First value is the velocity, second is the time. Default is [0 cm/yr, 0 yr]
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf coupling depth}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf/3}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 100000.0
+\item {\bf type}: number
+\item {\bf description}: The depth at which the slab surface first comes in contact with the hot mantle wedge in meters. Default is 100 km.
+\end{itemize}\item {\bf forearc cooling factor}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: Increase the value to create thin (~2 km) cold thermal boundary layer above the slab.Any value greater than 1 does NOT meet the instantaneous conservation of mass, but does allow one to account for the history of insulating the forearc from heating up to this point in time. Note younger subducting lithosphere provides less insulation, while thicker, older slabs provide more insulation. Values up to 10 to 30 have been tested and don't cause any other extraneous effects. The larger th value the more you are not meeting the mass conserving criteria, so you don't want to see this affecting the temperature beyond the coupling depth as it will increase the mass of the slab and affect how it sinks.  If you use higher values, you will start to see that this creates a very thick cool layer above the entire slab - if you see this extending beyond the coupling zone reduce the value. You should use a value of 1 first and then only increase as little as possible to cool just the forearc region. Please examine the output temperature carefully. 
+\end{itemize}\item {\bf thermal conductivity}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf/items}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 3.3
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\item {\bf thermal expansion coefficient}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansivity of the subducting plate material in $K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf specific heat}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf thermal diffusivity}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\item {\bf adiabatic heating}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: Whether adiabatic heating should be used for the slab.
+\end{itemize}\item {\bf taper distance}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 100000.0
+\item {\bf type}: number
+\item {\bf description}: Distance over which to taper the slab tip.tapers the initial heat content to zero and the minimum temperature to the background temperature.
+\end{itemize}\item {\bf potential mantle temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf ridge coordinates}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An list of ridges. Each ridge is a lists of at least 2 2d points which define the location of the ridge. You need to define at least one ridge.So the an example with two ridges is [[[10,20],[20,30],[10,40]],[[50,10],[60,10]]].
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\item {\bf reference model name}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: half space model
+\item {\bf type}: string
+\item {\bf description}: The type of thermal model to use in the mass conserving model of slab temperature. Options are half space model and plate model
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Plate model (based on McKenzie, 1970).
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, plate velocity]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [plate model]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/min distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/max distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/density}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 3300.0
+\item {\bf type}: number
+\item {\bf description}: The reference density of the subducting plate in $kg/m^3$
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/plate velocity}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: NaN
+\item {\bf type}: number
+\item {\bf description}: The velocity in meters per year with which the plate subducts in meters per year.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/thermal conductivity}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 2.0
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/thermal expansion coefficient}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansivity of the subducting plate material in $K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/specific heat}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/adiabatic heating}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: Whether adiabatic heating should be used for the slab. Setting the parameter to false leads to equation 26 from McKenzie (1970),which is the result obtained from McKenzie 1969.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/potential mantle temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If smaller than zero, the global value is used.
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/min distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/max distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}]\item {\bf composition models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of composition models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Compositional model object
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [smooth]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this layer is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this layer is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/top fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the top of the slab (layer).
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/top fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/bottom fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the bottom of the slab (layer).
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/bottom fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\item {\bf grains models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of grains models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/normalize grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/1/normalize grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/normalize grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/normalize grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/deflections}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/2/deflections/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/rotation matrices}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/rotation matrices/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/rotation matrices/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/rotation matrices/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/Euler angles z-x-z}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/Euler angles z-x-z/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/Euler angles z-x-z/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/3/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf sections}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of feature properties for a coordinate.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: object
+\end{itemize}
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/min depth}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/max depth}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/dip point}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/dip point/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The depth to which this feature is present
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: object
+\item {\bf additionalProperties}: false
+\item {\bf description}: 
+\item {\bf required}: [length, thickness, angle]\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/length}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: number
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/thickness}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/thickness/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/top truncation}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/top truncation/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/angle}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 2
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/angle/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: number
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models}
+\begin{itemize}[leftmargin=4em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items}
+
+\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/1}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/1/model}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/1/potential mantle temperature}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/1/thermal expansion coefficient}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/1/specific heat}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/2}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max distance slab top]\end{itemize}
+\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/2/model}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/2/top temperature}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/2/bottom temperature}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the bottom in degree Kelvin of this feature. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: object
+\item {\bf description}: Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, plate velocity]\end{itemize}
+\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/model}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [mass conserving]\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/operation}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/min distance slab top}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be negative and should be 1.5-2 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle above the slab surface. Also note that the top truncation value for the slab segment needs to have a value of -1, otherwise the temperature above the slab will be cut off at a distance less than the value set here.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/max distance slab top}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/density}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 3300.0
+\item {\bf type}: number
+\item {\bf description}: The reference density of the subducting plate in $kg/m^3$
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity}
+\begin{itemize}[leftmargin=7em]\item {\bf description}: The velocity with which the plate subducts in meters per year. Default is 5 cm/yr
+\end{itemize}
+\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/1}
+\begin{itemize}[leftmargin=8em]\item {\bf default value}: 0.05
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=9em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\item {\bf description}: 
+\end{itemize}\paragraph{(10) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=10em]\item {\bf anyOf}: [\end{itemize}\paragraph{(10) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=10em]\item {\bf type}: number\item {\bf default value}: 0.05
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=9em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\paragraph{(10) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=10em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\end{itemize}\paragraph{(11) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=11em]\item {\bf type}: , number\end{itemize}]]\item {\bf subducting velocity}: \subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity}
+\begin{itemize}[leftmargin=6em]\item {\bf description}: The velocity with which the ridge is moving through time, and how long the ridge has been moving. First value is the velocity, second is the time. Default is [0 cm/yr, 0 yr]
+\end{itemize}
+\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/1}
+\begin{itemize}[leftmargin=7em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(8) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=8em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\paragraph{(9) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=9em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf coupling depth}: \subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf/3}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 100000.0
+\item {\bf type}: number
+\item {\bf description}: The depth at which the slab surface first comes in contact with the hot mantle wedge in meters. Default is 100 km.
+\end{itemize}\item {\bf forearc cooling factor}: \subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items/oneOf}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: Increase the value to create thin (~2 km) cold thermal boundary layer above the slab.Any value greater than 1 does NOT meet the instantaneous conservation of mass, but does allow one to account for the history of insulating the forearc from heating up to this point in time. Note younger subducting lithosphere provides less insulation, while thicker, older slabs provide more insulation. Values up to 10 to 30 have been tested and don't cause any other extraneous effects. The larger th value the more you are not meeting the mass conserving criteria, so you don't want to see this affecting the temperature beyond the coupling depth as it will increase the mass of the slab and affect how it sinks.  If you use higher values, you will start to see that this creates a very thick cool layer above the entire slab - if you see this extending beyond the coupling zone reduce the value. You should use a value of 1 first and then only increase as little as possible to cool just the forearc region. Please examine the output temperature carefully. 
+\end{itemize}\item {\bf thermal conductivity}: \subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models/items}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 3.3
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\item {\bf thermal expansion coefficient}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items/temperature models}
+\begin{itemize}[leftmargin=2em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansivity of the subducting plate material in $K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf specific heat}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments/items}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf thermal diffusivity}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/segments}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\item {\bf adiabatic heating}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: Whether adiabatic heating should be used for the slab.
+\end{itemize}\item {\bf taper distance}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 100000.0
+\item {\bf type}: number
+\item {\bf description}: Distance over which to taper the slab tip.tapers the initial heat content to zero and the minimum temperature to the background temperature.
+\end{itemize}\item {\bf potential mantle temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf ridge coordinates}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An list of ridges. Each ridge is a lists of at least 2 2d points which define the location of the ridge. You need to define at least one ridge.So the an example with two ridges is [[[10,20],[20,30],[10,40]],[[50,10],[60,10]]].
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\item {\bf reference model name}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: half space model
+\item {\bf type}: string
+\item {\bf description}: The type of thermal model to use in the mass conserving model of slab temperature. Options are half space model and plate model
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Plate model (based on McKenzie, 1970).
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, plate velocity]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [plate model]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/min distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/max distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/density}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 3300.0
+\item {\bf type}: number
+\item {\bf description}: The reference density of the subducting plate in $kg/m^3$
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/plate velocity}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: NaN
+\item {\bf type}: number
+\item {\bf description}: The velocity in meters per year with which the plate subducts in meters per year.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/thermal conductivity}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 2.0
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/thermal expansion coefficient}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansivity of the subducting plate material in $K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/specific heat}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/adiabatic heating}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: Whether adiabatic heating should be used for the slab. Setting the parameter to false leads to equation 26 from McKenzie (1970),which is the result obtained from McKenzie 1969.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min depth/potential mantle temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If smaller than zero, the global value is used.
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/min distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/max distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}]\item {\bf composition models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Compositional model object
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [smooth]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this layer is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this layer is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/top fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the top of the slab (layer).
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/top fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/bottom fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the bottom of the slab (layer).
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/bottom fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/2/fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/2/fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\item {\bf grains models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: 
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/normalize grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/1/normalize grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/normalize grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/normalize grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/deflections}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/2/deflections/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/rotation matrices}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/rotation matrices/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/rotation matrices/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/rotation matrices/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/Euler angles z-x-z}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/Euler angles z-x-z/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/Euler angles z-x-z/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/oneOf/3/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf temperature models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of temperature models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Adiabatic temperature model. Uses global values by default.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [adiabatic]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/1/potential mantle temperature}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/1/thermal expansion coefficient}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansion coefficient in $K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/1/specific heat}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat in $J kg^{-1} K^{-1}$. If the value is lower then zero, the global value is used.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Linear temperature model. Can be set to use an adiabatic temperature at the boundaries.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, max distance slab top]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [linear]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/2/top temperature}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature at the top in degree Kelvin of this feature.If the value is below zero, the an adiabatic temperature is used.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/2/bottom temperature}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The temperature at the bottom in degree Kelvin of this feature. If the value is below zero, an adiabatic temperature is used.
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, plate velocity]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [mass conserving]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be negative and should be 1.5-2 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle above the slab surface. Also note that the top truncation value for the slab segment needs to have a value of -1, otherwise the temperature above the slab will be cut off at a distance less than the value set here.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/density}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 3300.0
+\item {\bf type}: number
+\item {\bf description}: The reference density of the subducting plate in $kg/m^3$
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity}
+\begin{itemize}[leftmargin=3em]\item {\bf description}: The velocity with which the plate subducts in meters per year. Default is 5 cm/yr
+\end{itemize}
+\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/1}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.05
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf additionalProperties}: false
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf anyOf}: [\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: number\item {\bf default value}: 0.05
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf type}: , array\item {\bf minItems}: 1
+\item {\bf maxItems}: 18446744073709551615
+\end{itemize}\subsubsection{(7) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items/items}
+\begin{itemize}[leftmargin=7em]\item {\bf type}: , number\end{itemize}]]\item {\bf subducting velocity}: \section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity}
+\begin{itemize}[leftmargin=2em]\item {\bf description}: The velocity with which the ridge is moving through time, and how long the ridge has been moving. First value is the velocity, second is the time. Default is [0 cm/yr, 0 yr]
+\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/1}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3/plate velocity/oneOf/2/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf coupling depth}: \section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf/3}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 100000.0
+\item {\bf type}: number
+\item {\bf description}: The depth at which the slab surface first comes in contact with the hot mantle wedge in meters. Default is 100 km.
+\end{itemize}\item {\bf forearc cooling factor}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: Increase the value to create thin (~2 km) cold thermal boundary layer above the slab.Any value greater than 1 does NOT meet the instantaneous conservation of mass, but does allow one to account for the history of insulating the forearc from heating up to this point in time. Note younger subducting lithosphere provides less insulation, while thicker, older slabs provide more insulation. Values up to 10 to 30 have been tested and don't cause any other extraneous effects. The larger th value the more you are not meeting the mass conserving criteria, so you don't want to see this affecting the temperature beyond the coupling depth as it will increase the mass of the slab and affect how it sinks.  If you use higher values, you will start to see that this creates a very thick cool layer above the entire slab - if you see this extending beyond the coupling zone reduce the value. You should use a value of 1 first and then only increase as little as possible to cool just the forearc region. Please examine the output temperature carefully. 
+\end{itemize}\item {\bf thermal conductivity}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 3.3
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\item {\bf thermal expansion coefficient}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansivity of the subducting plate material in $K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf specific heat}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf thermal diffusivity}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\item {\bf adiabatic heating}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: Whether adiabatic heating should be used for the slab.
+\end{itemize}\item {\bf taper distance}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 100000.0
+\item {\bf type}: number
+\item {\bf description}: Distance over which to taper the slab tip.tapers the initial heat content to zero and the minimum temperature to the background temperature.
+\end{itemize}\item {\bf potential mantle temperature}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If smaller than zero, the global value is used.
+\end{itemize}\item {\bf ridge coordinates}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: An list of ridges. Each ridge is a lists of at least 2 2d points which define the location of the ridge. You need to define at least one ridge.So the an example with two ridges is [[[10,20],[20,30],[10,40]],[[50,10],[60,10]]].
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items}
+\begin{itemize}[leftmargin=1em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: array
+\item {\bf minItems}: 2
+\item {\bf maxItems}: 2
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth/oneOf/items/items/items}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: number
+\end{itemize}\item {\bf reference model name}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: half space model
+\item {\bf type}: string
+\item {\bf description}: The type of thermal model to use in the mass conserving model of slab temperature. Options are half space model and plate model
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Plate model (based on McKenzie, 1970).
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, plate velocity]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [plate model]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/min distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/max distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/density}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 3300.0
+\item {\bf type}: number
+\item {\bf description}: The reference density of the subducting plate in $kg/m^3$
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/plate velocity}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: NaN
+\item {\bf type}: number
+\item {\bf description}: The velocity in meters per year with which the plate subducts in meters per year.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/thermal conductivity}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 2.0
+\item {\bf type}: number
+\item {\bf description}: The thermal conductivity of the subducting plate material in $W m^{-1} K^{-1}$.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/thermal expansion coefficient}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The thermal expansivity of the subducting plate material in $K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/specific heat}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The specific heat of the subducting plate material in $J kg^{-1} K^{-1}$. If smaller than zero, the global value is used.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/adiabatic heating}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: Whether adiabatic heating should be used for the slab. Setting the parameter to false leads to equation 26 from McKenzie (1970),which is the result obtained from McKenzie 1969.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min depth/potential mantle temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: The potential temperature of the mantle at the surface in Kelvin. If smaller than zero, the global value is used.
+\end{itemize}\section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf type}: object
+\item {\bf description}: Uniform temperature model. Set the temperature to a constan value.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, temperature]\end{itemize}
+\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/model}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the temperature model.
+\item {\bf enum}: [uniform]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/operation}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
+\item {\bf enum}: [replace, add, subtract]\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/min distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/max distance slab top}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/temperature}
+\begin{itemize}[leftmargin=1em]\item {\bf default value}: 293.15
+\item {\bf type}: number
+\item {\bf description}: The temperature in degree Kelvin which this feature should have
+\end{itemize}]\item {\bf composition models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of composition models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Compositional model object
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [smooth]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this layer is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance in meters from which the composition of this layer is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/top fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the top of the slab (layer).
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/top fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/bottom fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: The composition fraction at the bottom of the slab (layer).
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/bottom fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform compositional model. Sets constant compositional field.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the composition model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: todo The depth in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/fractions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 1
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: TA list of compositional fractions corresponding to the compositions list.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/fractions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+\item {\bf enum}: [replace, replace defined only, add, subtract]\end{itemize}\item {\bf grains models}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf description}: A list of grains models.
+\item {\bf default value}: 
+\item {\bf type}: array
+\end{itemize}\section{(1) /features/items/oneOf/1/items/oneOf/items/oneOf/items}
+
+\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/normalize grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/1/normalize grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [random uniform distribution deflected]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/normalize grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/normalize grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: true
+\item {\bf type}: boolean
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/deflections}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the deflections of all of the grains in each composition between 0 and 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/2/deflections/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\section{(2) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3}
+\begin{itemize}[leftmargin=2em]\item {\bf type}: object
+\item {\bf description}: Uniform grains model. All grains start exactly the same.
+\item {\bf additionalProperties}: false
+\item {\bf required}: [model, compositions]\end{itemize}
+\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/model}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 
+\item {\bf type}: string
+\item {\bf description}: The name of the grains model.
+\item {\bf enum}: [uniform]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/min distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters from which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/max distance slab top}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: 1.7976931348623157e308
+\item {\bf type}: number
+\item {\bf description}: The distance from the slab top in meters to which the composition of this feature is present.
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/compositions}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the integer labels of the composition which are present there.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/compositions/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/rotation matrices}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the labels of the grains which are present there for each compositions.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/rotation matrices/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/rotation matrices/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsubsection{(6) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/rotation matrices/items/items/items}
+\begin{itemize}[leftmargin=6em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/Euler angles z-x-z}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/Euler angles z-x-z/items}
+\begin{itemize}[leftmargin=4em]\item {\bf type}: array
+\item {\bf minItems}: 3
+\item {\bf maxItems}: 3
+\item {\bf uniqueItems}: false
+\item {\bf description}: 
+\end{itemize}\subsection{(5) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/Euler angles z-x-z/items/items}
+\begin{itemize}[leftmargin=5em]\item {\bf default value}: 0.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/orientation operation}
+\begin{itemize}[leftmargin=3em]\item {\bf default value}: replace
+\item {\bf type}: string
+\item {\bf description}: Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+\item {\bf enum}: [replace]\end{itemize}\subsection{(3) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/grain sizes}
+\begin{itemize}[leftmargin=3em]\item {\bf type}: array
+\item {\bf minItems}: 0
+\item {\bf maxItems}: 4294967295
+\item {\bf uniqueItems}: false
+\item {\bf description}: A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+\end{itemize}\subsection{(4) /features/items/oneOf/1/items/oneOf/items/oneOf/items/oneOf/3/grain sizes/items}
+\begin{itemize}[leftmargin=4em]\item {\bf default value}: -1.0
+\item {\bf type}: number
+\item {\bf description}: 
+\end{itemize}\item {\bf coordinate}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 0
+\item {\bf type}: integer
+\item {\bf description}: The coordinate which should be overwritten
+\end{itemize}]\item {\bf random number seed}: \section{(0) /features/items/oneOf/1/items/oneOf/items/oneOf}
+\begin{itemize}[leftmargin=0em]\item {\bf default value}: 4294967295
+\item {\bf type}: integer
+\item {\bf description}: Use random number seed input to generate random numbers.
+\end{itemize}

--- a/include/world_builder/features/subducting_plate_models/composition/water_content.h
+++ b/include/world_builder/features/subducting_plate_models/composition/water_content.h
@@ -1,0 +1,126 @@
+/*
+  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+
+  This file is part of the World Builder.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_COMPOSITION_WATER_CONTENT_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_MODELS_COMPOSITION_WATER_CONTENT_H
+
+
+#include "world_builder/features/subducting_plate_models/composition/interface.h"
+#include <mutex>
+
+
+namespace WorldBuilder
+{
+
+  namespace Features
+  {
+    namespace SubductingPlateModels
+    {
+      namespace Composition
+      {
+        /**
+         * This class represents the bound water content in a subducting plate and can implement
+         * submodules for computing this bound water content. These submodules determine what
+         * the returned water content will be based on the the temperature and pressure at a point
+         * within the world.
+         */
+        class WaterContent final: public Interface
+        {
+          public:
+            /**
+             * constructor
+             */
+            WaterContent(WorldBuilder::World *world);
+
+            /**
+             * Destructor
+             */
+            ~WaterContent() override final;
+
+            /**
+             * declare and read in the world builder file into the parameters class
+             */
+            static
+            void declare_entries(Parameters &prm, const std::string &parent_name = "");
+
+            /**
+             * declare and read in the world builder file into the parameters class
+             */
+            void parse_entries(Parameters &prm) override final;
+
+            /**
+             *  Calculates what the maximum bound water content is at a point given a pressure and
+             * temperature. This can be done for 4 different lithologies, "sediment", "gabbro",
+             * "MORB", and "peridotite"
+             */
+            double calculate_water_content(double pressure,
+                                           double temperature,
+                                           unsigned int lithology_ind) const;
+            /**
+             * Returns a value for the bound water contend based on the given position, depth in the model,
+             * gravity, and the temperature at that point.
+             */
+            double get_composition(const Point<3> &position,
+                                   const double depth,
+                                   const unsigned int composition_number,
+                                   double composition,
+                                   const double feature_min_depth,
+                                   const double feature_max_depth,
+                                   const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_planes,
+                                   // std::string lithology_str,
+                                   const AdditionalParameters &additional_parameters) const override final;
+
+
+          private:
+            // water_content composition submodule parameters
+            double min_depth;
+            double max_depth;
+            double density;
+            std::vector<unsigned int> compositions;
+            Operations operation;
+
+            double max_water_content;
+            std::string lithology_str;
+            unsigned int lithology_index;
+            // Peridotite polynomial coefficients
+            std::vector<double> LR_poly_peridotite = {-19.0609, 168.983, -630.032, 1281.84, -1543.14, 1111.88, -459.142, 95.4143, 1.97246};
+            std::vector<double> c_sat_poly_peridotite = {0.00115628, 2.42179};
+            std::vector<double> Td_poly_peridotite = {-15.4627, 94.9716, 636.603};
+
+            // Gabbro polynomial coefficients
+            std::vector<double> LR_poly_gabbro = {-1.81745, 7.67198, -10.8507, 5.09329, 8.14519};
+            std::vector<double> c_sat_poly_gabbro = {-0.0176673, 0.0893044, 1.52732};
+            std::vector<double> Td_poly_gabbro = {-1.72277, 20.5898, 637.517};
+
+            // MORB polynomial coefficients
+            std::vector<double> LR_poly_MORB = {-1.78177, 7.50871, -10.4840, 5.19725, 7.96365};
+            std::vector<double> c_sat_poly_MORB = {0.0102725, -0.115390, 0.324452, 1.41588};
+            std::vector<double> Td_poly_MORB = {-3.81280, 22.7809, 638.049};
+
+            // Sediment polynomial coefficients
+            std::vector<double> LR_poly_sediment = {-2.03283, 10.8186, -21.2119, 18.3351, -6.48711, 8.32459};
+            std::vector<double> c_sat_poly_sediment = {-0.150662, 0.301807, 1.01867};
+            std::vector<double> Td_poly_sediment = {2.83277, -24.7593, 85.9090, 524.898};
+        };
+      } // namespace Composition
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
+
+#endif

--- a/include/world_builder/features/subducting_plate_models/composition/water_content.h
+++ b/include/world_builder/features/subducting_plate_models/composition/water_content.h
@@ -69,9 +69,9 @@ namespace WorldBuilder
              * temperature. This can be done for 4 different lithologies, "sediment", "gabbro",
              * "MORB", and "peridotite"
              */
-            double calculate_water_content(double pressure,
-                                           double temperature,
-                                           unsigned int lithology_ind) const;
+            // double calculate_water_content(double pressure,
+            //                                double temperature,
+            //                                unsigned int lithology_ind) const;
             /**
              * Returns a value for the bound water contend based on the given position, depth in the model,
              * gravity, and the temperature at that point.
@@ -95,28 +95,9 @@ namespace WorldBuilder
             std::vector<unsigned int> compositions;
             Operations operation;
 
-            double max_water_content;
+            std::vector<double> max_water_contents;
             std::string lithology_str;
             unsigned int lithology_index;
-            // Peridotite polynomial coefficients
-            std::vector<double> LR_poly_peridotite = {-19.0609, 168.983, -630.032, 1281.84, -1543.14, 1111.88, -459.142, 95.4143, 1.97246};
-            std::vector<double> c_sat_poly_peridotite = {0.00115628, 2.42179};
-            std::vector<double> Td_poly_peridotite = {-15.4627, 94.9716, 636.603};
-
-            // Gabbro polynomial coefficients
-            std::vector<double> LR_poly_gabbro = {-1.81745, 7.67198, -10.8507, 5.09329, 8.14519};
-            std::vector<double> c_sat_poly_gabbro = {-0.0176673, 0.0893044, 1.52732};
-            std::vector<double> Td_poly_gabbro = {-1.72277, 20.5898, 637.517};
-
-            // MORB polynomial coefficients
-            std::vector<double> LR_poly_MORB = {-1.78177, 7.50871, -10.4840, 5.19725, 7.96365};
-            std::vector<double> c_sat_poly_MORB = {0.0102725, -0.115390, 0.324452, 1.41588};
-            std::vector<double> Td_poly_MORB = {-3.81280, 22.7809, 638.049};
-
-            // Sediment polynomial coefficients
-            std::vector<double> LR_poly_sediment = {-2.03283, 10.8186, -21.2119, 18.3351, -6.48711, 8.32459};
-            std::vector<double> c_sat_poly_sediment = {-0.150662, 0.301807, 1.01867};
-            std::vector<double> Td_poly_sediment = {2.83277, -24.7593, 85.9090, 524.898};
         };
       } // namespace Composition
     } // namespace SubductingPlateModels

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -299,7 +299,8 @@ namespace WorldBuilder
         segment(NaN::ISNAN),
         average_angle(NaN::DSNAN),
         depth_reference_surface(NaN::DSNAN),
-        closest_trench_point(Point<3>(coordinate_system))
+        closest_trench_point(Point<3>(coordinate_system)),
+        water_flux(NaN::DSNAN)
       {}
 
       /**
@@ -345,6 +346,11 @@ namespace WorldBuilder
        * The depth of the closest point on reference surface.
        */
       double depth_reference_surface;
+
+
+      std::array<double, 4> water_content;
+
+      double water_flux;
 
       /**
        * The closest point on the trench line in cartesian coordinates.
@@ -409,7 +415,9 @@ namespace WorldBuilder
                                                                     const double start_radius,
                                                                     const std::unique_ptr<CoordinateSystems::Interface> &coordinate_system,
                                                                     const bool only_positive,
-                                                                    const Objects::BezierCurve &bezier_curve);
+                                                                    const Objects::BezierCurve &bezier_curve,
+                                                                    bool compute_water = false,
+                                                                    const WorldBuilder::World *world = nullptr);
 
 
 
@@ -486,6 +494,11 @@ namespace WorldBuilder
     */
     std::vector<double>
     calculate_effective_trench_and_plate_ages(std::vector<double> ridge_parameters, double distance_along_plane);
+
+    double
+    calculate_water_content(double pressure,
+                            double temperature,
+                            unsigned int lithology_index);
 
   } // namespace Utilities
 } // namespace WorldBuilder

--- a/source/world_builder/features/fault.cc
+++ b/source/world_builder/features/fault.cc
@@ -705,6 +705,7 @@ namespace WorldBuilder
                << ", starting_depth " << starting_depth
               );
 
+      std::string lithology_str;
       const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
         WorldBuilder::Utilities::distance_point_from_curved_planes(position_in_cartesian_coordinates,
                                                                    position_in_natural_coordinates,

--- a/source/world_builder/features/subducting_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/subducting_plate_models/composition/uniform.cc
@@ -105,6 +105,8 @@ namespace WorldBuilder
                 {
                   if (compositions[i] == composition_number)
                     {
+                      // return apply_operation(operation,composition,distance_from_plane.water_content);
+                      // return apply_operation(operation,composition,fractions[i]);
                       return apply_operation(operation,composition,fractions[i]);
                     }
                 }

--- a/source/world_builder/features/subducting_plate_models/composition/water_content.cc
+++ b/source/world_builder/features/subducting_plate_models/composition/water_content.cc
@@ -1,0 +1,216 @@
+/*
+  Copyright (C) 2018 - 2021 by the authors of the World Builder code.
+
+  This file is part of the World Builder.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "world_builder/features/subducting_plate_models/composition/water_content.h"
+
+#include "world_builder/nan.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/unsigned_int.h"
+#include "world_builder/utilities.h"
+
+
+namespace WorldBuilder
+{
+
+  using namespace Utilities;
+
+  namespace Features
+  {
+    namespace SubductingPlateModels
+    {
+      namespace Composition
+      {
+        WaterContent::WaterContent(WorldBuilder::World *world_)
+          :
+          min_depth(NaN::DSNAN),
+          max_depth(NaN::DSNAN),
+          density(NaN::DSNAN)
+        {
+          this->world = world_;
+          this->name = "water content";
+        }
+
+        WaterContent::~WaterContent()
+          = default;
+
+        void
+        WaterContent::declare_entries(Parameters &prm, const std::string & /*unused*/)
+        {
+          // Document plugin and require entries if needed.
+          // Add compositions to the required parameters.
+          prm.declare_entry("", Types::Object({"compositions"}),
+                            "WaterContent compositional model. Sets constant compositional field.");
+
+          // Declare entries of this plugin
+          prm.declare_entry("min distance slab top", Types::Double(0),
+                            "todo The depth in meters from which the composition of this feature is present.");
+          prm.declare_entry("max distance slab top", Types::Double(std::numeric_limits<double>::max()),
+                            "todo The depth in meters to which the composition of this feature is present.");
+          prm.declare_entry("density", Types::Double(3000.0),
+                            "The reference density used to estimate the lithostatic pressure for calculating "
+                            "the bound water content.");
+          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+                            "A list with the labels of the composition which are present there.");
+          prm.declare_entry("lithology",  Types::String("peridotite"),
+                            "The lithology used to determine which polynomials to use for calculating the water content.");
+          prm.declare_entry("initial water content", Types::Double(5),
+                            "The value of the initial water content (in wt%) for the lithology at the trench. This is essentially the "
+                            "max value applied to this lithology.");
+          prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
+                            "Whether the value should replace any value previously defined at this location (replace) or "
+                            "add the value to the previously define value. Replacing implies that all compositions not "
+                            "explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.");
+
+        }
+
+        void
+        WaterContent::parse_entries(Parameters &prm)
+        {
+          min_depth = prm.get<double>("min distance slab top");
+          max_depth = prm.get<double>("max distance slab top");
+          density = prm.get<double>("density");
+          compositions = prm.get_vector<unsigned int>("compositions");
+          max_water_content = prm.get<double>("initial water content");
+          lithology_str = prm.get<std::string>("lithology");
+          operation = string_operations_to_enum(prm.get<std::string>("operation"));
+        }
+
+
+        double
+        WaterContent::calculate_water_content(double pressure,
+                                              double temperature,
+                                              unsigned int lithology_index) const
+        {
+          double inv_pressure = 1/pressure;
+          double ln_LR_value = 0;
+          double ln_c_sat_value = 0;
+          double Td_value = 0;
+          std::vector<double> LR_polynomial_coeffs;
+          std::vector<double> c_sat_polynomial_coeffs;
+          std::vector<double> Td_polynomial_coeffs;
+
+          if (lithology_index == 0)
+            {
+              LR_polynomial_coeffs = LR_poly_peridotite;
+              c_sat_polynomial_coeffs = c_sat_poly_peridotite;
+              Td_polynomial_coeffs = Td_poly_peridotite;
+            }
+
+          if (lithology_index == 1)
+            {
+              LR_polynomial_coeffs = LR_poly_gabbro;
+              c_sat_polynomial_coeffs = c_sat_poly_gabbro;
+              Td_polynomial_coeffs = Td_poly_gabbro;
+            }
+
+          if (lithology_index == 2)
+            {
+              LR_polynomial_coeffs = LR_poly_MORB;
+              c_sat_polynomial_coeffs = c_sat_poly_MORB;
+              Td_polynomial_coeffs = Td_poly_MORB;
+            }
+
+          if (lithology_index == 3)
+            {
+              LR_polynomial_coeffs = LR_poly_sediment;
+              c_sat_polynomial_coeffs = c_sat_poly_sediment;
+              Td_polynomial_coeffs = Td_poly_sediment;
+            }
+
+          // Calculate the c_sat value from Tian et al., 2019
+          if (lithology_index == 3)
+            {
+              for (unsigned int c_sat_index = 0; c_sat_index < c_sat_polynomial_coeffs.size(); ++c_sat_index)
+                ln_c_sat_value += c_sat_polynomial_coeffs[c_sat_index] * (std::pow(std::log10(pressure), c_sat_polynomial_coeffs.size() - 1 - c_sat_index));
+            }
+          else
+            {
+              for (unsigned int c_sat_index = 0; c_sat_index < c_sat_polynomial_coeffs.size(); ++c_sat_index)
+                ln_c_sat_value += c_sat_polynomial_coeffs[c_sat_index] * (std::pow(pressure, c_sat_polynomial_coeffs.size() - 1 - c_sat_index));
+            }
+
+          // Calculate the LR value from Tian et al., 2019
+          for (unsigned int LR_coeff_index = 0; LR_coeff_index < LR_polynomial_coeffs.size(); ++LR_coeff_index)
+            ln_LR_value += LR_polynomial_coeffs[LR_coeff_index] * (std::pow(inv_pressure, LR_polynomial_coeffs.size() - 1 - LR_coeff_index));
+
+          // Calculate the Td value from Tian et al., 2019
+          for (unsigned int Td_coeff_index = 0; Td_coeff_index < Td_polynomial_coeffs.size(); ++Td_coeff_index)
+            Td_value += Td_polynomial_coeffs[Td_coeff_index] * (std::pow(pressure, Td_polynomial_coeffs.size() - 1 - Td_coeff_index));
+
+          double partition_coeff = std::exp(ln_c_sat_value) * std::exp(std::exp(ln_LR_value) * (1/temperature - 1/Td_value));
+          return partition_coeff;
+        }
+
+
+        double
+        WaterContent::get_composition(const Point<3> &position_in_cartesian_coordinates,
+                                      const double depth,
+                                      const unsigned int composition_number,
+                                      double composition,
+                                      const double  /*feature_min_depth*/,
+                                      const double  /*feature_max_depth*/,
+                                      const WorldBuilder::Utilities::PointDistanceFromCurvedPlanes &distance_from_plane,
+                                      // std::string lithology_str,
+                                      const AdditionalParameters & /*additional_parameters*/) const
+        {
+          if (distance_from_plane.distance_from_plane <= max_depth && distance_from_plane.distance_from_plane >= min_depth)
+            {
+              unsigned int lithology_index;
+              if (lithology_str == "peridotite")
+                {
+                  lithology_index = 0;
+                }
+              if (lithology_str == "gabbro")
+                {
+                  lithology_index = 1;
+                }
+              if (lithology_str == "MORB")
+                {
+                  lithology_index = 2;
+                }
+              if (lithology_str == "sediment")
+                {
+                  lithology_index = 3;
+                }
+
+              for (unsigned int i = 0; i < compositions.size(); ++i)
+                {
+                  if (compositions[i] == composition_number)
+                    {
+                      // return apply_operation(operation,composition, partition_coefficient);
+                      return apply_operation(operation,composition,distance_from_plane.water_content[lithology_index]);
+                    }
+                }
+
+              if (operation == Operations::REPLACE)
+                {
+                  return 0.0;
+                }
+            }
+          return composition;
+        }
+        WB_REGISTER_FEATURE_SUBDUCTING_PLATE_COMPOSITION_MODEL(WaterContent, water content)
+      } // namespace Composition
+    } // namespace SubductingPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
+
+


### PR DESCRIPTION
Due to a change in the implementation, PR #661 has been closed and has been repurposed in this PR. The goal is the same, but the issue with the implementation in the previous PR is that the water content at a given point within the slab did not depend on what the water content was at points updip. This new implementation accounts for the history of a given point within the slab by iterating along a plane at a fixed depth from the slab surface from the trench to the current point, comparing the water content with each iteration to the previous iteration. The method currently used is poorly optimized, but gives the desired result. 

- [x] Implement Tian et al., 2019 parametrizations
- [x] Implement water content into linear slab segments
- [ ] Implement water content into variable dip slab segments
- [ ] Create tests