### PR TITLE
Update classname in macro

### DIFF
--- a/include/world_builder/coordinate_systems/interface.h
+++ b/include/world_builder/coordinate_systems/interface.h
@@ -165,18 +165,18 @@ namespace WorldBuilder
      * register it. Because this is a library, we need some extra measures
      * to ensure that the static variable is actually initialized.
      */
-#define WB_REGISTER_COORDINATE_SYSTEM(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_COORDINATE_SYSTEM(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
   } // namespace CoordinateSystems
 } // namespace WorldBuilder

--- a/include/world_builder/features/continental_plate_models/composition/interface.h
+++ b/include/world_builder/features/continental_plate_models/composition/interface.h
@@ -143,18 +143,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_CONTINENTAL_PLATE_COMPOSITION_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_CONTINENTAL_PLATE_COMPOSITION_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Composition
     } // namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/grains/interface.h
+++ b/include/world_builder/features/continental_plate_models/grains/interface.h
@@ -149,18 +149,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_CONTINENTAL_PLATE_GRAINS_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_CONTINENTAL_PLATE_GRAINS_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       virtual std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Grains
     } // namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/temperature/interface.h
+++ b/include/world_builder/features/continental_plate_models/temperature/interface.h
@@ -148,18 +148,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TEMPERATURE_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TEMPERATURE_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Temperature
     } // namespace ContinentalPlateModels

--- a/include/world_builder/features/continental_plate_models/velocity/interface.h
+++ b/include/world_builder/features/continental_plate_models/velocity/interface.h
@@ -148,18 +148,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_CONTINENTAL_PLATE_VELOCITY_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_CONTINENTAL_PLATE_VELOCITY_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Velocity
     } // namespace ContinentalPlateModels

--- a/include/world_builder/features/fault_models/composition/interface.h
+++ b/include/world_builder/features/fault_models/composition/interface.h
@@ -151,18 +151,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_FAULT_COMPOSITION_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_FAULT_COMPOSITION_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Composition
     } // namespace FaultModels

--- a/include/world_builder/features/fault_models/grains/interface.h
+++ b/include/world_builder/features/fault_models/grains/interface.h
@@ -152,18 +152,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_FAULT_GRAINS_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_FAULT_GRAINS_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       virtual std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Grains
     } // namespace FaultModels

--- a/include/world_builder/features/fault_models/temperature/interface.h
+++ b/include/world_builder/features/fault_models/temperature/interface.h
@@ -152,18 +152,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_FAULT_TEMPERATURE_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_FAULT_TEMPERATURE_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Temperature
     } // namespace FaultModels

--- a/include/world_builder/features/fault_models/velocity/interface.h
+++ b/include/world_builder/features/fault_models/velocity/interface.h
@@ -151,18 +151,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_FAULT_VELOCITY_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_FAULT_VELOCITY_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Velocity
     } // namespace FaultModels

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -209,18 +209,18 @@ namespace WorldBuilder
      * register it. Because this is a library, we need some extra measures
      * to ensure that the static variable is actually initialized.
      */
-#define WB_REGISTER_FEATURE(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, klass::make_snippet, this); \
+        Interface::registerType(#name, classname::declare_entries, classname::make_snippet, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
   } // namespace Features
 } // namespace WorldBuilder

--- a/include/world_builder/features/mantle_layer_models/composition/interface.h
+++ b/include/world_builder/features/mantle_layer_models/composition/interface.h
@@ -147,18 +147,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_MANTLE_LAYER_COMPOSITION_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_MANTLE_LAYER_COMPOSITION_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Composition
     } // namespace MantleLayerModels

--- a/include/world_builder/features/mantle_layer_models/grains/interface.h
+++ b/include/world_builder/features/mantle_layer_models/grains/interface.h
@@ -149,18 +149,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_MANTLE_LAYER_GRAINS_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_MANTLE_LAYER_GRAINS_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       virtual std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Grains
     } // namespace MantleLayerModels

--- a/include/world_builder/features/mantle_layer_models/temperature/interface.h
+++ b/include/world_builder/features/mantle_layer_models/temperature/interface.h
@@ -148,18 +148,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_MANTLE_LAYER_TEMPERATURE_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_MANTLE_LAYER_TEMPERATURE_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Temperature
     } // namespace MantleLayerModels

--- a/include/world_builder/features/mantle_layer_models/velocity/interface.h
+++ b/include/world_builder/features/mantle_layer_models/velocity/interface.h
@@ -148,18 +148,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_MANTLE_LAYER_VELOCITY_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_MANTLE_LAYER_VELOCITY_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Velocity
     } // namespace MantleLayerModels

--- a/include/world_builder/features/oceanic_plate_models/composition/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/composition/interface.h
@@ -147,18 +147,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_OCEANIC_PLATE_COMPOSITION_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_OCEANIC_PLATE_COMPOSITION_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Composition
     } // namespace OceanicPlateModels

--- a/include/world_builder/features/oceanic_plate_models/grains/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/interface.h
@@ -145,18 +145,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_OCEANIC_PLATE_GRAINS_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_OCEANIC_PLATE_GRAINS_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       virtual std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Grains
     } // namespace OceanicPlateModels

--- a/include/world_builder/features/oceanic_plate_models/temperature/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/temperature/interface.h
@@ -148,18 +148,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_OCEANIC_PLATE_TEMPERATURE_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_OCEANIC_PLATE_TEMPERATURE_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Temperature
     } // namespace OceanicPlateModels

--- a/include/world_builder/features/oceanic_plate_models/velocity/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/velocity/interface.h
@@ -148,18 +148,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_OCEANIC_PLATE_VELOCITY_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_OCEANIC_PLATE_VELOCITY_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Velocity
     } // namespace OceanicPlateModels

--- a/include/world_builder/features/plume_models/composition/interface.h
+++ b/include/world_builder/features/plume_models/composition/interface.h
@@ -143,18 +143,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_PLUME_COMPOSITION_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_PLUME_COMPOSITION_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Composition
     } // namespace PlumeModels

--- a/include/world_builder/features/plume_models/grains/interface.h
+++ b/include/world_builder/features/plume_models/grains/interface.h
@@ -149,18 +149,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_PLUME_GRAINS_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_PLUME_GRAINS_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       virtual std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Grains
     } // namespace PlumeModels

--- a/include/world_builder/features/plume_models/temperature/interface.h
+++ b/include/world_builder/features/plume_models/temperature/interface.h
@@ -152,18 +152,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_PLUME_TEMPERATURE_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_PLUME_TEMPERATURE_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Temperature
     } // namespace PlumeModels

--- a/include/world_builder/features/plume_models/velocity/interface.h
+++ b/include/world_builder/features/plume_models/velocity/interface.h
@@ -152,18 +152,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_PLUME_VELOCITY_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_PLUME_VELOCITY_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Velocity
     } // namespace PlumeModels

--- a/include/world_builder/features/subducting_plate_models/composition/interface.h
+++ b/include/world_builder/features/subducting_plate_models/composition/interface.h
@@ -152,18 +152,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_SUBDUCTING_PLATE_COMPOSITION_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_SUBDUCTING_PLATE_COMPOSITION_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Composition
     } // namespace SubductingPlateModels

--- a/include/world_builder/features/subducting_plate_models/grains/interface.h
+++ b/include/world_builder/features/subducting_plate_models/grains/interface.h
@@ -152,18 +152,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_SUBDUCTING_PLATE_GRAINS_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_SUBDUCTING_PLATE_GRAINS_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       virtual std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Grains
     } // namespace SubductingPlateModels

--- a/include/world_builder/features/subducting_plate_models/temperature/interface.h
+++ b/include/world_builder/features/subducting_plate_models/temperature/interface.h
@@ -153,18 +153,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_SUBDUCTING_PLATE_TEMPERATURE_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_SUBDUCTING_PLATE_TEMPERATURE_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Temperature
     } // namespace SubductingPlateModels

--- a/include/world_builder/features/subducting_plate_models/velocity/interface.h
+++ b/include/world_builder/features/subducting_plate_models/velocity/interface.h
@@ -153,18 +153,18 @@ namespace WorldBuilder
          * register it. Because this is a library, we need some extra measures
          * to ensure that the static variable is actually initialized.
          */
-#define WB_REGISTER_FEATURE_SUBDUCTING_PLATE_VELOCITY_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_FEATURE_SUBDUCTING_PLATE_VELOCITY_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
       } // namespace Velocity
     } // namespace SubductingPlateModels

--- a/include/world_builder/gravity_model/interface.h
+++ b/include/world_builder/gravity_model/interface.h
@@ -130,18 +130,18 @@ namespace WorldBuilder
      * register it. Because this is a library, we need some extra measures
      * to ensure that the static variable is actually initialized.
      */
-#define WB_REGISTER_GRAVITY_MODEL(klass,name) \
-  class klass##Factory : public ObjectFactory { \
+#define WB_REGISTER_GRAVITY_MODEL(classname,name) \
+  class classname##Factory : public ObjectFactory { \
     public: \
-      klass##Factory() \
+      classname##Factory() \
       { \
-        Interface::registerType(#name, klass::declare_entries, this); \
+        Interface::registerType(#name, classname::declare_entries, this); \
       } \
       std::unique_ptr<Interface> create(World *world) override final { \
-        return std::unique_ptr<Interface>(new klass(world)); \
+        return std::unique_ptr<Interface>(new classname(world)); \
       } \
   }; \
-  static klass##Factory global_##klass##Factory;
+  static classname##Factory global_##classname##Factory;
 
   } // namespace CoordinateSystems
 } // namespace WorldBuilder


### PR DESCRIPTION
@MFraters: As discussed, maybe a minor change, but I would prefer if we can use `classname` instead of `klass` as the argument for these macros. `classname` follows more closely good English language practice and includes a bit more meaning as well (and it is what we use in ASPECT for these macros). `klass` was just used before to avoid the use of `class` which is a c++ keyword.