### PR TITLE
refactor to have a geometry type for each feature.

### DIFF
--- a/doc/world_builder_declarations.schema.json
+++ b/doc/world_builder_declarations.schema.json
@@ -170,7 +170,7 @@
             "items": {
                 "defaultSnippets": [
                     {
-                        "label": "add a 'continental plate'",
+                        "label": "add a 'continental plate coordinates'",
                         "body": {
                             "model": "continental plate",
                             "name": "${1:My Plate}",
@@ -178,7 +178,7 @@
                         }
                     },
                     {
-                        "label": "add a 'fault'",
+                        "label": "add a 'fault coordinates'",
                         "body": {
                             "model": "fault",
                             "name": "${1:My Fault}",
@@ -188,7 +188,7 @@
                         }
                     },
                     {
-                        "label": "add a 'mantle layer'",
+                        "label": "add a 'mantle layer coordinates'",
                         "body": {
                             "model": "mantle layer",
                             "name": "${1:My Mantle Layer}",
@@ -198,7 +198,7 @@
                         }
                     },
                     {
-                        "label": "add a 'oceanic plate'",
+                        "label": "add a 'oceanic plate coordinates'",
                         "body": {
                             "model": "oceanic plate",
                             "name": "${1:My Oceanic Plate}",
@@ -208,17 +208,17 @@
                         }
                     },
                     {
-                        "label": "add a 'plume'",
+                        "label": "add a 'plume coordinates'",
                         "body": {
                             "model": "plume",
-                            "name": "${1:My Plume}",
+                            "name": "${1:My PlumeCoordinates}",
                             "coordinates": [],
                             "temperature models": [],
                             "composition models": []
                         }
                     },
                     {
-                        "label": "add a 'subducting plate'",
+                        "label": "add a 'subducting plate coordinates'",
                         "body": {
                             "model": "subducting plate",
                             "name": "${1:My Subducting Plate}",
@@ -243,6 +243,14 @@
                                 "description": "The model name of the feature determining its type.",
                                 "enum": [
                                     "continental plate"
+                                ]
+                            },
+                            "geometry type": {
+                                "default value": "coordinates",
+                                "type": "string",
+                                "description": "The model geometry type",
+                                "enum": [
+                                    "coordinates"
                                 ]
                             },
                             "name": {
@@ -1785,6 +1793,15 @@
                                 "description": "The model name of the feature determining its type.",
                                 "enum": [
                                     "fault"
+                                ]
+                            },
+                            "geometry type": {
+                                "default value": "coordinates",
+                                "type": "string",
+                                "description": "The model geometry type",
+                                "enum": [
+                                    "coordinates",
+                                    "coordinates"
                                 ]
                             },
                             "name": {
@@ -4713,6 +4730,15 @@
                                     "mantle layer"
                                 ]
                             },
+                            "geometry type": {
+                                "default value": "coordinates",
+                                "type": "string",
+                                "description": "The model geometry type",
+                                "enum": [
+                                    "coordinates",
+                                    "coordinates"
+                                ]
+                            },
                             "name": {
                                 "default value": "",
                                 "type": "string",
@@ -6096,6 +6122,15 @@
                                 "description": "The model name of the feature determining its type.",
                                 "enum": [
                                     "oceanic plate"
+                                ]
+                            },
+                            "geometry type": {
+                                "default value": "coordinates",
+                                "type": "string",
+                                "description": "The model geometry type",
+                                "enum": [
+                                    "coordinates",
+                                    "coordinates"
                                 ]
                             },
                             "name": {
@@ -8151,7 +8186,7 @@
                     },
                     {
                         "type": "object",
-                        "description": "Plume object. Requires properties `model` and `coordinates`.",
+                        "description": "PlumeCoordinates object. Requires properties `model` and `coordinates`.",
                         "additionalProperties": false,
                         "required": [
                             "model"
@@ -8163,6 +8198,15 @@
                                 "description": "The model name of the feature determining its type.",
                                 "enum": [
                                     "plume"
+                                ]
+                            },
+                            "geometry type": {
+                                "default value": "coordinates",
+                                "type": "string",
+                                "description": "The model geometry type",
+                                "enum": [
+                                    "coordinates",
+                                    "coordinates"
                                 ]
                             },
                             "name": {
@@ -8768,6 +8812,15 @@
                                 "description": "The model name of the feature determining its type.",
                                 "enum": [
                                     "subducting plate"
+                                ]
+                            },
+                            "geometry type": {
+                                "default value": "coordinates",
+                                "type": "string",
+                                "description": "The model geometry type",
+                                "enum": [
+                                    "coordinates",
+                                    "coordinates"
                                 ]
                             },
                             "name": {

--- a/doc/world_builder_declarations_closed.md
+++ b/doc/world_builder_declarations_closed.md
@@ -253,6 +253,15 @@
 - **enum**:[continental plate]
 ::::::::::::::::::::
 
+::::::::::::::::::::{dropdown} /features/items/oneOf/1/geometry type
+:name: closed_features_items_oneOf_1_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates]
+::::::::::::::::::::
+
 ::::::::::::::::::::{dropdown} /features/items/oneOf/1/name
 :name: closed_features_items_oneOf_1_name
 
@@ -2629,6 +2638,15 @@
 - **type**:string
 - **description**:The model name of the feature determining its type.
 - **enum**:[fault]
+::::::::::::::::::::
+
+::::::::::::::::::::{dropdown} /features/items/oneOf/2/geometry type
+:name: closed_features_items_oneOf_2_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
 ::::::::::::::::::::
 
 ::::::::::::::::::::{dropdown} /features/items/oneOf/2/name
@@ -6660,6 +6678,15 @@
 - **enum**:[mantle layer]
 ::::::::::::::::::::
 
+::::::::::::::::::::{dropdown} /features/items/oneOf/3/geometry type
+:name: closed_features_items_oneOf_3_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
+::::::::::::::::::::
+
 ::::::::::::::::::::{dropdown} /features/items/oneOf/3/name
 :name: closed_features_items_oneOf_3_name
 
@@ -8800,6 +8827,15 @@
 - **type**:string
 - **description**:The model name of the feature determining its type.
 - **enum**:[oceanic plate]
+::::::::::::::::::::
+
+::::::::::::::::::::{dropdown} /features/items/oneOf/4/geometry type
+:name: closed_features_items_oneOf_4_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
 ::::::::::::::::::::
 
 ::::::::::::::::::::{dropdown} /features/items/oneOf/4/name
@@ -11987,7 +12023,7 @@
 :name: closed_features_items_oneOf_5
 
 - **type**:object
-- **description**:Plume object. Requires properties `model` and `coordinates`.
+- **description**:PlumeCoordinates object. Requires properties `model` and `coordinates`.
 - **additionalProperties**:false
 - **required**:[model]
 
@@ -11998,6 +12034,15 @@
 - **type**:string
 - **description**:The model name of the feature determining its type.
 - **enum**:[plume]
+::::::::::::::::::::
+
+::::::::::::::::::::{dropdown} /features/items/oneOf/5/geometry type
+:name: closed_features_items_oneOf_5_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
 ::::::::::::::::::::
 
 ::::::::::::::::::::{dropdown} /features/items/oneOf/5/name
@@ -12840,6 +12885,15 @@
 - **type**:string
 - **description**:The model name of the feature determining its type.
 - **enum**:[subducting plate]
+::::::::::::::::::::
+
+::::::::::::::::::::{dropdown} /features/items/oneOf/6/geometry type
+:name: closed_features_items_oneOf_6_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
 ::::::::::::::::::::
 
 ::::::::::::::::::::{dropdown} /features/items/oneOf/6/name

--- a/doc/world_builder_declarations_open.md
+++ b/doc/world_builder_declarations_open.md
@@ -284,6 +284,16 @@
 - **enum**:[continental plate]
 ::::::::::::::::::::
 
+::::::::::::::::::::{dropdown} /features/items/oneOf/1/geometry type
+:open:
+:name: open_features_items_oneOf_1_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates]
+::::::::::::::::::::
+
 ::::::::::::::::::::{dropdown} /features/items/oneOf/1/name
 :open:
 :name: open_features_items_oneOf_1_name
@@ -2977,6 +2987,16 @@
 - **type**:string
 - **description**:The model name of the feature determining its type.
 - **enum**:[fault]
+::::::::::::::::::::
+
+::::::::::::::::::::{dropdown} /features/items/oneOf/2/geometry type
+:open:
+:name: open_features_items_oneOf_2_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
 ::::::::::::::::::::
 
 ::::::::::::::::::::{dropdown} /features/items/oneOf/2/name
@@ -7473,6 +7493,16 @@
 - **enum**:[mantle layer]
 ::::::::::::::::::::
 
+::::::::::::::::::::{dropdown} /features/items/oneOf/3/geometry type
+:open:
+:name: open_features_items_oneOf_3_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
+::::::::::::::::::::
+
 ::::::::::::::::::::{dropdown} /features/items/oneOf/3/name
 :open:
 :name: open_features_items_oneOf_3_name
@@ -9899,6 +9929,16 @@
 - **type**:string
 - **description**:The model name of the feature determining its type.
 - **enum**:[oceanic plate]
+::::::::::::::::::::
+
+::::::::::::::::::::{dropdown} /features/items/oneOf/4/geometry type
+:open:
+:name: open_features_items_oneOf_4_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
 ::::::::::::::::::::
 
 ::::::::::::::::::::{dropdown} /features/items/oneOf/4/name
@@ -13514,7 +13554,7 @@
 :name: open_features_items_oneOf_5
 
 - **type**:object
-- **description**:Plume object. Requires properties `model` and `coordinates`.
+- **description**:PlumeCoordinates object. Requires properties `model` and `coordinates`.
 - **additionalProperties**:false
 - **required**:[model]
 
@@ -13526,6 +13566,16 @@
 - **type**:string
 - **description**:The model name of the feature determining its type.
 - **enum**:[plume]
+::::::::::::::::::::
+
+::::::::::::::::::::{dropdown} /features/items/oneOf/5/geometry type
+:open:
+:name: open_features_items_oneOf_5_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
 ::::::::::::::::::::
 
 ::::::::::::::::::::{dropdown} /features/items/oneOf/5/name
@@ -14465,6 +14515,16 @@
 - **type**:string
 - **description**:The model name of the feature determining its type.
 - **enum**:[subducting plate]
+::::::::::::::::::::
+
+::::::::::::::::::::{dropdown} /features/items/oneOf/6/geometry type
+:open:
+:name: open_features_items_oneOf_6_geometry-type
+
+- **default value**:coordinates
+- **type**:string
+- **description**:The model geometry type
+- **enum**:[coordinates, coordinates]
 ::::::::::::::::::::
 
 ::::::::::::::::::::{dropdown} /features/items/oneOf/6/name

--- a/include/world_builder/features/continental_plate_coordinates.h
+++ b/include/world_builder/features/continental_plate_coordinates.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_H
-#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_H
+#ifndef WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_COORDINATES_H
+#define WORLD_BUILDER_FEATURES_CONTINENTAL_PLATE_COORDINATES_H
 
 
 #include "world_builder/features/interface.h"
@@ -58,18 +58,18 @@ namespace WorldBuilder
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class ContinentalPlate final: public Interface
+    class ContinentalPlateCoordinates final: public Interface
     {
       public:
         /**
          * constructor
          */
-        ContinentalPlate(WorldBuilder::World *world);
+        ContinentalPlateCoordinates(WorldBuilder::World *world);
 
         /**
          * Destructor
          */
-        ~ContinentalPlate() override final;
+        ~ContinentalPlateCoordinates() override final;
 
         /**
          * declare and read in the world builder file into the parameters class

--- a/include/world_builder/features/fault_coordinates.h
+++ b/include/world_builder/features/fault_coordinates.h
@@ -17,14 +17,14 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_H
-#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_H
+#ifndef WORLD_BUILDER_FEATURES_FAULT_COORDINATES_H
+#define WORLD_BUILDER_FEATURES_FAULT_COORDINATES_H
 
 
-#include "world_builder/features/subducting_plate_models/composition/interface.h"
-#include "world_builder/features/subducting_plate_models/grains/interface.h"
-#include "world_builder/features/subducting_plate_models/temperature/interface.h"
-#include "world_builder/features/subducting_plate_models/velocity/interface.h"
+#include "world_builder/features/fault_models/composition/interface.h"
+#include "world_builder/features/fault_models/grains/interface.h"
+#include "world_builder/features/fault_models/temperature/interface.h"
+#include "world_builder/features/fault_models/velocity/interface.h"
 #include "world_builder/objects/segment.h"
 #include "world_builder/bounding_box.h"
 #include "world_builder/objects/distance_from_surface.h"
@@ -37,8 +37,7 @@ namespace WorldBuilder
 
   namespace Features
   {
-    using namespace FeatureUtilities;
-    namespace SubductingPlateModels
+    namespace FaultModels
     {
       namespace Composition
       {
@@ -55,27 +54,27 @@ namespace WorldBuilder
       namespace Velocity
       {
         class Interface;
-      }  // namespace Velocity
-    }  // namespace SubductingPlateModels
+      }  // namespace Temperature
+    }  // namespace FaultModels
 
     /**
-     * This class represents a subducting plate and can implement submodules
+     * This class represents a fault and can implement submodules
      * for temperature and composition. These submodules determine what
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class SubductingPlate final: public Interface
+    class FaultCoordinates final: public Interface
     {
       public:
         /**
          * constructor
          */
-        SubductingPlate(WorldBuilder::World *world);
+        FaultCoordinates(WorldBuilder::World *world);
 
         /**
          * Destructor
          */
-        ~SubductingPlate() override final;
+        ~FaultCoordinates() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -98,7 +97,7 @@ namespace WorldBuilder
 
 
         /**
-         * Returns the bounding points for a BoundingBox object using two extreme points in all the surface
+         * Computes the bounding points for a BoundingBox object using two extreme points in all the surface
          * coordinates and an additional buffer zone that accounts for the fault thickness and length. The first and second
          * points correspond to the lower left and the upper right corners of the bounding box, respectively (see the
          * documentation in include/bounding_box.h).
@@ -143,7 +142,7 @@ namespace WorldBuilder
                    std::vector<double> &output) const override final;
 
         /**
-        * Returns a PlaneDistances object that has the distance from and along a subducting plate plane,
+        * Returns a PlaneDistances object that has the distance from and along a fault plane,
         * calculated from the coordinates and the depth of the point.
         */
         Objects::PlaneDistances
@@ -151,50 +150,49 @@ namespace WorldBuilder
                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
                                   const double depth) const override;
 
-
       private:
-        std::vector<std::shared_ptr<Features::SubductingPlateModels::Temperature::Interface> > default_temperature_models;
-        std::vector<std::shared_ptr<Features::SubductingPlateModels::Composition::Interface>  > default_composition_models;
-        std::vector<std::shared_ptr<Features::SubductingPlateModels::Grains::Interface>  > default_grains_models;
-        std::vector<std::shared_ptr<Features::SubductingPlateModels::Velocity::Interface>  > default_velocity_models;
+        std::vector<std::shared_ptr<Features::FaultModels::Temperature::Interface> > default_temperature_models;
+        std::vector<std::shared_ptr<Features::FaultModels::Composition::Interface>  > default_composition_models;
+        std::vector<std::shared_ptr<Features::FaultModels::Grains::Interface>  > default_grains_models;
+        std::vector<std::shared_ptr<Features::FaultModels::Velocity::Interface>  > default_velocity_models;
 
-        std::vector<Objects::Segment<Features::SubductingPlateModels::Temperature::Interface,
-            Features::SubductingPlateModels::Composition::Interface,
-            Features::SubductingPlateModels::Grains::Interface,
-            Features::SubductingPlateModels::Velocity::Interface> > default_segment_vector;
+        std::vector<Objects::Segment<Features::FaultModels::Temperature::Interface,
+            Features::FaultModels::Composition::Interface,
+            Features::FaultModels::Grains::Interface,
+            Features::FaultModels::Velocity::Interface> > default_segment_vector;
 
-        std::vector< std::vector<Objects::Segment<Features::SubductingPlateModels::Temperature::Interface,
-            Features::SubductingPlateModels::Composition::Interface,
-            Features::SubductingPlateModels::Grains::Interface,
-            Features::SubductingPlateModels::Velocity::Interface> > > sections_segment_vector;
+        std::vector< std::vector<Objects::Segment<Features::FaultModels::Temperature::Interface,
+            Features::FaultModels::Composition::Interface,
+            Features::FaultModels::Grains::Interface,
+            Features::FaultModels::Velocity::Interface> > > sections_segment_vector;
 
         // This vector stores segments to this coordinate/section.
         //First used (raw) pointers to the segment relevant to this coordinate/section,
         // but I do not trust it won't fail when memory is moved. So storing the all the data now.
-        std::vector<std::vector<Objects::Segment<Features::SubductingPlateModels::Temperature::Interface,
-            Features::SubductingPlateModels::Composition::Interface,
-            Features::SubductingPlateModels::Grains::Interface,
-            Features::SubductingPlateModels::Velocity::Interface> > > segment_vector;
+        std::vector<std::vector<Objects::Segment<Features::FaultModels::Temperature::Interface,
+            Features::FaultModels::Composition::Interface,
+            Features::FaultModels::Grains::Interface,
+            Features::FaultModels::Velocity::Interface> > > segment_vector;
 
         // todo: the memory of this can be greatly improved by
         // or using a plugin system for the submodules, or
         // putting the variables in a union. Although the memory
         // used by this program is in real cases expected to be
-        // Insignificant compared to what a calling program may
+        // insignificant compared to what a calling program may
         // use, a smaller amount of memory used in here, could
         // theoretically speed up the computation, because more
         // relevant data could be stored in the cache. But this
         // not a urgent problem, and would require testing.
 
         /**
-         * This variable stores the depth at which the subducting
-         * plate starts. It makes this depth effectively the surface
-         * of the model for the slab.
+         * This variable stores the depth at which the fault
+         * starts. It makes this depth effectively the surface
+         * of the model for the fault.
          */
         double starting_depth;
 
         /**
-         * The depth which below the subducting plate may no longer
+         * The depth which below the fault may no longer
          * be present. This can not only help setting up models with
          * less effort, but can also improve performance, because
          * the algorithm doesn't have to search in locations below
@@ -203,7 +201,7 @@ namespace WorldBuilder
         double maximum_depth;
 
         /**
-         * Stores the bounding points for a BoundingBox object using two extreme points in all the surface
+         * Computee bounding points for a BoundingBox object using two extreme points in all the surface
          * coordinates and an additional buffer zone that accounts for the fault thickness and length. The first and second
          * points correspond to the lower left and the upper right corners of the bounding box, respectively (see the
          * documentation in include/bounding_box.h).
@@ -213,17 +211,17 @@ namespace WorldBuilder
         BoundingBox<2> surface_bounding_box;
 
         /**
-         * A point on the surface to which the subducting plates subduct.
+         * A point on the surface to which the fault dips.
          */
-        Point<2> reference_point;
+        WorldBuilder::Point<2> reference_point;
 
-        std::vector<std::vector<double> > slab_segment_lengths;
-        std::vector<std::vector<Point<2> > > slab_segment_thickness;
-        std::vector<std::vector<Point<2> > > slab_segment_top_truncation;
-        std::vector<std::vector<Point<2> > > slab_segment_angles;
-        std::vector<double> total_slab_length;
-        double maximum_total_slab_length;
-        double maximum_slab_thickness;
+        std::vector<std::vector<double> > fault_segment_lengths;
+        std::vector<std::vector<Point<2> > > fault_segment_thickness;
+        std::vector<std::vector<Point<2> > > fault_segment_top_truncation;
+        std::vector<std::vector<Point<2> > > fault_segment_angles;
+        std::vector<double> total_fault_length;
+        double maximum_total_fault_length;
+        double maximum_fault_thickness;
 
         double min_along_x;
         double max_along_x;
@@ -231,7 +229,8 @@ namespace WorldBuilder
         double max_along_y;
         double min_lat_cos_inv;
         double max_lat_cos_inv;
-        double buffer_around_slab_cartesian;
+        double buffer_around_fault_cartesian;
+
     };
   } // namespace Features
 } // namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_coordinates.h
+++ b/include/world_builder/features/mantle_layer_coordinates.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef WORLD_BUILDER_FEATURES_PLUME_H
-#define WORLD_BUILDER_FEATURES_PLUME_H
+#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_COORDINATES_H
+#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_COORDINATES_H
 
 
 #include "world_builder/features/interface.h"
@@ -32,7 +32,7 @@ namespace WorldBuilder
 
   namespace Features
   {
-    namespace PlumeModels
+    namespace MantleLayerModels
     {
       namespace Composition
       {
@@ -50,26 +50,26 @@ namespace WorldBuilder
       {
         class Interface;
       }  // namespace Velocity
-    }  // namespace PlumeModels
+    }  // namespace MantleLayerModels
 
     /**
-     * This class represents a plume and can implement submodules
+     * This class represents a mantle layer and can implement submodules
      * for temperature and composition. These submodules determine what
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class Plume final: public Interface
+    class MantleLayerCoordinates final: public Interface
     {
       public:
         /**
          * constructor
          */
-        Plume(WorldBuilder::World *world);
+        MantleLayerCoordinates(WorldBuilder::World *world);
 
         /**
          * Destructor
          */
-        ~Plume() override final;
+        ~MantleLayerCoordinates() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -106,7 +106,7 @@ namespace WorldBuilder
          * Composition is identified by 2. This produces one
          * value in the output. The second entry  identifies the composition number and the third
          * number is not used. So a commposition query asking about composition 1 looks like this:
-         * {2,1,0}. A composition query produces one entry in the output vector.
+         * {2,1,0}. A composition query prodoces one entry in the output vector.
          *
          * Grains are identified by 2. The second entry is the grain composition number and the third
          * entry is the number of grains. A query about the grains, where it asks about composition 1
@@ -133,7 +133,7 @@ namespace WorldBuilder
          * unique pointers are used.
          * @see Features
          */
-        std::vector<std::unique_ptr<Features::PlumeModels::Temperature::Interface> > temperature_models;
+        std::vector<std::unique_ptr<Features::MantleLayerModels::Temperature::Interface> > temperature_models;
 
         /**
          * A vector containing all the pointers to the composition models. This vector is
@@ -141,7 +141,7 @@ namespace WorldBuilder
          * unique pointers are used.
          * @see Features
          */
-        std::vector<std::unique_ptr<Features::PlumeModels::Composition::Interface> > composition_models;
+        std::vector<std::unique_ptr<Features::MantleLayerModels::Composition::Interface> > composition_models;
 
         /**
          * A vector containing all the pointers to the grains models. This vector is
@@ -149,7 +149,7 @@ namespace WorldBuilder
          * unique pointers are used.
          * @see Features
          */
-        std::vector<std::unique_ptr<Features::PlumeModels::Velocity::Interface> > velocity_models;
+        std::vector<std::unique_ptr<Features::MantleLayerModels::Grains::Interface> > grains_models;
 
         /**
          * A vector containing all the pointers to the grains models. This vector is
@@ -157,16 +157,13 @@ namespace WorldBuilder
          * unique pointers are used.
          * @see Features
          */
-        std::vector<std::unique_ptr<Features::PlumeModels::Grains::Interface> > grains_models;
-
+        std::vector<std::unique_ptr<Features::MantleLayerModels::Velocity::Interface> > velocity_models;
 
         double min_depth;
+        Objects::Surface min_depth_surface;
         double max_depth;
+        Objects::Surface max_depth_surface;
 
-        std::vector<double> depths;
-        std::vector<double> semi_major_axis_lengths;
-        std::vector<double> eccentricities;
-        std::vector<double> rotation_angles;
     };
 
 

--- a/include/world_builder/features/oceanic_plate_coordinates.h
+++ b/include/world_builder/features/oceanic_plate_coordinates.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_H
-#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_H
+#ifndef WORLD_BUILDER_FEATURES_OCEANIC_PLATE_COORDINATES_H
+#define WORLD_BUILDER_FEATURES_OCEANIC_PLATE_COORDINATES_H
 
 
 #include "world_builder/features/interface.h"
@@ -58,18 +58,18 @@ namespace WorldBuilder
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class OceanicPlate final: public Interface
+    class OceanicPlateCoordinates final: public Interface
     {
       public:
         /**
          * constructor
          */
-        OceanicPlate(WorldBuilder::World *world);
+        OceanicPlateCoordinates(WorldBuilder::World *world);
 
         /**
          * Destructor
          */
-        ~OceanicPlate() override final;
+        ~OceanicPlateCoordinates() override final;
 
         /**
          * declare and read in the world builder file into the parameters class

--- a/include/world_builder/features/plume_coordinates.h
+++ b/include/world_builder/features/plume_coordinates.h
@@ -17,8 +17,8 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef WORLD_BUILDER_FEATURES_MANTLE_LAYER_H
-#define WORLD_BUILDER_FEATURES_MANTLE_LAYER_H
+#ifndef WORLD_BUILDER_FEATURES_PLUME_COORDINATES_H
+#define WORLD_BUILDER_FEATURES_PLUME_COORDINATES_H
 
 
 #include "world_builder/features/interface.h"
@@ -32,7 +32,7 @@ namespace WorldBuilder
 
   namespace Features
   {
-    namespace MantleLayerModels
+    namespace PlumeModels
     {
       namespace Composition
       {
@@ -50,26 +50,26 @@ namespace WorldBuilder
       {
         class Interface;
       }  // namespace Velocity
-    }  // namespace MantleLayerModels
+    }  // namespace PlumeModels
 
     /**
-     * This class represents a mantle layer and can implement submodules
+     * This class represents a plume and can implement submodules
      * for temperature and composition. These submodules determine what
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class MantleLayer final: public Interface
+    class PlumeCoordinates final: public Interface
     {
       public:
         /**
          * constructor
          */
-        MantleLayer(WorldBuilder::World *world);
+        PlumeCoordinates(WorldBuilder::World *world);
 
         /**
          * Destructor
          */
-        ~MantleLayer() override final;
+        ~PlumeCoordinates() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -106,7 +106,7 @@ namespace WorldBuilder
          * Composition is identified by 2. This produces one
          * value in the output. The second entry  identifies the composition number and the third
          * number is not used. So a commposition query asking about composition 1 looks like this:
-         * {2,1,0}. A composition query prodoces one entry in the output vector.
+         * {2,1,0}. A composition query produces one entry in the output vector.
          *
          * Grains are identified by 2. The second entry is the grain composition number and the third
          * entry is the number of grains. A query about the grains, where it asks about composition 1
@@ -133,7 +133,7 @@ namespace WorldBuilder
          * unique pointers are used.
          * @see Features
          */
-        std::vector<std::unique_ptr<Features::MantleLayerModels::Temperature::Interface> > temperature_models;
+        std::vector<std::unique_ptr<Features::PlumeModels::Temperature::Interface> > temperature_models;
 
         /**
          * A vector containing all the pointers to the composition models. This vector is
@@ -141,7 +141,7 @@ namespace WorldBuilder
          * unique pointers are used.
          * @see Features
          */
-        std::vector<std::unique_ptr<Features::MantleLayerModels::Composition::Interface> > composition_models;
+        std::vector<std::unique_ptr<Features::PlumeModels::Composition::Interface> > composition_models;
 
         /**
          * A vector containing all the pointers to the grains models. This vector is
@@ -149,7 +149,7 @@ namespace WorldBuilder
          * unique pointers are used.
          * @see Features
          */
-        std::vector<std::unique_ptr<Features::MantleLayerModels::Grains::Interface> > grains_models;
+        std::vector<std::unique_ptr<Features::PlumeModels::Velocity::Interface> > velocity_models;
 
         /**
          * A vector containing all the pointers to the grains models. This vector is
@@ -157,13 +157,16 @@ namespace WorldBuilder
          * unique pointers are used.
          * @see Features
          */
-        std::vector<std::unique_ptr<Features::MantleLayerModels::Velocity::Interface> > velocity_models;
+        std::vector<std::unique_ptr<Features::PlumeModels::Grains::Interface> > grains_models;
+
 
         double min_depth;
-        Objects::Surface min_depth_surface;
         double max_depth;
-        Objects::Surface max_depth_surface;
 
+        std::vector<double> depths;
+        std::vector<double> semi_major_axis_lengths;
+        std::vector<double> eccentricities;
+        std::vector<double> rotation_angles;
     };
 
 

--- a/include/world_builder/features/subducting_plate_coordinates.h
+++ b/include/world_builder/features/subducting_plate_coordinates.h
@@ -17,14 +17,14 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef WORLD_BUILDER_FEATURES_FAULT_H
-#define WORLD_BUILDER_FEATURES_FAULT_H
+#ifndef WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_COORDINATES_H
+#define WORLD_BUILDER_FEATURES_SUBDUCTING_PLATE_COORDINATES_H
 
 
-#include "world_builder/features/fault_models/composition/interface.h"
-#include "world_builder/features/fault_models/grains/interface.h"
-#include "world_builder/features/fault_models/temperature/interface.h"
-#include "world_builder/features/fault_models/velocity/interface.h"
+#include "world_builder/features/subducting_plate_models/composition/interface.h"
+#include "world_builder/features/subducting_plate_models/grains/interface.h"
+#include "world_builder/features/subducting_plate_models/temperature/interface.h"
+#include "world_builder/features/subducting_plate_models/velocity/interface.h"
 #include "world_builder/objects/segment.h"
 #include "world_builder/bounding_box.h"
 #include "world_builder/objects/distance_from_surface.h"
@@ -37,7 +37,8 @@ namespace WorldBuilder
 
   namespace Features
   {
-    namespace FaultModels
+    using namespace FeatureUtilities;
+    namespace SubductingPlateModels
     {
       namespace Composition
       {
@@ -54,27 +55,27 @@ namespace WorldBuilder
       namespace Velocity
       {
         class Interface;
-      }  // namespace Temperature
-    }  // namespace FaultModels
+      }  // namespace Velocity
+    }  // namespace SubductingPlateModels
 
     /**
-     * This class represents a fault and can implement submodules
+     * This class represents a subducting plate and can implement submodules
      * for temperature and composition. These submodules determine what
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    class Fault final: public Interface
+    class SubductingPlateCoordinates final: public Interface
     {
       public:
         /**
          * constructor
          */
-        Fault(WorldBuilder::World *world);
+        SubductingPlateCoordinates(WorldBuilder::World *world);
 
         /**
          * Destructor
          */
-        ~Fault() override final;
+        ~SubductingPlateCoordinates() override final;
 
         /**
          * declare and read in the world builder file into the parameters class
@@ -97,7 +98,7 @@ namespace WorldBuilder
 
 
         /**
-         * Computes the bounding points for a BoundingBox object using two extreme points in all the surface
+         * Returns the bounding points for a BoundingBox object using two extreme points in all the surface
          * coordinates and an additional buffer zone that accounts for the fault thickness and length. The first and second
          * points correspond to the lower left and the upper right corners of the bounding box, respectively (see the
          * documentation in include/bounding_box.h).
@@ -142,7 +143,7 @@ namespace WorldBuilder
                    std::vector<double> &output) const override final;
 
         /**
-        * Returns a PlaneDistances object that has the distance from and along a fault plane,
+        * Returns a PlaneDistances object that has the distance from and along a subducting plate plane,
         * calculated from the coordinates and the depth of the point.
         */
         Objects::PlaneDistances
@@ -150,49 +151,50 @@ namespace WorldBuilder
                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
                                   const double depth) const override;
 
+
       private:
-        std::vector<std::shared_ptr<Features::FaultModels::Temperature::Interface> > default_temperature_models;
-        std::vector<std::shared_ptr<Features::FaultModels::Composition::Interface>  > default_composition_models;
-        std::vector<std::shared_ptr<Features::FaultModels::Grains::Interface>  > default_grains_models;
-        std::vector<std::shared_ptr<Features::FaultModels::Velocity::Interface>  > default_velocity_models;
+        std::vector<std::shared_ptr<Features::SubductingPlateModels::Temperature::Interface> > default_temperature_models;
+        std::vector<std::shared_ptr<Features::SubductingPlateModels::Composition::Interface>  > default_composition_models;
+        std::vector<std::shared_ptr<Features::SubductingPlateModels::Grains::Interface>  > default_grains_models;
+        std::vector<std::shared_ptr<Features::SubductingPlateModels::Velocity::Interface>  > default_velocity_models;
 
-        std::vector<Objects::Segment<Features::FaultModels::Temperature::Interface,
-            Features::FaultModels::Composition::Interface,
-            Features::FaultModels::Grains::Interface,
-            Features::FaultModels::Velocity::Interface> > default_segment_vector;
+        std::vector<Objects::Segment<Features::SubductingPlateModels::Temperature::Interface,
+            Features::SubductingPlateModels::Composition::Interface,
+            Features::SubductingPlateModels::Grains::Interface,
+            Features::SubductingPlateModels::Velocity::Interface> > default_segment_vector;
 
-        std::vector< std::vector<Objects::Segment<Features::FaultModels::Temperature::Interface,
-            Features::FaultModels::Composition::Interface,
-            Features::FaultModels::Grains::Interface,
-            Features::FaultModels::Velocity::Interface> > > sections_segment_vector;
+        std::vector< std::vector<Objects::Segment<Features::SubductingPlateModels::Temperature::Interface,
+            Features::SubductingPlateModels::Composition::Interface,
+            Features::SubductingPlateModels::Grains::Interface,
+            Features::SubductingPlateModels::Velocity::Interface> > > sections_segment_vector;
 
         // This vector stores segments to this coordinate/section.
         //First used (raw) pointers to the segment relevant to this coordinate/section,
         // but I do not trust it won't fail when memory is moved. So storing the all the data now.
-        std::vector<std::vector<Objects::Segment<Features::FaultModels::Temperature::Interface,
-            Features::FaultModels::Composition::Interface,
-            Features::FaultModels::Grains::Interface,
-            Features::FaultModels::Velocity::Interface> > > segment_vector;
+        std::vector<std::vector<Objects::Segment<Features::SubductingPlateModels::Temperature::Interface,
+            Features::SubductingPlateModels::Composition::Interface,
+            Features::SubductingPlateModels::Grains::Interface,
+            Features::SubductingPlateModels::Velocity::Interface> > > segment_vector;
 
         // todo: the memory of this can be greatly improved by
         // or using a plugin system for the submodules, or
         // putting the variables in a union. Although the memory
         // used by this program is in real cases expected to be
-        // insignificant compared to what a calling program may
+        // Insignificant compared to what a calling program may
         // use, a smaller amount of memory used in here, could
         // theoretically speed up the computation, because more
         // relevant data could be stored in the cache. But this
         // not a urgent problem, and would require testing.
 
         /**
-         * This variable stores the depth at which the fault
-         * starts. It makes this depth effectively the surface
-         * of the model for the fault.
+         * This variable stores the depth at which the subducting
+         * plate starts. It makes this depth effectively the surface
+         * of the model for the slab.
          */
         double starting_depth;
 
         /**
-         * The depth which below the fault may no longer
+         * The depth which below the subducting plate may no longer
          * be present. This can not only help setting up models with
          * less effort, but can also improve performance, because
          * the algorithm doesn't have to search in locations below
@@ -201,7 +203,7 @@ namespace WorldBuilder
         double maximum_depth;
 
         /**
-         * Computee bounding points for a BoundingBox object using two extreme points in all the surface
+         * Stores the bounding points for a BoundingBox object using two extreme points in all the surface
          * coordinates and an additional buffer zone that accounts for the fault thickness and length. The first and second
          * points correspond to the lower left and the upper right corners of the bounding box, respectively (see the
          * documentation in include/bounding_box.h).
@@ -211,17 +213,17 @@ namespace WorldBuilder
         BoundingBox<2> surface_bounding_box;
 
         /**
-         * A point on the surface to which the fault dips.
+         * A point on the surface to which the subducting plates subduct.
          */
-        WorldBuilder::Point<2> reference_point;
+        Point<2> reference_point;
 
-        std::vector<std::vector<double> > fault_segment_lengths;
-        std::vector<std::vector<Point<2> > > fault_segment_thickness;
-        std::vector<std::vector<Point<2> > > fault_segment_top_truncation;
-        std::vector<std::vector<Point<2> > > fault_segment_angles;
-        std::vector<double> total_fault_length;
-        double maximum_total_fault_length;
-        double maximum_fault_thickness;
+        std::vector<std::vector<double> > slab_segment_lengths;
+        std::vector<std::vector<Point<2> > > slab_segment_thickness;
+        std::vector<std::vector<Point<2> > > slab_segment_top_truncation;
+        std::vector<std::vector<Point<2> > > slab_segment_angles;
+        std::vector<double> total_slab_length;
+        double maximum_total_slab_length;
+        double maximum_slab_thickness;
 
         double min_along_x;
         double max_along_x;
@@ -229,8 +231,7 @@ namespace WorldBuilder
         double max_along_y;
         double min_lat_cos_inv;
         double max_lat_cos_inv;
-        double buffer_around_fault_cartesian;
-
+        double buffer_around_slab_cartesian;
     };
   } // namespace Features
 } // namespace WorldBuilder

--- a/source/world_builder/features/fault_coordinates.cc
+++ b/source/world_builder/features/fault_coordinates.cc
@@ -17,7 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "world_builder/features/fault.h"
+#include "world_builder/features/fault_coordinates.h"
 
 
 #include "glm/glm.h"
@@ -39,7 +39,7 @@ namespace WorldBuilder
 
   namespace Features
   {
-    Fault::Fault(WorldBuilder::World *world_)
+    FaultCoordinates::FaultCoordinates(WorldBuilder::World *world_)
       :
       reference_point(0,0,cartesian)
     {
@@ -47,12 +47,12 @@ namespace WorldBuilder
       this->name = "fault";
     }
 
-    Fault::~Fault()
+    FaultCoordinates::~FaultCoordinates()
       = default;
 
 
 
-    void Fault::make_snippet(Parameters &prm)
+    void FaultCoordinates::make_snippet(Parameters &prm)
     {
       using namespace rapidjson;
       Document &declarations = prm.declarations;
@@ -70,9 +70,9 @@ namespace WorldBuilder
 
 
     void
-    Fault::declare_entries(Parameters &prm,
-                           const std::string &parent_name,
-                           const std::vector<std::string> &required_entries)
+    FaultCoordinates::declare_entries(Parameters &prm,
+                                      const std::string &parent_name,
+                                      const std::vector<std::string> &required_entries)
     {
 
       // This statement is needed because of the recursion associated with
@@ -84,6 +84,8 @@ namespace WorldBuilder
       else
         {
           prm.declare_entry("", Types::Object(required_entries), "Fault object. Requires properties `model` and `coordinates`.");
+          prm.declare_entry("geometry type", Types::String("coordinates","coordinates"),
+                            "The model geometry type");
         }
       prm.declare_entry("min depth", Types::Double(0),
                         "The depth to which this feature is present");
@@ -115,7 +117,7 @@ namespace WorldBuilder
       if (parent_name != "items")
         {
           // This only happens if we are not in sections
-          prm.declare_entry("sections", Types::Array(Types::PluginSystem("",Features::Fault::declare_entries, {"coordinate"}, false)),"A list of feature properties for a coordinate.");
+          prm.declare_entry("sections", Types::Array(Types::PluginSystem("",Features::FaultCoordinates::declare_entries, {"coordinate"}, false)),"A list of feature properties for a coordinate.");
         }
       else
         {
@@ -129,7 +131,7 @@ namespace WorldBuilder
     }
 
     void
-    Fault::parse_entries(Parameters &prm)
+    FaultCoordinates::parse_entries(Parameters &prm)
     {
       const CoordinateSystem coordinate_system = prm.coordinate_system->natural_coordinate_system();
 
@@ -182,7 +184,7 @@ namespace WorldBuilder
 
 
       // now search whether a section is present, if so, replace the default segments.
-      std::vector<std::unique_ptr<Features::Fault> > sections_vector;
+      std::vector<std::unique_ptr<Features::FaultCoordinates> > sections_vector;
       prm.get_unique_pointers("sections", sections_vector);
 
       prm.enter_subsection("sections");
@@ -462,20 +464,20 @@ namespace WorldBuilder
 
 
     const BoundingBox<2> &
-    Fault::get_surface_bounding_box () const
+    FaultCoordinates::get_surface_bounding_box () const
     {
       return surface_bounding_box;
     }
 
 
     void
-    Fault::properties(const Point<3> &position_in_cartesian_coordinates,
-                      const Objects::NaturalCoordinate &position_in_natural_coordinates,
-                      const double depth,
-                      const std::vector<std::array<unsigned int,3>> &properties,
-                      const double gravity_norm,
-                      const std::vector<size_t> &entry_in_output,
-                      std::vector<double> &output) const
+    FaultCoordinates::properties(const Point<3> &position_in_cartesian_coordinates,
+                                 const Objects::NaturalCoordinate &position_in_natural_coordinates,
+                                 const double depth,
+                                 const std::vector<std::array<unsigned int,3>> &properties,
+                                 const double gravity_norm,
+                                 const std::vector<size_t> &entry_in_output,
+                                 std::vector<double> &output) const
     {
       // The 'depth coordinate' is the z-coordinate in Cartesian coordinates, and radius in spherical coordinates.
       // The depth input parameter is the distance from the surface to the position,
@@ -780,9 +782,9 @@ namespace WorldBuilder
     }
 
     Objects::PlaneDistances
-    Fault::distance_to_feature_plane(const Point<3> &position_in_cartesian_coordinates,
-                                     const Objects::NaturalCoordinate &position_in_natural_coordinates,
-                                     const double depth) const
+    FaultCoordinates::distance_to_feature_plane(const Point<3> &position_in_cartesian_coordinates,
+                                                const Objects::NaturalCoordinate &position_in_natural_coordinates,
+                                                const double depth) const
     {
       // The depth variable is the distance from the surface to the position, the depth
       // coordinate is the distance from the bottom of the model to the position and
@@ -815,7 +817,7 @@ namespace WorldBuilder
     /**
      * Register plugin
      */
-    WB_REGISTER_FEATURE(Fault, fault)
+    WB_REGISTER_FEATURE(FaultCoordinates, fault coordinates)
   } // namespace Features
 } // namespace WorldBuilder
 

--- a/source/world_builder/features/interface.cc
+++ b/source/world_builder/features/interface.cc
@@ -103,8 +103,26 @@ namespace WorldBuilder
               {
                 prm.declare_entry("", Types::Object(required_entries), "feature object");
 
-                prm.declare_entry("model", Types::String("",it.first),
+                std::string model_name = it.first;
+                std::vector<std::string> geometry_types = {" coordinates"};
+
+                for (auto &geometry_type : geometry_types)
+                  {
+                    // TODO: now just remove all, maybe only find last position of coordinates and remove it.
+                    size_t pos = 0;
+                    while ((pos = model_name.find(geometry_type, pos)) != std::string::npos)
+                      {
+                        model_name.replace(pos, geometry_type.length(), "");
+                        pos += 0;
+                      }
+                  }
+
+
+                prm.declare_entry("model", Types::String("",model_name),
                                   "The model name of the feature determining its type.");
+
+                prm.declare_entry("geometry type", Types::String("coordinates","coordinates"),
+                                  "The model geometry type");
                 prm.declare_entry("name", Types::String(""),
                                   "The name which the user has given to the feature. "
                                   "This is mostly used for documentation purposes, and should in most cases be unique, "

--- a/source/world_builder/features/oceanic_plate_coordinates.cc
+++ b/source/world_builder/features/oceanic_plate_coordinates.cc
@@ -17,7 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "world_builder/features/oceanic_plate.h"
+#include "world_builder/features/oceanic_plate_coordinates.h"
 
 #include "world_builder/features/oceanic_plate_models/composition/interface.h"
 #include "world_builder/features/oceanic_plate_models/grains/interface.h"
@@ -40,7 +40,7 @@ namespace WorldBuilder
 
   namespace Features
   {
-    OceanicPlate::OceanicPlate(WorldBuilder::World *world_)
+    OceanicPlateCoordinates::OceanicPlateCoordinates(WorldBuilder::World *world_)
       :
       min_depth(NaN::DSNAN),
       max_depth(NaN::DSNAN)
@@ -49,12 +49,12 @@ namespace WorldBuilder
       this->name = "oceanic plate";
     }
 
-    OceanicPlate::~OceanicPlate()
+    OceanicPlateCoordinates::~OceanicPlateCoordinates()
       = default;
 
 
 
-    void OceanicPlate::make_snippet(Parameters &prm)
+    void OceanicPlateCoordinates::make_snippet(Parameters &prm)
     {
       using namespace rapidjson;
       Document &declarations = prm.declarations;
@@ -86,12 +86,14 @@ namespace WorldBuilder
 
 
     void
-    OceanicPlate::declare_entries(Parameters &prm,
-                                  const std::string & /*unused*/,
-                                  const std::vector<std::string> &required_entries)
+    OceanicPlateCoordinates::declare_entries(Parameters &prm,
+                                             const std::string & /*unused*/,
+                                             const std::vector<std::string> &required_entries)
     {
       prm.declare_entry("", Types::Object(required_entries), "Oceanic plate object. Requires properties `model` and `coordinates`.");
 
+      prm.declare_entry("geometry type", Types::String("coordinates","coordinates"),
+                        "The model geometry type");
       prm.declare_entry("min depth", Types::OneOf(Types::Double(0),Types::Array(Types::ValueAtPoints(0., 2.))),
                         "The depth from which this feature is present");
       prm.declare_entry("max depth", Types::OneOf(Types::Double(std::numeric_limits<double>::max()),Types::Array(Types::ValueAtPoints(std::numeric_limits<double>::max(), 2.))),
@@ -111,7 +113,7 @@ namespace WorldBuilder
     }
 
     void
-    OceanicPlate::parse_entries(Parameters &prm)
+    OceanicPlateCoordinates::parse_entries(Parameters &prm)
     {
 
       const CoordinateSystem coordinate_system = prm.coordinate_system->natural_coordinate_system();
@@ -199,13 +201,13 @@ namespace WorldBuilder
 
 
     void
-    OceanicPlate::properties(const Point<3> &position_in_cartesian_coordinates,
-                             const Objects::NaturalCoordinate &position_in_natural_coordinates,
-                             const double depth,
-                             const std::vector<std::array<unsigned int,3>> &properties,
-                             const double gravity_norm,
-                             const std::vector<size_t> &entry_in_output,
-                             std::vector<double> &output) const
+    OceanicPlateCoordinates::properties(const Point<3> &position_in_cartesian_coordinates,
+                                        const Objects::NaturalCoordinate &position_in_natural_coordinates,
+                                        const double depth,
+                                        const std::vector<std::array<unsigned int,3>> &properties,
+                                        const double gravity_norm,
+                                        const std::vector<size_t> &entry_in_output,
+                                        std::vector<double> &output) const
     {
       if (depth <= max_depth && depth >= min_depth &&
           WorldBuilder::Utilities::polygon_contains_point(coordinates, Point<2>(position_in_natural_coordinates.get_surface_coordinates(),
@@ -323,7 +325,7 @@ namespace WorldBuilder
     /**
      * Register plugin
      */
-    WB_REGISTER_FEATURE(OceanicPlate, oceanic plate)
+    WB_REGISTER_FEATURE(OceanicPlateCoordinates, oceanic plate coordinates)
   } // namespace Features
 } // namespace WorldBuilder
 

--- a/source/world_builder/features/plume_coordinates.cc
+++ b/source/world_builder/features/plume_coordinates.cc
@@ -17,7 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "world_builder/features/plume.h"
+#include "world_builder/features/plume_coordinates.h"
 
 
 #include "world_builder/features/plume_models/composition/interface.h"
@@ -44,7 +44,7 @@ namespace WorldBuilder
 
   namespace Features
   {
-    Plume::Plume(WorldBuilder::World *world_)
+    PlumeCoordinates::PlumeCoordinates(WorldBuilder::World *world_)
       :
       min_depth(NaN::DSNAN),
       max_depth(NaN::DSNAN)
@@ -53,12 +53,12 @@ namespace WorldBuilder
       this->name = "plume";
     }
 
-    Plume::~Plume()
+    PlumeCoordinates::~PlumeCoordinates()
       = default;
 
 
 
-    void Plume::make_snippet(Parameters &prm)
+    void PlumeCoordinates::make_snippet(Parameters &prm)
     {
       using namespace rapidjson;
       Document &declarations = prm.declarations;
@@ -67,7 +67,7 @@ namespace WorldBuilder
 
       Pointer((path + "/body").c_str()).Set(declarations,"object");
       Pointer((path + "/body/model").c_str()).Set(declarations,"plume");
-      Pointer((path + "/body/name").c_str()).Set(declarations,"${1:My Plume}");
+      Pointer((path + "/body/name").c_str()).Set(declarations,"${1:My PlumeCoordinates}");
       Pointer((path + "/body/coordinates").c_str()).Create(declarations).SetArray();
       Pointer((path + "/body/temperature models").c_str()).Create(declarations).SetArray();
       Pointer((path + "/body/composition models").c_str()).Create(declarations).SetArray();
@@ -76,12 +76,14 @@ namespace WorldBuilder
 
 
     void
-    Plume::declare_entries(Parameters &prm,
-                           const std::string & /*unused*/,
-                           const std::vector<std::string> &required_entries)
+    PlumeCoordinates::declare_entries(Parameters &prm,
+                                      const std::string & /*unused*/,
+                                      const std::vector<std::string> &required_entries)
     {
-      prm.declare_entry("", Types::Object(required_entries), "Plume object. Requires properties `model` and `coordinates`.");
+      prm.declare_entry("", Types::Object(required_entries), "PlumeCoordinates object. Requires properties `model` and `coordinates`.");
 
+      prm.declare_entry("geometry type", Types::String("coordinates","coordinates"),
+                        "The model geometry type");
       prm.declare_entry("min depth", Types::Double(0),
                         "The depth from which this feature is present, in other words, the "
                         "depth of the tip of the plume. If the first entry in the cross "
@@ -118,7 +120,7 @@ namespace WorldBuilder
     }
 
     void
-    Plume::parse_entries(Parameters &prm)
+    PlumeCoordinates::parse_entries(Parameters &prm)
     {
       const CoordinateSystem coordinate_system = prm.coordinate_system->natural_coordinate_system();
 
@@ -251,13 +253,13 @@ namespace WorldBuilder
 
 
     void
-    Plume::properties(const Point<3> &position_in_cartesian_coordinates,
-                      const Objects::NaturalCoordinate &position_in_natural_coordinates,
-                      const double depth,
-                      const std::vector<std::array<unsigned int,3>> &properties,
-                      const double gravity_norm,
-                      const std::vector<size_t> &entry_in_output,
-                      std::vector<double> &output) const
+    PlumeCoordinates::properties(const Point<3> &position_in_cartesian_coordinates,
+                                 const Objects::NaturalCoordinate &position_in_natural_coordinates,
+                                 const double depth,
+                                 const std::vector<std::array<unsigned int,3>> &properties,
+                                 const double gravity_norm,
+                                 const std::vector<size_t> &entry_in_output,
+                                 std::vector<double> &output) const
     {
       // Figure out if the point is within the plume
       auto upper = std::upper_bound(depths.begin(), depths.end(), depth);
@@ -440,7 +442,7 @@ namespace WorldBuilder
         }
     }
 
-    WB_REGISTER_FEATURE(Plume, plume)
+    WB_REGISTER_FEATURE(PlumeCoordinates, plume coordinates)
 
   } // namespace Features
 } // namespace WorldBuilder

--- a/source/world_builder/features/subducting_plate_coordinates.cc
+++ b/source/world_builder/features/subducting_plate_coordinates.cc
@@ -17,7 +17,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "world_builder/features/subducting_plate.h"
+#include "world_builder/features/subducting_plate_coordinates.h"
 
 
 #include "glm/glm.h"
@@ -39,7 +39,7 @@ namespace WorldBuilder
 
   namespace Features
   {
-    SubductingPlate::SubductingPlate(WorldBuilder::World *world_)
+    SubductingPlateCoordinates::SubductingPlateCoordinates(WorldBuilder::World *world_)
       :
       reference_point(0,0,cartesian)
     {
@@ -47,12 +47,12 @@ namespace WorldBuilder
       this->name = "subducting plate";
     }
 
-    SubductingPlate::~SubductingPlate()
+    SubductingPlateCoordinates::~SubductingPlateCoordinates()
       = default;
 
 
 
-    void SubductingPlate::make_snippet(Parameters &prm)
+    void SubductingPlateCoordinates::make_snippet(Parameters &prm)
     {
       using namespace rapidjson;
       Document &declarations = prm.declarations;
@@ -84,9 +84,9 @@ namespace WorldBuilder
 
 
     void
-    SubductingPlate::declare_entries(Parameters &prm,
-                                     const std::string &parent_name,
-                                     const std::vector<std::string> &required_entries)
+    SubductingPlateCoordinates::declare_entries(Parameters &prm,
+                                                const std::string &parent_name,
+                                                const std::vector<std::string> &required_entries)
     {
       // This statement is needed because of the recursion associated with
       // the sections entry.
@@ -97,6 +97,8 @@ namespace WorldBuilder
       else
         {
           prm.declare_entry("", Types::Object(required_entries), "Subducting slab object. Requires properties `model` and `coordinates`.");
+          prm.declare_entry("geometry type", Types::String("coordinates","coordinates"),
+                            "The model geometry type");
         }
 
 
@@ -135,7 +137,7 @@ namespace WorldBuilder
       if (parent_name != "items")
         {
           // This only happens if we are not in sections
-          prm.declare_entry("sections", Types::Array(Types::PluginSystem("",Features::SubductingPlate::declare_entries, {"coordinate"}, false)),"A list of feature properties for a coordinate.");
+          prm.declare_entry("sections", Types::Array(Types::PluginSystem("",Features::SubductingPlateCoordinates::declare_entries, {"coordinate"}, false)),"A list of feature properties for a coordinate.");
         }
       else
         {
@@ -149,7 +151,7 @@ namespace WorldBuilder
     }
 
     void
-    SubductingPlate::parse_entries(Parameters &prm)
+    SubductingPlateCoordinates::parse_entries(Parameters &prm)
     {
       const CoordinateSystem coordinate_system = prm.coordinate_system->natural_coordinate_system();
 
@@ -202,7 +204,7 @@ namespace WorldBuilder
 
 
       // now search whether a section is present, if so, replace the default segments.
-      std::vector<std::unique_ptr<Features::SubductingPlate> > sections_vector;
+      std::vector<std::unique_ptr<Features::SubductingPlateCoordinates> > sections_vector;
       prm.get_unique_pointers("sections", sections_vector);
 
       prm.enter_subsection("sections");
@@ -488,20 +490,20 @@ namespace WorldBuilder
 
 
     const BoundingBox<2> &
-    SubductingPlate::get_surface_bounding_box () const
+    SubductingPlateCoordinates::get_surface_bounding_box () const
     {
       return surface_bounding_box;
     }
 
 
     void
-    SubductingPlate::properties(const Point<3> &position_in_cartesian_coordinates,
-                                const Objects::NaturalCoordinate &position_in_natural_coordinates,
-                                const double depth,
-                                const std::vector<std::array<unsigned int,3>> &properties,
-                                const double gravity_norm,
-                                const std::vector<size_t> &entry_in_output,
-                                std::vector<double> &output) const
+    SubductingPlateCoordinates::properties(const Point<3> &position_in_cartesian_coordinates,
+                                           const Objects::NaturalCoordinate &position_in_natural_coordinates,
+                                           const double depth,
+                                           const std::vector<std::array<unsigned int,3>> &properties,
+                                           const double gravity_norm,
+                                           const std::vector<size_t> &entry_in_output,
+                                           std::vector<double> &output) const
     {
       // The depth variable is the distance from the surface to the position, the depth
       // coordinate is the distance from the bottom of the model to the position and
@@ -813,9 +815,9 @@ namespace WorldBuilder
     }
 
     Objects::PlaneDistances
-    SubductingPlate::distance_to_feature_plane(const Point<3> &position_in_cartesian_coordinates,
-                                               const Objects::NaturalCoordinate &position_in_natural_coordinates,
-                                               const double depth) const
+    SubductingPlateCoordinates::distance_to_feature_plane(const Point<3> &position_in_cartesian_coordinates,
+                                                          const Objects::NaturalCoordinate &position_in_natural_coordinates,
+                                                          const double depth) const
     {
       // The depth variable is the distance from the surface to the position, the depth
       // coordinate is the distance from the bottom of the model to the position and
@@ -848,7 +850,7 @@ namespace WorldBuilder
     /**
      * Register plugin
      */
-    WB_REGISTER_FEATURE(SubductingPlate, subducting plate)
+    WB_REGISTER_FEATURE(SubductingPlateCoordinates, subducting plate coordinates)
   } // namespace Features
 } // namespace WorldBuilder
 

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -21,7 +21,7 @@
 
 
 #include "world_builder/config.h"
-#include "world_builder/features/subducting_plate.h"
+#include "world_builder/features/subducting_plate_coordinates.h"
 #include "world_builder/gravity_model/interface.h"
 #include "world_builder/nan.h"
 #include "world_builder/point.h"

--- a/tests/gwb-dat/app_continental_plate_3d.wb
+++ b/tests/gwb-dat/app_continental_plate_3d.wb
@@ -5,7 +5,7 @@
   "gravity model":{"model":"uniform", "magnitude":10},
   "features":
   [
-    {"model":"continental plate", "name":"First continental plate", "max depth":250e3, "coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
+    {"model":"continental plate", "geometry type": "coordinates","name":"First continental plate", "max depth":250e3, "coordinates":[[-1e3,500e3],[500e3,500e3],[500e3,1000e3],[-1e3,1000e3]],
      "temperature models":[{"model":"uniform", "max depth":75e3, "temperature":150},
                            {"model":"uniform", "min depth":75e3, "max depth":150e3, "temperature":100},
                            {"model":"uniform", "min depth":150e3, "max depth":225e3, "temperature":50}],

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -28,7 +28,7 @@
 #include "world_builder/coordinate_systems/cartesian.h"
 #include "world_builder/coordinate_systems/interface.h"
 #include "world_builder/coordinate_systems/invalid.h"
-#include "world_builder/features/continental_plate.h"
+#include "world_builder/features/continental_plate_coordinates.h"
 #include "world_builder/features/interface.h"
 #include "world_builder/grains.h"
 #include "world_builder/objects/natural_coordinate.h"
@@ -1155,7 +1155,7 @@ TEST_CASE("WorldBuilder Features: Interface")
                     Contains("Internal error: Plugin with name '!not_implemented_feature!' is not found. "
                              "The size of factories is "));
 
-  const std::unique_ptr<Features::Interface> interface = Features::Interface::create("continental plate", &world);
+  const std::unique_ptr<Features::Interface> interface = Features::Interface::create("continental plate coordinates", &world);
 
 }
 
@@ -1167,7 +1167,7 @@ TEST_CASE("WorldBuilder Features: Distance to Feature Plane")
   const std::string file_name = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/subducting_plate_constant_angles_cartesian.wb";
   WorldBuilder::World world1(file_name);
   {
-    std::unique_ptr<Features::Interface> subducting_plate = Features::Interface::create("Subducting Plate", &world1);
+    std::unique_ptr<Features::Interface> subducting_plate = Features::Interface::create("Subducting Plate coordinates", &world1);
 
     world1.parameters.enter_subsection("features");
     world1.parameters.enter_subsection("2");
@@ -1196,7 +1196,7 @@ TEST_CASE("WorldBuilder Features: Distance to Feature Plane")
   const std::string file_name2 = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/fault_constant_angles_cartesian.wb";
   WorldBuilder::World world2(file_name2);
   {
-    std::unique_ptr<Features::Interface> fault = Features::Interface::create("Fault", &world2);
+    std::unique_ptr<Features::Interface> fault = Features::Interface::create("Fault coordinates", &world2);
 
     world2.parameters.enter_subsection("features");
     world2.parameters.enter_subsection("2");
@@ -1234,7 +1234,7 @@ TEST_CASE("WorldBuilder Features: Continental Plate")
 
   // Check continental plate directly
   {
-    std::unique_ptr<Features::Interface> continental_plate = Features::Interface::create("continental plate", &world1);
+    std::unique_ptr<Features::Interface> continental_plate = Features::Interface::create("continental plate coordinates", &world1);
 
     world1.parameters.enter_subsection("features");
     world1.parameters.enter_subsection("2");
@@ -1481,7 +1481,7 @@ TEST_CASE("WorldBuilder Features: Mantle layer")
 
   // Check mantle layer directly
   {
-    std::unique_ptr<Features::Interface> mantle_layer = Features::Interface::create("mantle layer", &world1);
+    std::unique_ptr<Features::Interface> mantle_layer = Features::Interface::create("mantle layer coordinates", &world1);
 
     world1.parameters.enter_subsection("features");
     world1.parameters.enter_subsection("2");
@@ -1728,7 +1728,7 @@ TEST_CASE("WorldBuilder Features: Oceanic Plate")
 
   // Check continental plate directly
   {
-    std::unique_ptr<Features::Interface> oceanic_plate = Features::Interface::create("oceanic plate", &world1);
+    std::unique_ptr<Features::Interface> oceanic_plate = Features::Interface::create("oceanic plate coordinates", &world1);
 
     world1.parameters.enter_subsection("features");
     world1.parameters.enter_subsection("2");
@@ -1937,7 +1937,7 @@ TEST_CASE("WorldBuilder Features: Oceanic Plate")
   WorldBuilder::World world2(file_name);
 
   // Check continental plate directly
-  const std::unique_ptr<Features::Interface> oceanic_plate = Features::Interface::create("oceanic plate", &world2);
+  const std::unique_ptr<Features::Interface> oceanic_plate = Features::Interface::create("oceanic plate coordinates", &world2);
 
   // Check continental plate through the world
   const double dtr = Consts::PI / 180.0;
@@ -2115,7 +2115,7 @@ TEST_CASE("WorldBuilder Features: Subducting Plate")
 
   // Check continental plate directly (upper case should automatically turn into lower case).
   {
-    std::unique_ptr<Features::Interface> subducting_plate = Features::Interface::create("Subducting Plate", &world1);
+    std::unique_ptr<Features::Interface> subducting_plate = Features::Interface::create("Subducting Plate Coordinates", &world1);
 
     world1.parameters.enter_subsection("features");
     world1.parameters.enter_subsection("2");
@@ -2615,7 +2615,7 @@ TEST_CASE("WorldBuilder Features: Fault")
 
   // Check continental plate directly (upper case should automatically turn into lower case).
   {
-    std::unique_ptr<Features::Interface> fault = Features::Interface::create("Fault", &world1);
+    std::unique_ptr<Features::Interface> fault = Features::Interface::create("Fault Coordinates", &world1);
 
     world1.parameters.enter_subsection("features");
     world1.parameters.enter_subsection("2");
@@ -2884,7 +2884,7 @@ TEST_CASE("WorldBuilder Features: Fault")
   WorldBuilder::World world3(file_name);
 
   // Check fault directly (upper case should automatically turn into lower case).
-  const std::unique_ptr<Features::Interface> continental_plate = Features::Interface::create("Fault", &world3);
+  const std::unique_ptr<Features::Interface> continental_plate = Features::Interface::create("Fault Coordinates", &world3);
 
   // Check fault through the world
   position = {{0,0,800e3}};
@@ -3563,7 +3563,7 @@ TEST_CASE("WorldBuilder Types: Coordinate System")
 TEST_CASE("WorldBuilder Types: PluginSystem")
 {
 #define TYPE PluginSystem
-  Types::TYPE type("test", Features::ContinentalPlate::declare_entries, std::vector<std::string> {{"test required"}}, false);
+  Types::TYPE type("test", Features::ContinentalPlateCoordinates::declare_entries, std::vector<std::string> {{"test required"}}, false);
   CHECK(type.default_value == "test");
   CHECK(type.required_entries[0] == "test required");
   CHECK(type.allow_multiple == false);


### PR DESCRIPTION
With @danieldouglas92 adding contours and  @Minerallo adding gplates functionality to define the geometry of features, I thought it would be good to have a more generic way of dealing with different geometries. 

This solution add the geometry type (e.g. coordinates, contours, gplate) to the name of the feature file (coninental_plate, mantle_layer, etc.) and the same for the class name. We still want the user to be able to chose a model and geometry type separately, also not to break backward compatibility. 

I will try it out with a mock contours continental plate, to see if this actually works as expected, but comments are welcome if this is a reasonable approach or not. @danieldouglas92, @Minerallo, @gassmoeller, @tjhei.