### PR TITLE
Update and fix most ubuntu testers to 24.04.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix: 
-        os: ['ubuntu-latest','macos-12','macos-11','macos-13']
+        os: ['ubuntu-22.04', 'ubuntu-24.04','macos-12','macos-11','macos-13']
         build_type: ['Release', 'Debug']
       
     runs-on: ${{ matrix.os }}
@@ -134,7 +134,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix: 
-        os: ['ubuntu-latest']
+        os: ['ubuntu-24.04']
         build_type: ['Debug']
       
     runs-on: ${{ matrix.os }}
@@ -218,7 +218,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix: 
-        os: ['ubuntu-latest','macos-12','macos-13']
+        os: ['ubuntu-24.04','macos-12','macos-13']
         build_type: ['Release']
       
     runs-on: ${{ matrix.os }}
@@ -274,7 +274,7 @@ jobs:
       run: ctest -VV -C ${{ matrix.build_type }}
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 
@@ -340,7 +340,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix: 
-        os: ['ubuntu-latest']
+        os: ['ubuntu-24.04']
         cmake_version: ['2.8.12','3.16.x', '3.20.x']
         use_mpi: ['TRUE','FALSE']
         build_type: ['Release']


### PR DESCRIPTION
Ubuntu-latest hasn't been set yet to ubuntu-24.04, but it is available. If it works, I think it makes sense to switch the default of most tester to this. I kept a specific 22.04 tester in both debug and release. 