### PR TITLE
Fix Asserts and typos

### DIFF
--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -354,7 +354,7 @@ int main(int argc, char **argv)
       if (find_command_line_option(argv, argv+argc, "-h") || find_command_line_option(argv, argv+argc, "--help"))
         {
           std::cout << "World Builder Grid Visualization tool.\n"
-                    <<  "This program loads a world builder file and generates a visualization on a structured grid "
+                    <<  "This program loads a World Builder file and generates a visualization on a structured grid "
                     << "based on information specified in a separate .grid configuration file.\n\n"
                     << "Usage:\n"
                     << argv[0] << " [-j N] [--filtered] [--by-tag] example.wb example.grid\n\n"
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
       /**
        * Try to start the world builder
        */
-      std::cout << "[2/6] Starting the world builder with " << number_of_threads << " threads...                         \r";
+      std::cout << "[2/6] Starting the World Builder with " << number_of_threads << " threads...                         \r";
       std::cout.flush();
 
       std::unique_ptr<WorldBuilder::World> world;
@@ -452,7 +452,7 @@ int main(int argc, char **argv)
         }
       catch (std::exception &e)
         {
-          std::cerr << "Could not start the World builder from file '" << wb_file << "', error: " << e.what() << "\n";
+          std::cerr << "Could not start the World Builder from file '" << wb_file << "', error: " << e.what() << "\n";
 
 #ifdef WB_WITH_MPI
           MPI_Finalize();

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -566,12 +566,12 @@ int main(int argc, char **argv)
       WBAssertThrow(!std::isnan(z_max), "z_max is not a number:" << z_max << ". This value has probably not been provided in the grid file.");
 
 
-      WBAssertThrow(n_cell_x != 0, "n_cell_z may not be equal to zero: " << n_cell_x << '.');
+      WBAssertThrow(n_cell_x != 0, "n_cell_x may not be equal to zero: " << n_cell_x << '.');
       // int's cannot generally be nan's (see https://stackoverflow.com/questions/3949457/can-an-integer-be-nan-in-c),
       // but visual studio is giving problems over this, so it is taken out for now.
-      //WBAssertThrow(!std::isnan(n_cell_x), "n_cell_z is not a number:" << n_cell_x << '.');
+      //WBAssertThrow(!std::isnan(n_cell_x), "n_cell_x is not a number:" << n_cell_x << '.');
 
-      WBAssertThrow(dim == 3 || n_cell_z != 0, "In 3d n_cell_z may not be equal to zero: " << n_cell_y << '.');
+      WBAssertThrow(dim == 2 || n_cell_y != 0, "In 3d n_cell_y may not be equal to zero: " << n_cell_y << '.');
       // int's cannot generally be nan's (see https://stackoverflow.com/questions/3949457/can-an-integer-be-nan-in-c),
       // but visual studio is giving problems over this, so it is taken out for now.
       //WBAssertThrow(!std::isnan(n_cell_z), "n_cell_z is not a number:" << n_cell_y << '.');

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -165,15 +165,15 @@ namespace WorldBuilder
      */
 
     WBAssertThrow((prm.get<std::string>("version") == Version::MAJOR + "." + Version::MINOR),
-                  "The major and minor version combination for which is input file was written "
+                  "The major and minor version combination for which this input file was written "
                   "is not the same as the version of the World Builder you are running. This means "
-                  "That there may have been incompatible changes made between the versions. \n\n"
+                  "that there may have been incompatible changes made between the versions. \n\n"
                   "Verify those changes and whether they affect your model. If this is not "
                   "the case, adjust the version number in the input file. \n\nThe provided version "
-                  "number is \"" << prm.get<std::string>("version") << "\", while the used world builder "
+                  "number is \"" << prm.get<std::string>("version") << "\", while the used World Builder "
                   "has  (major.minor) version \"" << Version::MAJOR << "." << Version::MINOR << "\". "
                   "If you created this file from scratch, fill set the version number to \"" <<
-                  Version::MAJOR << "." << Version::MINOR << "\" to continue. If you got the world builder "
+                  Version::MAJOR << "." << Version::MINOR << "\" to continue. If you got the World Builder "
                   "file from somewhere, make sure that the output is what you expect it to be, because "
                   "backwards incompatible changes may have been made to the code.");
 

--- a/tests/gwb-dat/run_gwb-dat_tests.cmake
+++ b/tests/gwb-dat/run_gwb-dat_tests.cmake
@@ -54,7 +54,7 @@ String(REGEX REPLACE "[:/a-zA-Z\\/0-9_\\.-]*gwb-grid[.exe]*" "(..path..)bin/gwb-
 String(REGEX REPLACE "  -j N                  Specify the number of threads the visualizer is allowed to use. Default: [0-9]*." "  -j N                  Specify the number of threads the visualizer is allowed to use. Default: --." TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
 String(REGEX REPLACE "GWB Version: [0-9.a-zA-Z]*" "GWB Version: -.-.-.-" TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
 String(REGEX REPLACE "git hash: [0-9.a-zA-Z-]* branch: [-0-9.a-zA-Z_]*" "git hash: (..git hash..) branch: (..git branch..)" TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
-String(REGEX REPLACE "Starting the world builder with ([0-9]*) threads..." "Starting the world builder with -- threads..." TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
+String(REGEX REPLACE "Starting the World Builder with ([0-9]*) threads..." "Starting the World Builder with -- threads..." TEST_OUTPUT_PROCESSED "${TEST_OUTPUT_PROCESSED}")
 file(WRITE ${TEST_OUTPUT} ${TEST_OUTPUT_PROCESSED})
 
 if( TEST_RESULT_VAR )

--- a/tests/gwb-grid/grid_help.log
+++ b/tests/gwb-grid/grid_help.log
@@ -1,5 +1,5 @@
 World Builder Grid Visualization tool.
-This program loads a world builder file and generates a visualization on a structured grid based on information specified in a separate .grid configuration file.
+This program loads a World Builder file and generates a visualization on a structured grid based on information specified in a separate .grid configuration file.
 
 Usage:
 (..path..)bin/gwb-grid [-j N] [--filtered] [--by-tag] example.wb example.grid

--- a/tests/gwb-grid/grid_non_existing_wb.log
+++ b/tests/gwb-grid/grid_non_existing_wb.log
@@ -1,3 +1,3 @@
-[1/6] Parsing file...                         [2/6] Starting the world builder with -- threads...                         Expected fail with: 
+[1/6] Parsing file...                         [2/6] Starting the World Builder with -- threads...                         Expected fail with: 
 AssertThrow `(..error type..)` failed in (..path..)/source/world_builder/utilities.cc at line (..line..): Could not open file <..file..>.
 


### PR DESCRIPTION
I ran into some Asserts when converting a 3D .grid file into a 2D one. There were some inconstistencies in the Asserts checking the number of grid cells in each direction and some typos that this PR fixes.