### PR TITLE
update ubuntu 20.04 tester.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -415,7 +415,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-20.04']
+        os: ['ubuntu-24.04']
         build_type: ['Debug']
 
     runs-on: ${{ matrix.os }}
@@ -596,7 +596,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-20.04']
+        os: ['ubuntu-24.04']
         build_type: ['Debug']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
ubuntu-20.04 is no longer available.