### PR TITLE
Fix indent warning

### DIFF
--- a/doc/indent
+++ b/doc/indent
@@ -34,9 +34,9 @@ fi
 # collect all header and source files and process them in batches of 50 files
 # with up to 10 in parallel
 
-find include source tests/unit_tests \( -name '*.cc' -o -name '*.h' \) -print | xargs -n 50 -P 10 astyle --options=doc/astyle-2.04.rc
+find include source tests/unit_tests \( -name '*.cc' -o -name '*.h' \) -print0 | xargs -0 -n 50 -P 10 astyle --options=doc/astyle-2.04.rc
 # remove execute permission on source files:
-find include source tests/unit_tests \( -name '*.cc' -o -name '*.h' -o -name '*.prm' \) -print | xargs -n 50 -P 10 chmod -x
+find include source tests/unit_tests \( -name '*.cc' -o -name '*.h' -o -name '*.prm' \) -print0 | xargs -0 -n 50 -P 10 chmod -x
 
 # convert dos formatted files to unix file format by stripping out
 # carriage returns (15=0x0D):
@@ -48,5 +48,5 @@ dos_to_unix()
     rm -f $f.tmp
 }
 export -f dos_to_unix
-find include source \( -name '*.cc' -o -name '*.h' -o -name '*.prm' \) -print | xargs -n 1 -P 10 -I {} bash -c 'dos_to_unix "$@"' _ {}
+find include source \( -name '*.cc' -o -name '*.h' -o -name '*.prm' \) -print0 | xargs -0 -P 10 -I {} bash -c 'dos_to_unix "$@"' _ {}
 


### PR DESCRIPTION
Running the indent script used to produce the following warning for a while now:

xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value

This PR fixes the warning by removing the `-n` (max-args) option that was ignored anyway. It also takes over some improvements from https://github.com/geodynamics/aspect/pull/6153 to print file names separated by NULL characters to avoid problems with spaces and special characters in file names.