### PR TITLE
Disable automatic MPI linkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - The tian2019 composition model now returns a mass fraction instead of a mass percentage. \[Daniel Douglas; 2024-11-12; [#767](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/767)\]
+- Only link to MPI libraries if the cmake variable USE_MPI has been set. No longer automatically link to MPI if MPI is found. \[Rene Gassmoeller; 2025-01-20; [#792](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/792)\]
+
 ### Fixed
 
 ## [1.0.0]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,16 +94,19 @@ else()
   message(STATUS "SWIG was not found, disabling python wrapper compilation.")
 endif()
 
+# Check if MPI is requested
+set(USE_MPI OFF CACHE BOOL "Whether or not to enable MPI when compiling the world builder. MPI is optional.")
 
-# Find MPI if available.
-find_package(MPI)
+if(USE_MPI)
+  # Find MPI if available.
+  find_package(MPI)
 
-if(MPI_FOUND AND ${CMAKE_VERSION} VERSION_GREATER "3.9.0" )
-  message(STATUS "MPI found.")
-  set(USE_MPI ON CACHE BOOL "Whether or not to enable MPI when compiling the world builder.")
-else()
-  message(STATUS "MPI not found or cmake version lower than 3.9.0.")
-  set(USE_MPI OFF CACHE BOOL "Whether or not to enable MPI when compiling the world builder." FORCE)
+  if(MPI_FOUND AND ${CMAKE_VERSION} VERSION_GREATER "3.9.0" )
+    message(STATUS "MPI found.")
+  else()
+    message(STATUS "MPI not found or cmake version lower than 3.9.0.")
+    set(USE_MPI OFF CACHE BOOL "Whether or not to enable MPI when compiling the world builder. MPI is optional." FORCE)
+  endif()
 endif()
 
 if(USE_MPI)

--- a/doc/sphinx/user_manual/installation/installing_prerequisites.md
+++ b/doc/sphinx/user_manual/installation/installing_prerequisites.md
@@ -4,7 +4,7 @@ Installing the prerequisites
 
 When installing the World Builder on a system, make sure CMake is installed.
 If you want a Fortran wrapper, then also make sure a Fortran compiler is installed (GFortran is the preferred option, but other Fortran compilers should work as well).
-If you want a Python interface, make sure you have Python 3 installed.
+If you want a Python interface, make sure you have Python 3 installed. Some World Builder apps can make use of MPI parallelization, although the main library generally makes no use of it. If you want to use MPI parallelization in the apps make sure that a MPI library *including its development header files* is installed on your system.
 
 There are many ways to install the prerequisites of the World Builder per operating system.
 For each system, we show some options which we know work.
@@ -17,6 +17,7 @@ If it doesn't work for your system, please let us know through GitHub issues (<h
 3. Set the environment variables using `export CC=gcc; export CXX=g++;`.
 4. (Optional) For a Fortran wrapper, run `sudo apt install gFortran`.
 5. (Optional) For a Python wrapper, run `sudo apt install swig python3-setuptools`.
+6. (Optional) For MPI parallelization, run `sudo apt install libopenmpi-dev`.
 
 :::::
 

--- a/doc/sphinx/user_manual/installation/stand_alone_install.md
+++ b/doc/sphinx/user_manual/installation/stand_alone_install.md
@@ -12,18 +12,20 @@ Stand-alone installation with all apps
 ::::{tab-set}
 :::{tab-item} For Windows with Visual Studio
 6. Run CMake by entering: `cmake MAKE_FILE_GENERATOR="Visual Studio 15 2017 Win64"..`, or the version of Visual Studio you have installed, and make sure CMake finds all the dependencies.
-7. For production runs, set build type to release by entering `-DCMAKE_BUILD_TYPE=Release`.
-8. Run make with the amount of threads you want to use (e.g., use 8 processes: `make -j 8`).
-9. If you want the Geodynamic World Builder to be installed on your system, run `cmake -build . -target install -j 8`
-10. Run the tests to make sure everything is installed correctly (`cmake -build . -target run_tests -j 8`).
+7. If you want to make use of MPI parallelism in the stand-alone apps, add `-DUSE_MPI=ON` to the cmake command of 6.
+8. For production runs, set build type to release by adding `-DCMAKE_BUILD_TYPE=Release` to the cmake command of 6.
+9. Run make with the amount of threads you want to use (e.g., use 8 processes: `make -j 8`).
+10. If you want the Geodynamic World Builder to be installed on your system, run `cmake -build . -target install -j 8`
+11. Run the tests to make sure everything is installed correctly (`cmake -build . -target run_tests -j 8`).
 :::
 
 :::{tab-item} For all other configurations
 6. Run CMake by entering: `cmake ..` and make sure CMake finds all the dependencies.
-7. For production runs, set build type to release by entering `make release`.
-8. Run make with the amount of threads you want to use (e.g., use 8 processes: `make -j 8`).
-9. If you want the Geodynamic World Builder to be installed on your system, run `sudo make install -j 4`
-10. Run the tests to make sure everything is installed correctly (`ctest`).
+7. If you want to make use of MPI parallelism in the stand-alone apps, add `-DUSE_MPI=ON` to the cmake command of 6.
+8. For production runs, set build type to release by entering `make release`.
+9. Run make with the amount of threads you want to use (e.g., use 8 processes: `make -j 8`).
+10. If you want the Geodynamic World Builder to be installed on your system, run `sudo make install -j 4`
+11. Run the tests to make sure everything is installed correctly (`ctest`).
 :::
 ::::
 


### PR DESCRIPTION
This change disables automatically looking for MPI and link to it if found. Instead now the user needs to manually set the USE_MPI cmake variable in order to make cmake look for the MPI package.

The rationale for this change is the bug (or unintended interaction) described in https://gitlab.kitware.com/cmake/cmake/-/issues/18196. If on a debian system the apt package `openmpi-bin` is installed, but `libopenmpi-dev` is not installed, then the cmake call to `find_package(MPI)` crashes with an error message that is incomprehensible to new users. We cannot test for this and write a helpful error message. And since we dont need MPI for most cases the safest option is to disable linking to MPI by default, and emphasize in the documentation that both MPI runtime and MPI headers have to be installed in order to use MPI.

Edit: I should probably also add documentation on how to enable the USE_MPI variable in the installation process. I will add this tomorrow, it is getting late.