### PR TITLE
Update benchark actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -181,7 +181,7 @@ jobs:
             cat ${{github.workspace}}/result_${{matrix.benchmark_number}}.csv | cargo run --release analyze --disable-dynamic-printing > ${{github.workspace}}/benchmark_${{matrix.benchmark_number}}_results/analyze_${{matrix.benchmark_number}}.log ||:;
             cat ${{github.workspace}}/benchmark_${{matrix.benchmark_number}}_results/analyze_${{matrix.benchmark_number}}.log
     
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: benchmark_${{matrix.benchmark_number}}_results
         path: benchmark_${{matrix.benchmark_number}}_results/


### PR DESCRIPTION
Otherwise the benchmarks automatically fail due to v3 being deprecated.