### PR TITLE
Update minimum cmake version from 2.8.12 -> 3.5 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,15 +23,15 @@ jobs:
 
       - name: Use cmake
         run: cmake --version
-      
+
       - uses: actions/checkout@v4
 
       - name: Install astyle
         shell: bash
         run: cd .. && mkdir astyle && cd astyle && wget 'https://sourceforge.net/projects/astyle/files/astyle/astyle 2.04/astyle_2.04_linux.tar.gz' && tar -zxvf astyle_2.04_linux.tar.gz && cd astyle/build/gcc && make && sudo make install && cd ../../../../
-      
+
       - name: Create Build Environment
-        run: | 
+        run: |
               mkdir build;
               cd build;
 
@@ -53,21 +53,21 @@ jobs:
       - name: check indentation
         shell: bash
         working-directory: ${{github.workspace}}/build
-        run: | 
-              if [[ "$(git status | grep 'modified' --count)" -gt "0" ]]; then 
-                 git diff > diff.log; 
-                 cat diff.log; 
-                 exit 1; 
+        run: |
+              if [[ "$(git status | grep 'modified' --count)" -gt "0" ]]; then
+                 git diff > diff.log;
+                 cat diff.log;
+                 exit 1;
               fi
 
   test_linux_and_macos:
     needs: test_indentation
-    strategy: 
+    strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         os: ['ubuntu-22.04', 'ubuntu-24.04','macos-13']
         build_type: ['Release', 'Debug']
-      
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -99,7 +99,7 @@ jobs:
             fi
          fi
       shell: bash
-      
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build
 
@@ -131,17 +131,17 @@ jobs:
 
   test_linux_non_unity_no_optional_dependencies:
     needs: test_indentation
-    strategy: 
+    strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         os: ['ubuntu-24.04']
         build_type: ['Debug']
-      
+
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
-      
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build
 
@@ -164,17 +164,17 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: ctest -VV -C ${{ matrix.build_type }}
-      
+
 
   test_windows:
     needs: test_indentation
-    strategy: 
+    strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         os: ['windows-2022']
         build_type: ['Release', 'Debug']
         build_system: ['Visual Studio 17 2022']
-      
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -187,7 +187,7 @@ jobs:
     #  shell: bash
 
     - uses: ilammy/msvc-dev-cmd@v1
-        
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build
 
@@ -211,16 +211,16 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: ctest -VV -C ${{ matrix.build_type }}  -E _no_coordinates
-      
+
 
   test_linux_and_macos_mpi:
     needs: test_indentation
-    strategy: 
+    strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         os: ['ubuntu-24.04','macos-13']
         build_type: ['Release']
-      
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -232,19 +232,19 @@ jobs:
             sudo apt update;
             sudo apt install gfortran swig python3-setuptools openmpi-bin libopenmpi-dev
          elif [ "$RUNNER_OS" == "macOS" ]; then
-            sudo brew install open-mpi || true    
+            sudo brew install open-mpi || true
             echo "4"
             if [ "${{ matrix.os }}" == "macos-13" ]; then
                 sudo xcode-select --switch /Applications/Xcode_15.0.1.app
             else
                 sudo xcode-select --switch /Applications/Xcode_13.2.1.app
             fi
-         else          
+         else
             echo "$RUNNER_OS not supported"
             exit 1
          fi
       shell: bash
-      
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build
 
@@ -284,11 +284,11 @@ jobs:
 
       - name: extend path
         run: echo $PATH && export PATH=$PATH:/home/runner/.local/bin && echo $PATH && export PYTHONPATH=$PYTHONPATH:/home/runner/.local/bin
-      
+
       - name: Install coveralls
-        run: pipx install cpp-coveralls 
+        run: pipx install cpp-coveralls
         shell: bash
-         
+
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
 
@@ -350,14 +350,14 @@ jobs:
 
   linux-cmake_mpi:
     needs: [test_indentation,coverage]
-    strategy: 
+    strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         os: ['ubuntu-24.04']
-        cmake_version: ['2.8.12','3.16.x', '3.20.x']
+        cmake_version: ['3.16.x', '3.20.x']
         use_mpi: ['TRUE','FALSE']
         build_type: ['Release']
-      
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -369,8 +369,8 @@ jobs:
             sudo apt update;
             sudo apt install gfortran swig python3-setuptools openmpi-bin libopenmpi-dev
          elif [ "$RUNNER_OS" == "macOS" ]; then
-            sudo brew install open-mpi || true    
-         else          
+            sudo brew install open-mpi || true
+         else
             echo "$RUNNER_OS not supported"
             exit 1
          fi
@@ -379,8 +379,8 @@ jobs:
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v2.0
       with:
-        cmake-version: ${{ matrix.cmake_version }} 
-            
+        cmake-version: ${{ matrix.cmake_version }}
+
     - name: Use cmake
       run: cmake --version
 
@@ -590,7 +590,7 @@ jobs:
       shell: bash
       run: ctest -VV -C ${{ matrix.build_type }}
 
-  
+
   linux-gcc_no_apps:
     needs: [test_indentation,coverage]
     strategy:
@@ -718,4 +718,3 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: ctest -VV -C ${{ matrix.build_type }} -R _valgrind -E _no_coordinates_valgrind
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,7 @@ if (NOT MSVC AND NOT APPLE)
    #TODO: if other compiles need to be threaded, see https://computing.llnl.gov/tutorials/pthreads/#Compiling to add the correct cases.
    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER MATCHES "AppleClang")
       # Preventing issues with older cmake compilers (<3.7) which do not support VERSION_GREATER_EQUAL
-      # cmake vesrion 3.12.0 introduces COMPILE_LANGUAGE:FORTRAN, otherwise this would be >=2.8.12
+      # cmake version 3.12.0 introduces COMPILE_LANGUAGE:FORTRAN, otherwise this would be >=2.8.12
       if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
         SET(WB_COMPILER_OPTIONS_PRIVATE -pedantic -Wall -Wextra
         $<$<COMPILE_LANGUAGE:CXX>:-Wmost  -Wunreachable-code -Wuninitialized -Wmissing-braces -Wunused-parameter -Wold-style-cast -Wshadow -Wfloat-equal -Wpointer-arith -Wwrite-strings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(WorldBuilder C CXX)
 
@@ -118,9 +118,9 @@ endif()
 
 
 #find python libs
-SET(WB_ENABLE_PYTHON ON CACHE BOOL "Whether or not to enable Python when compiling the world builder.") 
+SET(WB_ENABLE_PYTHON ON CACHE BOOL "Whether or not to enable Python when compiling the world builder.")
 if(${WB_ENABLE_PYTHON})
-  if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
+  if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     FIND_PACKAGE(PythonLibs 3.0)
     FIND_PACKAGE(PythonInterp 3.0)
 
@@ -299,7 +299,7 @@ if(MAKE_PYTHON_WRAPPER)
 
   # Add swig module
   SET_SOURCE_FILES_PROPERTIES(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/source/world_builder/wrapper_cpp.i PROPERTIES CPLUSPLUS ON)
-  if(${CMAKE_VERSION} VERSION_LESS "3.8.0") 
+  if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
     swig_add_module(gwb python ${CMAKE_CURRENT_SOURCE_DIR}/source/world_builder/wrapper_cpp.i)
   else()
     swig_add_library(gwb LANGUAGE python SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/source/world_builder/wrapper_cpp.i)
@@ -307,7 +307,7 @@ if(MAKE_PYTHON_WRAPPER)
 
 endif()
 
-# Find if we are using make or ninja. 
+# Find if we are using make or ninja.
 IF(CMAKE_GENERATOR MATCHES "Ninja")
   SET(_make_command "ninja")
 ELSE()
@@ -373,9 +373,9 @@ if (NOT MSVC AND NOT APPLE)
       # Preventing issues with older cmake compilers (<3.7) which do not support VERSION_GREATER_EQUAL
       # cmake vesrion 3.12.0 introduces COMPILE_LANGUAGE:FORTRAN, otherwise this would be >=2.8.12
       if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
-        SET(WB_COMPILER_OPTIONS_PRIVATE -pedantic -Wall -Wextra  
+        SET(WB_COMPILER_OPTIONS_PRIVATE -pedantic -Wall -Wextra
         $<$<COMPILE_LANGUAGE:CXX>:-Wmost  -Wunreachable-code -Wuninitialized -Wmissing-braces -Wunused-parameter -Wold-style-cast -Wshadow -Wfloat-equal -Wpointer-arith -Wwrite-strings
-        -Wsynth -Wsign-compare -Woverloaded-virtual -Wliteral-range -Wparentheses -Wunused-local-typedefs -Wcast-qual -fstrict-aliasing -Werror=uninitialized -Wundef 
+        -Wsynth -Wsign-compare -Woverloaded-virtual -Wliteral-range -Wparentheses -Wunused-local-typedefs -Wcast-qual -fstrict-aliasing -Werror=uninitialized -Wundef
         -Wcast-align -Wmissing-declarations -Wredundant-decls -Wdiv-by-zero -Wdisabled-optimization -Wswitch-default -Wunused>)
 
         if (${FORCE_COLORED_OUTPUT})
@@ -392,7 +392,7 @@ if (NOT MSVC AND NOT APPLE)
       endif()
 
    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-     SET(WB_COMPILER_OPTIONS_PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-pthread -pedantic -Wall -Wextra -Wpointer-arith -Wwrite-strings -Wsign-compare 
+     SET(WB_COMPILER_OPTIONS_PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-pthread -pedantic -Wall -Wextra -Wpointer-arith -Wwrite-strings -Wsign-compare
      -Woverloaded-virtual -Wno-parentheses -Wcast-qual -fstrict-aliasing -Wmaybe-uninitialized -Werror=maybe-uninitialized>)
    else()
       # gcc linux
@@ -466,7 +466,7 @@ else()
   endif()
 endif()
 
-if(${CMAKE_VERSION} VERSION_LESS "3.13.0") 
+if(${CMAKE_VERSION} VERSION_LESS "3.13.0")
     SET(CMAKE_EXE_LINKER_FLAGS "${WB_LINKER_OPTIONS} ${WB_VISU_LINKER_OPTIONS} ${WB_COMPILER_OPTIONS_PRIVATE_COVERAGE_OLD}")
 else()
     target_link_options(${WB_TARGET} INTERFACE ${WB_LINKER_OPTIONS})
@@ -549,7 +549,7 @@ if(MAKE_PYTHON_WRAPPER)
       swig_link_libraries(gwb ${GWB_LIBRARY_WHOLE} ${Python_LIBRARIES})
     endif()
   endif()
-  
+
   set_target_properties(${TARGET} PROPERTIES PREFIX "_" OUTPUT_NAME "gwb")
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information see the [GWB site](https://geodynamicworldbuilder.github.io
 
 ## Frequently Asked Questions (FAQ)
 ### What are the minimum requirements to compile the library and tools?
-Currently, GWB requires only a C++14 compiler and CMake version higher than 2.8.12 to compile the library tools. Note that for some optional features (such as certain wrappers and unity build) a higher version of CMake and other dependencies may be needed (e.g., a Fortran compiler to compile the Fortran wrapper).
+Currently, GWB requires only a C++14 compiler and CMake version higher than 3.5 to compile the library tools. Note that for some optional features (such as certain wrappers and unity build) a higher version of CMake and other dependencies may be needed (e.g., a Fortran compiler to compile the Fortran wrapper).
 ### What do I do when I have a question or want to request a feature?
 If you have a question about the code and you can not find the answer easily in the documentation or the question is not already raised as an [issue](https://github.com/GeodynamicWorldBuilder/WorldBuilder/issues), please let us know by opening an [issue on github](https://github.com/GeodynamicWorldBuilder/WorldBuilder/issues/new). This is also the preferred method for asking for new features for GWB.
 
@@ -26,7 +26,7 @@ If you have a question about the code and you can not find the answer easily in 
 Please do not keep it to yourself and let us know. Others will also profit from mistakes being found and fixed. Even if it is just a typo in the documentation feel free to raise an issue or, even better, make a pull request to fix the issue.
 
 ### Is there a way to ask a quick question or chat with the developers or other users?
-We are now also experimenting with matrix chat ([#gwb:matrix.org](https://app.element.io/#/room/#gwb:matrix.org)). [Matrix](https://matrix.org) is an open source distributed chat protocol (a description of how to communicate). The matrix is not limited to one client, but using the [Element](https://element.io) client is generally recommended. Element can be used as a desktop, mobile or web application. Since the main developer is already present on matrix, a special space has been created for the World Builder allowing the option for multiple rooms. You can join the main room [here](https://app.element.io/#/room/#gwb:matrix.org). This is the easiest way since you can just open it in your browser. If you want to join the whole space in any client, use this link: [https://matrix.to/#/!vhukRUGUINnZOIutoQ:matrix.org](https://matrix.to/#/!vhukRUGUINnZOIutoQ:matrix.org). 
+We are now also experimenting with matrix chat ([#gwb:matrix.org](https://app.element.io/#/room/#gwb:matrix.org)). [Matrix](https://matrix.org) is an open source distributed chat protocol (a description of how to communicate). The matrix is not limited to one client, but using the [Element](https://element.io) client is generally recommended. Element can be used as a desktop, mobile or web application. Since the main developer is already present on matrix, a special space has been created for the World Builder allowing the option for multiple rooms. You can join the main room [here](https://app.element.io/#/room/#gwb:matrix.org). This is the easiest way since you can just open it in your browser. If you want to join the whole space in any client, use this link: [https://matrix.to/#/!vhukRUGUINnZOIutoQ:matrix.org](https://matrix.to/#/!vhukRUGUINnZOIutoQ:matrix.org).
 
 Feel free to join!
 
@@ -43,7 +43,7 @@ Menno Fraters and others. August 2024. The Geodynamic World Builder v1.0.0. Zeno
 
 ### How can I follow the progress of this project?
 There are multiple ways in which you can follow this project:
- 1. Watch the repository on github. This will give you an update of what is happening in the repository. This happens automatically and you can set it up to notify you for different kinds of events. 
+ 1. Watch the repository on github. This will give you an update of what is happening in the repository. This happens automatically and you can set it up to notify you for different kinds of events.
  2. Follow the [World Builder Mastodon account](https://social.mfraters.net/@world_builder). This is a manually updated feed which updates when there are new releases or major new features merged into the main branch. More general news related to the project may also be posted.
  3. Subscribe to the Mastodon RSS feed: https://social.mfraters.net/@world_builder.rss. This will show exactly the same information as the Mastodon account, but you can use any RSS reader.
  4. Visit the [World Builder website](https://geodynamicworldbuilder.github.io/). Besides all kinds of useful information and links, it also contains a RSS feed viewer for the World Builder Mastodon account.

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -386,7 +386,7 @@ namespace WorldBuilder
      * when determining the location with respect to the curved plane.
      * \param spline_x the spline representing the x coordinate.
      * \param spline_y the spline representing the y coordinate.
-     * \param global_x_list This is a list of one dimensional coorindates, with zero or the
+     * \param global_x_list This is a list of one dimensional coordindates, with zero or the
      * amount of coordinates entries, used for interpolation. An empty list is interpreted
      * as a list filled with {0,1,2,...,number of coordinates}. Filling this list with other
      * values changes the returned section fraction. It allows for, for example, adding

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -386,7 +386,7 @@ namespace WorldBuilder
      * when determining the location with respect to the curved plane.
      * \param spline_x the spline representing the x coordinate.
      * \param spline_y the spline representing the y coordinate.
-     * \param global_x_list This is a list of one dimensional coordindates, with zero or the
+     * \param global_x_list This is a list of one dimensional coordinates, with zero or the
      * amount of coordinates entries, used for interpolation. An empty list is interpreted
      * as a list filled with {0,1,2,...,number of coordinates}. Filling this list with other
      * values changes the returned section fraction. It allows for, for example, adding

--- a/source/world_builder/features/plume.cc
+++ b/source/world_builder/features/plume.cc
@@ -318,7 +318,7 @@ namespace WorldBuilder
                                                               rotation_angle,
                                                               surface_point);
 
-      // If we are in the tip, we have to compute the difference diffently:
+      // If we are in the tip, we have to compute the difference differently:
       if (depth >= min_depth && depth < depths.front())
         {
           const double a = semi_major_axis_lengths.front();


### PR DESCRIPTION
CMake 2.8 has been deprecated, resulting in failing build. Update to 3.5

```
> build % cmake . 
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
```