### PR TITLE
[WIP] Add density structure to world builder

### DIFF
--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -50,6 +50,10 @@ namespace WorldBuilder
       {
         class Interface;
       }  // namespace Temperature
+      namespace Density
+      {
+        class Interface;
+      }  // namespace Density
     }  // namespace ContinentalPlateModels
 
     /**
@@ -158,6 +162,14 @@ namespace WorldBuilder
          * @see Features
          */
         std::vector<std::unique_ptr<Features::ContinentalPlateModels::Velocity::Interface> > velocity_models;
+
+        /**
+         * A vector containing all the pointers to the composition models. This vector is
+         * responsible for the features and has ownership over them. Therefore
+         * unique pointers are used.
+         * @see Features
+         */
+        std::vector<std::unique_ptr<Features::ContinentalPlateModels::Density::Interface> > density_models;
 
 
         double min_depth;

--- a/include/world_builder/features/continental_plate_models/density/interface.h
+++ b/include/world_builder/features/continental_plate_models/density/interface.h
@@ -1,0 +1,170 @@
+/*
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
+
+  This file is part of the World Builder.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_DENSITY_INTERFACE_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_DENSITY_INTERFACE_H
+
+
+#include "world_builder/parameters.h"
+#include "world_builder/objects/natural_coordinate.h"
+
+
+namespace WorldBuilder
+{
+  class World;
+  class Parameters;
+  template <unsigned int dim> class Point;
+
+  /**
+   * This class is an interface for the specific plate tectonic feature classes,
+   * such as continental plate, oceanic plate and subduction zone.
+   */
+  namespace Features
+  {
+
+    namespace ContinentalPlateModels
+    {
+      namespace Density
+      {
+        class ObjectFactory;
+
+        class Interface
+        {
+          public:
+            /**
+             * constructor
+             */
+            Interface();
+
+            /**
+             * Destructor
+             */
+            virtual
+            ~Interface();
+
+            /**
+             * declare and read in the world builder file into the parameters class
+             */
+            static
+            void declare_entries(Parameters &prm,
+                                 const std::string &parent_name,
+                                 const std::vector<std::string> &required_entries);
+
+            /**
+             * declare and read in the world builder file into the parameters class
+             */
+            virtual
+            void parse_entries(Parameters &prm, const std::vector<Point<2>> &coordinates) = 0;
+
+
+            /**
+             * takes temperature and position and returns a temperature.
+             */
+            virtual
+            double get_density(const Point<3> &position,
+                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
+                                   const double depth,
+                                   const double gravity,
+                                   double density,
+                                   const unsigned int composition_number,
+                                   const double feature_min_depth,
+                                   const double feature_max_depth) const = 0;
+            /**
+             * A function to register a new type. This is part of the automatic
+             * registration of the object factory.
+             */
+            static void registerType(const std::string &name,
+                                     void ( * /*declare_entries*/)(Parameters &, const std::string &),
+                                     ObjectFactory *factory);
+
+
+            /**
+             * A function to create a new type. This is part of the automatic
+             * registration of the object factory.
+             */
+            static std::unique_ptr<Interface> create(const std::string &name, WorldBuilder::World *world);
+
+            /**
+             * Returns the name of the plugin
+             */
+            std::string get_name() const
+            {
+              return name;
+            };
+
+          protected:
+            /**
+             * A pointer to the world class to retrieve variables.
+             */
+            WorldBuilder::World *world;
+
+            /**
+             * The name of the feature type.
+             */
+            std::string name;
+
+          private:
+            static std::map<std::string, ObjectFactory *> &get_factory_map()
+            {
+              static std::map<std::string, ObjectFactory *> factories;
+              return factories;
+            }
+
+            static std::map<std::string, void ( *)(Parameters &,const std::string &)> &get_declare_map()
+            {
+              static std::map<std::string, void ( *)(Parameters &,const std::string &)> declares;
+              return declares;
+            }
+
+        };
+
+
+        /**
+         * A class to create new objects
+         */
+        class ObjectFactory
+        {
+          public:
+            virtual std::unique_ptr<Interface> create(World *world) = 0;
+        };
+
+        /**
+         * A macro which should be in every derived cpp file to automatically
+         * register it. Because this is a library, we need some extra measures
+         * to ensure that the static variable is actually initialized.
+         */
+#define WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TEMPERATURE_MODEL(klass,name) \
+  class klass##Factory : public ObjectFactory { \
+    public: \
+      klass##Factory() \
+      { \
+        Interface::registerType(#name, klass::declare_entries, this); \
+      } \
+      std::unique_ptr<Interface> create(World *world) override final { \
+        return std::unique_ptr<Interface>(new klass(world)); \
+      } \
+  }; \
+  static klass##Factory global_##klass##Factory;
+
+      } // namespace Density
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
+
+#endif

--- a/include/world_builder/features/continental_plate_models/density/uniform.h
+++ b/include/world_builder/features/continental_plate_models/density/uniform.h
@@ -1,0 +1,101 @@
+/*
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
+
+  This file is part of the World Builder.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_DENSITY_UNIFORM_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_MODELS_DENSITY_UNIFORM_H
+
+
+#include "world_builder/features/continental_plate_models/density/interface.h"
+#include "world_builder/features/feature_utilities.h"
+#include "world_builder/objects/surface.h"
+
+
+namespace WorldBuilder
+{
+
+  namespace Features
+  {
+    using namespace FeatureUtilities;
+    namespace ContinentalPlateModels
+    {
+      namespace Density
+      {
+        /**
+         * This class represents a continental plate and can implement submodules
+         * for temperature and composition. These submodules determine what
+         * the returned temperature or composition of the temperature and composition
+         * functions of this class will be.
+         */
+        class Uniform final: public Interface
+        {
+          public:
+            /**
+             * constructor
+             */
+            Uniform(WorldBuilder::World *world);
+
+            /**
+             * Destructor
+             */
+            ~Uniform() override final;
+
+            /**
+             * declare and read in the world builder file into the parameters class
+             */
+            static
+            void declare_entries(Parameters &prm, const std::string &parent_name = "");
+
+            /**
+             * declare and read in the world builder file into the parameters class
+             */
+            void parse_entries(Parameters &prm, const std::vector<Point<2>> &coordinates) override final;
+
+
+            /**
+             * Returns a temperature based on the given position, depth in the model,
+             * gravity and current temperature.
+             */
+            double get_density(const Point<3> &position,
+                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
+                                   const double depth,
+                                   const double gravity,
+                                   double density,
+                                   const unsigned int composition_number,
+                                   const double feature_min_depth,
+                                   const double feature_max_depth) const override final;
+
+
+          private:
+            // uniform temperature submodule parameters
+            double min_depth;
+            Objects::Surface min_depth_surface;
+            double max_depth;
+            Objects::Surface max_depth_surface;
+            double density;
+            std::vector<double> densities;
+            Operations operation;
+            unsigned int n_comps;
+
+        };
+      } // namespace density
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
+
+#endif

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -205,13 +205,13 @@ namespace WorldBuilder
        * Returns the composition value based on a 2d Cartesian point, the depth in
        * the model at that point and the gravity norm at that point.
        */
-      double density(const std::array<double, 2> &point, const double depth, double density) const;
+      double density(const std::array<double, 2> &point, const double depth) const;
 
       /**
        * Returns the composition value based on a 3d Cartesian point, the depth in
        * the model at that point and the gravity norm at that point.
        */
-      double density(const std::array<double, 3> &point, const double depth, double density) const;
+      double density(const std::array<double, 3> &point, const double depth) const;
 
       /**
        * Returns the grain orientations and sizes based on a 2d Cartesian point, the depth in

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -201,6 +201,18 @@ namespace WorldBuilder
        */
       double composition(const std::array<double, 3> &point, const double depth, const unsigned int composition_number) const;
 
+            /**
+       * Returns the composition value based on a 2d Cartesian point, the depth in
+       * the model at that point and the gravity norm at that point.
+       */
+      double density(const std::array<double, 2> &point, const double depth, double density) const;
+
+      /**
+       * Returns the composition value based on a 3d Cartesian point, the depth in
+       * the model at that point and the gravity norm at that point.
+       */
+      double density(const std::array<double, 3> &point, const double depth, double density) const;
+
       /**
        * Returns the grain orientations and sizes based on a 2d Cartesian point, the depth in
        * the model at that point and the gravity norm at that point.

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -1558,6 +1558,7 @@ int main(int argc, char **argv)
         { "Temperature", vtu11::DataSetType::PointData, 1 },
         { "velocity", vtu11::DataSetType::PointData, 3 },
         { "Tag", vtu11::DataSetType::PointData, 1 },
+        { "Density", vtu11::DataSetType::PointData, 1 },
       };
       for (size_t c = 0; c < compositions; ++c)
         {
@@ -1574,18 +1575,21 @@ int main(int argc, char **argv)
 
       properties.push_back({{4,0,0}}); // tag
 
+      properties.push_back({{6,0,0}}); // density
+
       for (unsigned int c = 0; c < compositions; ++c)
         properties.push_back({{2,c,0}}); // composition c
 
 
       // compute temperature
-      std::vector<vtu11::DataSetData> data_set(4+compositions);
+      std::vector<vtu11::DataSetData> data_set(5+compositions);
       data_set[0] = grid_depth;
       data_set[1].resize(n_p);
       data_set[2].resize(n_p*3);
       data_set[3].resize(n_p);
+      data_set[4].resize(n_p);
       for (size_t c = 0; c < compositions; ++c)
-        data_set[4+c].resize(n_p);
+        data_set[5+c].resize(n_p);
 
       if (dim == 2)
         {
@@ -1598,9 +1602,10 @@ int main(int argc, char **argv)
             data_set[2][3*i+1] = output[2];
             data_set[2][3*i+2] = output[3];
             data_set[3][i] = output[3];
+            data_set[4][i] = output[5];
             for (size_t c = 0; c < compositions; ++c)
               {
-                data_set[4+c][i] = output[2+c];
+                data_set[5+c][i] = output[6+c];
               }
           });
         }
@@ -1615,9 +1620,10 @@ int main(int argc, char **argv)
             data_set[2][3*i+1] = output[2];
             data_set[2][3*i+2] = output[3];
             data_set[3][i] = output[4];
+            data_set[4][i] = output[5];
             for (size_t c = 0; c < compositions; ++c)
               {
-                data_set[4+c][i] = output[5+c];
+                data_set[5+c][i] = output[6+c];
               }
           });
         }

--- a/source/world_builder/features/continental_plate.cc
+++ b/source/world_builder/features/continental_plate.cc
@@ -24,6 +24,7 @@
 #include "world_builder/features/continental_plate_models/grains/interface.h"
 #include "world_builder/features/continental_plate_models/temperature/interface.h"
 #include "world_builder/features/continental_plate_models/velocity/interface.h"
+#include "world_builder/features/continental_plate_models/density/interface.h"
 #include "world_builder/features/feature_utilities.h"
 #include "world_builder/nan.h"
 #include "world_builder/types/array.h"
@@ -97,6 +98,9 @@ namespace WorldBuilder
       prm.declare_entry("grains models",
                         Types::PluginSystem("", Features::ContinentalPlateModels::Grains::Interface::declare_entries, {"model"}),
                         "A list of grains models.");
+      prm.declare_entry("density models",
+                        Types::PluginSystem("", Features::ContinentalPlateModels::Density::Interface::declare_entries, {"model"}),
+                        "A list of density models.");
     }
 
     void
@@ -163,6 +167,21 @@ namespace WorldBuilder
             prm.enter_subsection(std::to_string(i));
             {
               composition_models[i]->parse_entries(prm, coordinates);
+            }
+            prm.leave_subsection();
+          }
+      }
+      prm.leave_subsection();
+
+      prm.get_unique_pointers<Features::ContinentalPlateModels::Density::Interface>("density models", density_models);
+
+      prm.enter_subsection("density models");
+      {
+        for (unsigned int i = 0; i < density_models.size(); ++i)
+          {
+            prm.enter_subsection(std::to_string(i));
+            {
+              density_models[i]->parse_entries(prm, coordinates);
             }
             prm.leave_subsection();
           }
@@ -295,6 +314,23 @@ namespace WorldBuilder
                         //std::cout << "vel=" << output[entry_in_output[i_property]] << ":" << output[entry_in_output[i_property]+1] << ":" << output[entry_in_output[i_property]+2] << std::endl;
                         break;
                       }
+                      case 6: // composition
+                      {
+                          for (const auto &density_model: density_models)
+                            {
+                              output[entry_in_output[i_property]] = density_model->get_density(position_in_cartesian_coordinates,
+                                                                                                     position_in_natural_coordinates,
+                                                                                                     depth,
+                                                                                                     gravity_norm,
+                                                                                                     output[entry_in_output[i_property]],
+                                                                                                     min_depth_local,
+                                                                                                     max_depth_local);
+
+
+                            }
+
+                          break;
+                        }
                       default:
                       {
                         WBAssertThrow(false,

--- a/source/world_builder/features/continental_plate.cc
+++ b/source/world_builder/features/continental_plate.cc
@@ -249,7 +249,6 @@ namespace WorldBuilder
                           }
                         break;
                         case 2: // composition
-
                           for (const auto &composition_model: composition_models)
                             {
                               output[entry_in_output[i_property]] = composition_model->get_composition(position_in_cartesian_coordinates,
@@ -314,7 +313,7 @@ namespace WorldBuilder
                         //std::cout << "vel=" << output[entry_in_output[i_property]] << ":" << output[entry_in_output[i_property]+1] << ":" << output[entry_in_output[i_property]+2] << std::endl;
                         break;
                       }
-                      case 6: // composition
+                      case 6: // density
                       {
                           for (const auto &density_model: density_models)
                             {
@@ -323,6 +322,7 @@ namespace WorldBuilder
                                                                                                      depth,
                                                                                                      gravity_norm,
                                                                                                      output[entry_in_output[i_property]],
+                                                                                                     properties[2][1],
                                                                                                      min_depth_local,
                                                                                                      max_depth_local);
 

--- a/source/world_builder/features/continental_plate_models/density/interface.cc
+++ b/source/world_builder/features/continental_plate_models/density/interface.cc
@@ -1,0 +1,94 @@
+/*
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
+
+  This file is part of the World Builder.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "world_builder/features/continental_plate_models/density/interface.h"
+
+#include <algorithm>
+
+#include "world_builder/types/string.h"
+
+namespace WorldBuilder
+{
+  namespace Features
+  {
+    namespace ContinentalPlateModels
+    {
+      namespace Density
+      {
+        Interface::Interface()
+          = default;
+
+        Interface::~Interface ()
+          = default;
+
+        void
+        Interface::declare_entries(Parameters &prm,
+                                   const std::string &parent_name,
+                                   const std::vector<std::string> &required_entries)
+        {
+          // The type needs to be stored in a separate value, otherwise there are memory issues
+          const Types::String type = Types::String("replace", std::vector<std::string> {"replace", "add", "subtract"});
+
+          prm.declare_model_entries("density",parent_name, get_declare_map(),required_entries,
+          {
+            std::tuple<std::string,const WorldBuilder::Types::Interface &, std::string>
+            {
+              "operation", type,
+              "Whether the value should replace any value previously defined at this location (replace), "
+              "add the value to the previously define value (add) or subtract the value to the previously "
+              "define value (subtract)."
+            }
+          });
+        }
+
+
+        void
+        Interface::registerType(const std::string &name,
+                                void ( *declare_entries)(Parameters &, const std::string &),
+                                ObjectFactory *factory)
+        {
+          get_factory_map()[name] = factory;
+          get_declare_map()[name] = declare_entries;
+        }
+
+        std::unique_ptr<Interface>
+        Interface::create(const std::string &name, WorldBuilder::World *world)
+        {
+          std::string lower_case_name;
+          std::transform(name.begin(),
+                         name.end(),
+                         std::back_inserter(lower_case_name),
+                         ::tolower);;
+
+          // Have a nice assert message to check whether a plugin exists in the case
+          // of a debug compilation.
+          WBAssertThrow(get_factory_map().find(lower_case_name) != get_factory_map().end(),
+                        "Internal error: Plugin with name '" << lower_case_name << "' is not found. "
+                        "The size of factories is " << get_factory_map().size() << '.');
+
+          // Using at() because the [] will just insert values
+          // which is undesirable in this case. An exception is
+          // thrown when the name is not present.
+          return get_factory_map().at(lower_case_name)->create(world);
+        }
+      } // namespace Density
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
+

--- a/source/world_builder/features/continental_plate_models/density/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/density/uniform.cc
@@ -1,0 +1,121 @@
+/*
+  Copyright (C) 2018-2024 by the authors of the World Builder code.
+
+  This file is part of the World Builder.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as published
+   by the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "world_builder/features/continental_plate_models/density/uniform.h"
+
+
+#include "world_builder/nan.h"
+#include "world_builder/types/array.h"
+#include "world_builder/types/double.h"
+#include "world_builder/types/object.h"
+#include "world_builder/types/one_of.h"
+#include "world_builder/types/value_at_points.h"
+
+namespace WorldBuilder
+{
+
+  using namespace Utilities;
+
+  namespace Features
+  {
+    namespace ContinentalPlateModels
+    {
+      namespace Density
+      {
+        Uniform::Uniform(WorldBuilder::World *world_)
+          :
+          min_depth(NaN::DSNAN),
+          max_depth(NaN::DSNAN),
+          //density(NaN::DSNAN),
+          operation(Operations::REPLACE)
+        {
+          this->world = world_;
+          this->name = "uniform";
+        }
+
+        Uniform::~Uniform()
+          = default;
+
+        void
+        Uniform::declare_entries(Parameters &prm, const std::string & /*unused*/)
+        {
+          // Document plugin and require entries if needed.
+          // Add `temperature` to the required parameters.
+
+          // Is this object necessary?
+          //prm.declare_entry("", Types::Object({"densities"}),
+          //                  "Uniform density model. Set the density to a constant value.");
+
+          // Declare entries of this plugin
+          //prm.declare_entry("min depth", Types::OneOf(Types::Double(0),Types::Array(Types::ValueAtPoints(0., 2.))),
+          //                  "The depth in meters from which the composition of this feature is present.");
+
+          //prm.declare_entry("max depth", Types::OneOf(Types::Double(std::numeric_limits<double>::max()),Types::Array(Types::ValueAtPoints(std::numeric_limits<double>::max(), 2.))),
+          //                  "The depth in meters to which the composition of this feature is present.");
+
+          //prm.declare_entry("density", Types::Double(3300),
+          //                 "The density in kg/m3 which this feature should have");
+
+          prm.declare_entry("number of compositions", Types::UnsignedInt(1),
+                            "The density in kg/m3 which this feature should have");
+
+          prm.declare_entry("densities", Types::Array(Types::Double(3000)),
+                            "list of compositionalk densities");
+
+        }
+
+        void
+        Uniform::parse_entries(Parameters &prm, const std::vector<Point<2>> &coordinates)
+        {
+
+          //min_depth_surface = Objects::Surface(prm.get("min depth",coordinates));
+          //min_depth = min_depth_surface.minimum;
+          //max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
+          //max_depth = max_depth_surface.maximum;
+          operation = string_operations_to_enum(prm.get<std::string>("operation"));
+          //density = prm.get<double>("density");
+          densities = prm.get_vector<double>("densities");
+          n_comps = prm.get<int>("number of compositions");
+        }
+
+
+        double
+        Uniform::get_density(const Point<3> & position_in_cartesian_coordinates,
+                                 const Objects::NaturalCoordinate &position_in_natural_coordinates,
+                                 const double depth,
+                                 const double  /*gravity*/,
+                                 double density_,
+                                 const unsigned int composition_number,
+                                 const double /*feature_min_depth*/,
+                                 const double /*feature_max_depth*/) const
+        {
+          std::vector<double> compositions(n_comps, 0.0);
+          double density = 0.;
+          for (unsigned int i = 0; i < n_comps; ++i)
+              density += world->properties(position_in_cartesian_coordinates.get_array(), depth, {{{2, i, 0}}})[0] * densities[i];
+
+          return apply_operation(operation,density_,density);
+        }
+
+        WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TEMPERATURE_MODEL(Uniform, uniform)
+      } // namespace Temperature
+    } // namespace ContinentalPlateModels
+  } // namespace Features
+} // namespace WorldBuilder
+

--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -22,6 +22,7 @@
 #include "world_builder/features/continental_plate_models/velocity/interface.h"
 #include "world_builder/features/continental_plate_models/grains/interface.h"
 #include "world_builder/features/continental_plate_models/temperature/interface.h"
+#include "world_builder/features/continental_plate_models/density/interface.h"
 #include "world_builder/features/fault.h"
 #include "world_builder/features/mantle_layer_models/composition/interface.h"
 #include "world_builder/features/mantle_layer_models/grains/interface.h"
@@ -2131,6 +2132,14 @@ namespace WorldBuilder
   template bool
   Parameters::get_unique_pointers<Features::ContinentalPlateModels::Velocity::Interface>(const std::string &name,
       std::vector<std::unique_ptr<Features::ContinentalPlateModels::Velocity::Interface> > &vector);
+
+  /**
+  * Todo: Returns a vector of pointers to the Point<3> Type based on the provided name.
+  * Note that the variable with this name has to be loaded before this function is called.
+  */
+  template bool
+  Parameters::get_unique_pointers<Features::ContinentalPlateModels::Density::Interface>(const std::string &name,
+      std::vector<std::unique_ptr<Features::ContinentalPlateModels::Density::Interface> > &vector);
 
 
   /**

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -552,16 +552,14 @@ namespace WorldBuilder
 
   double
   World::density(const std::array<double,2> &point,
-                     const double depth,
-                     double density) const
+                     const double depth) const
   {
     return properties(point, depth, {{{6,0,0}}})[0];
   }
 
   double
   World::density(const std::array<double,3> &point,
-                     const double depth,
-                     double density) const
+                     const double depth) const
   {
     return properties(point, depth, {{{6,0,0}}})[0];
   }

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -299,6 +299,11 @@ namespace WorldBuilder
               n_output_entries += 3;
               break;
             }
+            case 6: // density (1 entries)
+            {
+              n_output_entries += 1;
+              break;
+            }
             default:
               WBAssertThrow(false,
                             "Internal error: Unimplemented property provided. " <<
@@ -383,6 +388,11 @@ namespace WorldBuilder
               results[counter+1] = results[counter+2];
               results[counter+2] = 0;
               counter += 3;
+              break;
+            }
+            case 6:   // density
+            {
+              counter += 1;
               break;
             }
             default:
@@ -471,6 +481,13 @@ namespace WorldBuilder
               properties_local.emplace_back(properties[i_property]);
               break;
             }
+            case 6: // density
+            {
+              entry_in_output.emplace_back(output.size());
+              output.emplace_back(0.);
+              properties_local.emplace_back(properties[i_property]);
+              break;
+            }
             default:
               WBAssertThrow(false,
                             "Internal error: Unimplemented property provided. " <<
@@ -530,6 +547,23 @@ namespace WorldBuilder
                      const unsigned int composition_number) const
   {
     return properties(point, depth, {{{2,composition_number,0}}})[0];
+  }
+
+
+  double
+  World::density(const std::array<double,2> &point,
+                     const double depth,
+                     double density) const
+  {
+    return properties(point, depth, {{{6,0,0}}})[0];
+  }
+
+  double
+  World::density(const std::array<double,3> &point,
+                     const double depth,
+                     double density) const
+  {
+    return properties(point, depth, {{{6,0,0}}})[0];
   }
 
 


### PR DESCRIPTION
Here is the initial try at this with an added continental plate model. So far, in the uniform model you give the number of compositions and then a list of densities for each composition.

For the calculation, I removed the max min depth, as it doesn't seem necessary when the density only depends on the composition. But maybe that will make things easier later on with multiple features? 