### PR TITLE
remove unavailable mac 12 tester.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix: 
-        os: ['ubuntu-22.04', 'ubuntu-24.04','macos-12','macos-13']
+        os: ['ubuntu-22.04', 'ubuntu-24.04','macos-13']
         build_type: ['Release', 'Debug']
       
     runs-on: ${{ matrix.os }}
@@ -218,7 +218,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix: 
-        os: ['ubuntu-24.04','macos-12','macos-13']
+        os: ['ubuntu-24.04','macos-13']
         build_type: ['Release']
       
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The mac-12 tester is not available anymore, so just remove it.