### PR TITLE
Fix sphinx toctree cookbooks index space.

### DIFF
--- a/cookbooks/index.md
+++ b/cookbooks/index.md
@@ -6,7 +6,7 @@ This section contains self-contained cookbooks on how to design different geodyn
 
 
 ```{toctree}
-: hidden:
+:hidden:
 
 3d_cartesian_rift/doc/README
 3d_cartesian_transform_fault/doc/README


### PR DESCRIPTION
Fixes #708 (hopefully). The current build of sphinx tester/builder on read the docs is failing due to a warning. This pull request is to fix that.