### PR TITLE
Revert dependabot github-actions script change to last working version.

### DIFF
--- a/.github/workflows/post_benchmark_results.yml
+++ b/.github/workflows/post_benchmark_results.yml
@@ -18,7 +18,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v3.1.0
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({


### PR DESCRIPTION
I noticed the benchmarking is not working anymore and that seems to have to do with the update of actions/github-script to v7.0.1. This pull request reverts it to the last version which worked. 