### PR TITLE
Remove macos-11 tester from github actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix: 
-        os: ['ubuntu-latest','macos-12','macos-11','macos-13']
+        os: ['ubuntu-latest','macos-12','macos-13']
         build_type: ['Release', 'Debug']
       
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
splitting up #712, because the macos-11 runner has been removed now, so there is no point asking for it anymore.