### PR TITLE
initialize unitialized variable

### DIFF
--- a/source/world_builder/objects/bezier_curve.cc
+++ b/source/world_builder/objects/bezier_curve.cc
@@ -378,10 +378,10 @@ namespace WorldBuilder
 
               Point<2> estimate_point = a*est*est*est+b*est*est+c*est+d;
 
-              double cos_lat_dg;
-              double sin_d_long_h_dg;
-              double sin_d_lat_h_dg;
-              double min_squared_distance_cartesian_temp_dg;
+              double cos_lat_dg = NaN::DSNAN;
+              double sin_d_long_h_dg = NaN::DSNAN;
+              double sin_d_lat_h_dg = NaN::DSNAN;
+              double min_squared_distance_cartesian_temp_dg = NaN::DSNAN;
               if (verbose == true)
                 {
                   cos_lat_dg = cos(estimate_point[1]);


### PR DESCRIPTION
When trying to compile ASPECT with World Builder on Stampede3, this uninitialized variable throws an error. Initializing it allows for successful compilation.