### PR TITLE
Prevent integer overflow for large grid files in gwb-grid

### DIFF
--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -1519,33 +1519,33 @@ int main(int argc, char **argv)
       if (dim == 2)
         for (size_t i = 0; i < n_cell; ++i)
           {
-            connectivity[i*pow_2_dim] = static_cast<int>(grid_connectivity[i][0]);
-            connectivity[i*pow_2_dim+1] = static_cast<int>(grid_connectivity[i][1]);
-            connectivity[i*pow_2_dim+2] = static_cast<int>(grid_connectivity[i][2]);
-            connectivity[i*pow_2_dim+3] = static_cast<int>(grid_connectivity[i][3]);
+            connectivity[i*pow_2_dim] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][0]);
+            connectivity[i*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][1]);
+            connectivity[i*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][2]);
+            connectivity[i*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][3]);
           }
       else
         for (size_t i = 0; i < n_cell; ++i)
           {
 
-            connectivity[i*pow_2_dim] = static_cast<int>(grid_connectivity[i][0]);
-            connectivity[i*pow_2_dim+1] = static_cast<int>(grid_connectivity[i][1]);
-            connectivity[i*pow_2_dim+2] = static_cast<int>(grid_connectivity[i][2]);
-            connectivity[i*pow_2_dim+3] = static_cast<int>(grid_connectivity[i][3]);
-            connectivity[i*pow_2_dim+4] = static_cast<int>(grid_connectivity[i][4]);
-            connectivity[i*pow_2_dim+5] = static_cast<int>(grid_connectivity[i][5]);
-            connectivity[i*pow_2_dim+6] = static_cast<int>(grid_connectivity[i][6]);
-            connectivity[i*pow_2_dim+7] = static_cast<int>(grid_connectivity[i][7]);
+            connectivity[i*pow_2_dim] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][0]);
+            connectivity[i*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][1]);
+            connectivity[i*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][2]);
+            connectivity[i*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][3]);
+            connectivity[i*pow_2_dim+4] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][4]);
+            connectivity[i*pow_2_dim+5] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][5]);
+            connectivity[i*pow_2_dim+6] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][6]);
+            connectivity[i*pow_2_dim+7] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][7]);
           }
       std::cout << "[5/6] Preparing to write the paraview file: stage 3 of 6, creating the offsets                              \r";
       std::cout.flush();
       std::vector<vtu11::VtkIndexType> offsets(n_cell);
       if (dim == 2)
         for (size_t i = 0; i < n_cell; ++i)
-          offsets[i] = static_cast<int>((i+1) * 4);
+          offsets[i] = static_cast<vtu11::VtkIndexType>((i+1) * 4);
       else
         for (size_t i = 0; i < n_cell; ++i)
-          offsets[i] = static_cast<int>((i+1) * 8);
+          offsets[i] = static_cast<vtu11::VtkIndexType>((i+1) * 8);
 
       std::cout << "[5/6] Preparing to write the paraview file: stage 4 of 6, creating the Data set info                              \r";
       std::cout.flush();


### PR DESCRIPTION
When visualizing a large grid file with gwb-grid I noticed a broken .vtu output even though the .wb file worked for smaller resolutions. Turns out there is a conversion to `int` in the output even though the vector type for the output is `vtu11::VtkIndexType` which resolves to `std::int64_t`. This PR fixes the problem and I can visualize the .vtu file correctly. Btw: This is not just a problem for outputs with >2 billion points, as the indices and connectivity for the output can reach this threshold much sooner, the model in question for me had 300 million points.