### PR TITLE
tests: fix regex for gwb-grid version test

### DIFF
--- a/tests/gwb-dat/run_gwb-dat_tests.cmake
+++ b/tests/gwb-dat/run_gwb-dat_tests.cmake
@@ -50,7 +50,7 @@ file(READ ${TEST_OUTPUT} TMP_TEST_OUTPUT)
 String(REGEX REPLACE "[:/a-zA-Z\\/0-9_\\.-]*gwb-grid[.exe]*" "(..path..)bin/gwb-grid" TEST_OUTPUT_PROCESSED "${TMP_TEST_OUTPUT}")
 String(REGEX REPLACE "  -j N                  Specify the number of threads the visualizer is allowed to use. Default: [0-9]*." "  -j N                  Specify the number of threads the visualizer is allowed to use. Default: --." TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
 String(REGEX REPLACE "GWB Version: [0-9.a-zA-Z]*" "GWB Version: -.-.-.-" TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
-String(REGEX REPLACE "git hash: [0-9.a-zA-Z-]* branch: [0-9.a-zA-Z-_]*" "git hash: (..git hash..) branch: (..git branch..)" TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
+String(REGEX REPLACE "git hash: [0-9.a-zA-Z-]* branch: [-0-9.a-zA-Z_]*" "git hash: (..git hash..) branch: (..git branch..)" TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
 String(REGEX REPLACE "Starting the world builder with ([0-9]*) threads..." "Starting the world builder with -- threads..." TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
 file(WRITE ${TEST_OUTPUT} ${TEST_OUTPUT_PROCESSED})
 


### PR DESCRIPTION
The test gwb-grid --version test fails for me if my git branch contains "-". Fix the regex by moving "-" to the beginning. Otherwise, it is treated as "Z to _", I think.