### PR TITLE
address suggestions by clang-tidy

### DIFF
--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -530,7 +530,10 @@ namespace WorldBuilder
     // start with adding the additional points with the default value
     // to do this we need the default value
     double default_value = 0;
-    enum InputTypes {DOUBLE_TYPE,ARRAY_TYPE,STRING_TYPE,MAX_INPUT_TYPES};
+    enum class InputTypes : uint8_t
+    {
+      DOUBLE_TYPE,ARRAY_TYPE,STRING_TYPE,MAX_INPUT_TYPES
+    };
     InputTypes input_type = InputTypes::MAX_INPUT_TYPES;
     if (Pointer((strict_base + "/" + name).c_str()).Get(parameters) != nullptr && Pointer((strict_base + "/" + name).c_str()).Get(parameters)->IsArray())
       {
@@ -722,7 +725,7 @@ namespace WorldBuilder
                 WBAssertThrow(coordinate_system->natural_coordinate_system() == CoordinateSystem::spherical,"The Litho1.0 data set is only available in spherical coordinates.");
                 constexpr int n_nodes = 40962;
                 constexpr int n_layers = 9;
-                enum LayerType
+                enum class LayerType : uint8_t
                 {
                   // ASTHENOSPHERE,
                   LITHOSPHERE,
@@ -2006,7 +2009,7 @@ namespace WorldBuilder
     unsigned int counter = 0;
     for (const auto &it : declare_map)
       {
-        typedef std::tuple<std::string,const WorldBuilder::Types::Interface &, std::string> DeclareEntry;
+        using DeclareEntry = std::tuple<std::string,const WorldBuilder::Types::Interface &, std::string>;
         // prevent infinite recursion
         if (it.first != parent_name)
           {

--- a/tests/unit_tests/unit_test_wb_glm.cc
+++ b/tests/unit_tests/unit_test_wb_glm.cc
@@ -87,7 +87,7 @@ compare_quaternions(
 
 TEST_CASE("glm quat basic functions")
 {
-  typedef glm::quaternion::quat QT;
+  using QT = glm::quaternion::quat;
   QT q1(2,3,4,5);
   QT const q2(6,7,8,9);
   QT const q3(9,8,7,6);

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -244,8 +244,8 @@ TEST_CASE("WorldBuilder Point: Testing initialize and operators")
   CHECK(p3.get_array() == std::array<double,3> {{4,8,12}});
 
   // Test dot operator
-  approval_tests.emplace_back(std::make_pair("",p2_array * p2_explicit));
-  approval_tests.emplace_back(std::make_pair("",p3_array * p3_explicit));
+  approval_tests.emplace_back("",p2_array * p2_explicit);
+  approval_tests.emplace_back("",p3_array * p3_explicit);
 
   // Test add operator
   p2 = p2 + p2;
@@ -274,15 +274,15 @@ TEST_CASE("WorldBuilder Point: Testing initialize and operators")
   CHECK(p3.get_array() == std::array<double,3> {{4,8,12}});
 
   // Test coordinate system
-  //approval_tests.emplace_back(std::make_pair("",p2.get_coordinate_system()));
-  //approval_tests.emplace_back(std::make_pair("",p3.get_coordinate_system()));
+  //approval_tests.emplace_back("",p2.get_coordinate_system());
+  //approval_tests.emplace_back("",p3.get_coordinate_system());
 
   // Test norm and norm_square
-  approval_tests.emplace_back(std::make_pair("",p2.norm_square()));
-  approval_tests.emplace_back(std::make_pair("",p3.norm_square()));
+  approval_tests.emplace_back("",p2.norm_square());
+  approval_tests.emplace_back("",p3.norm_square());
 
-  approval_tests.emplace_back(std::make_pair("",p2.norm()));
-  approval_tests.emplace_back(std::make_pair("",p3.norm()));
+  approval_tests.emplace_back("",p2.norm());
+  approval_tests.emplace_back("",p3.norm());
 
   // Test Point utility classes
   const std::array<double,2> an2 = Utilities::convert_point_to_array(p2_point);
@@ -369,65 +369,65 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   Utilities::interpolation monotone_cubic_spline;
   monotone_cubic_spline.set_points(y);
 
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(-1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(-0.9)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(-0.7)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(-0.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(-0.3)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(-0.1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(0)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(0.1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(0.3)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(0.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(0.7)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(0.9)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(1.1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(1.3)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(1.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(1.7)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(1.9)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.025)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.075)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.125)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.175)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.225)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.25)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.275)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.325)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.375)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.425)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.475)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.625)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.75)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(2.875)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(3)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(3.125)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline(3.25)));
+  approval_tests.emplace_back("",monotone_cubic_spline(-1));
+  approval_tests.emplace_back("",monotone_cubic_spline(-0.9));
+  approval_tests.emplace_back("",monotone_cubic_spline(-0.7));
+  approval_tests.emplace_back("",monotone_cubic_spline(-0.5));
+  approval_tests.emplace_back("",monotone_cubic_spline(-0.3));
+  approval_tests.emplace_back("",monotone_cubic_spline(-0.1));
+  approval_tests.emplace_back("",monotone_cubic_spline(0));
+  approval_tests.emplace_back("",monotone_cubic_spline(0.1));
+  approval_tests.emplace_back("",monotone_cubic_spline(0.3));
+  approval_tests.emplace_back("",monotone_cubic_spline(0.5));
+  approval_tests.emplace_back("",monotone_cubic_spline(0.7));
+  approval_tests.emplace_back("",monotone_cubic_spline(0.9));
+  approval_tests.emplace_back("",monotone_cubic_spline(1));
+  approval_tests.emplace_back("",monotone_cubic_spline(1.1));
+  approval_tests.emplace_back("",monotone_cubic_spline(1.3));
+  approval_tests.emplace_back("",monotone_cubic_spline(1.5));
+  approval_tests.emplace_back("",monotone_cubic_spline(1.7));
+  approval_tests.emplace_back("",monotone_cubic_spline(1.9));
+  approval_tests.emplace_back("",monotone_cubic_spline(2));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.025));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.075));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.125));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.175));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.225));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.25));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.275));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.325));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.375));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.425));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.475));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.5));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.625));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.75));
+  approval_tests.emplace_back("",monotone_cubic_spline(2.875));
+  approval_tests.emplace_back("",monotone_cubic_spline(3));
+  approval_tests.emplace_back("",monotone_cubic_spline(3.125));
+  approval_tests.emplace_back("",monotone_cubic_spline(3.25));
 
   Utilities::interpolation monotone_cubic_spline2;
   y[1] = -5;
   y[3] = -35;
   monotone_cubic_spline2.set_points(y);
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(-1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(-0.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(0)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(0.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(1.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(2)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(2.125) == Approx(3.828125)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(2.25)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(2.375) == Approx(-4.140625)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(2.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(2.625)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(2.75)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(2.875)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(3)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(3.125)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline2(3.25)));
+  approval_tests.emplace_back("",monotone_cubic_spline2(-1));
+  approval_tests.emplace_back("",monotone_cubic_spline2(-0.5));
+  approval_tests.emplace_back("",monotone_cubic_spline2(0));
+  approval_tests.emplace_back("",monotone_cubic_spline2(0.5));
+  approval_tests.emplace_back("",monotone_cubic_spline2(1));
+  approval_tests.emplace_back("",monotone_cubic_spline2(1.5));
+  approval_tests.emplace_back("",monotone_cubic_spline2(2));
+  approval_tests.emplace_back("",monotone_cubic_spline2(2.125) == Approx(3.828125));
+  approval_tests.emplace_back("",monotone_cubic_spline2(2.25));
+  approval_tests.emplace_back("",monotone_cubic_spline2(2.375) == Approx(-4.140625));
+  approval_tests.emplace_back("",monotone_cubic_spline2(2.5));
+  approval_tests.emplace_back("",monotone_cubic_spline2(2.625));
+  approval_tests.emplace_back("",monotone_cubic_spline2(2.75));
+  approval_tests.emplace_back("",monotone_cubic_spline2(2.875));
+  approval_tests.emplace_back("",monotone_cubic_spline2(3));
+  approval_tests.emplace_back("",monotone_cubic_spline2(3.125));
+  approval_tests.emplace_back("",monotone_cubic_spline2(3.25));
 
   Utilities::interpolation monotone_cubic_spline3;
   y[0] = 10;
@@ -435,23 +435,23 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   y[2] = -10;
   y[3] = -35;
   monotone_cubic_spline3.set_points(y);
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(-1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(-0.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(0)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(0.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(1.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(2)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(2.125)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(2.25) == Approx(-13.90625)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(2.375)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(2.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(2.625)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(2.75)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(2.875)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(3)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(3.125)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline3(3.25)));
+  approval_tests.emplace_back("",monotone_cubic_spline3(-1));
+  approval_tests.emplace_back("",monotone_cubic_spline3(-0.5));
+  approval_tests.emplace_back("",monotone_cubic_spline3(0));
+  approval_tests.emplace_back("",monotone_cubic_spline3(0.5));
+  approval_tests.emplace_back("",monotone_cubic_spline3(1));
+  approval_tests.emplace_back("",monotone_cubic_spline3(1.5));
+  approval_tests.emplace_back("",monotone_cubic_spline3(2));
+  approval_tests.emplace_back("",monotone_cubic_spline3(2.125));
+  approval_tests.emplace_back("",monotone_cubic_spline3(2.25) == Approx(-13.90625));
+  approval_tests.emplace_back("",monotone_cubic_spline3(2.375));
+  approval_tests.emplace_back("",monotone_cubic_spline3(2.5));
+  approval_tests.emplace_back("",monotone_cubic_spline3(2.625));
+  approval_tests.emplace_back("",monotone_cubic_spline3(2.75));
+  approval_tests.emplace_back("",monotone_cubic_spline3(2.875));
+  approval_tests.emplace_back("",monotone_cubic_spline3(3));
+  approval_tests.emplace_back("",monotone_cubic_spline3(3.125));
+  approval_tests.emplace_back("",monotone_cubic_spline3(3.25));
 
   // bi monotone cubic spline
   Utilities::interpolation monotone_cubic_spline_x;
@@ -471,33 +471,33 @@ TEST_CASE("WorldBuilder Utilities: interpolation")
   y[3] = 10;
   monotone_cubic_spline_y.set_points(y);
 
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(0)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(0.25)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(0.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(0.75)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(1.25) == Approx(9.453125)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(1.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(1.75)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(2)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(2.25)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(2.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(2.75)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_x(3)));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(0));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(0.25));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(0.5));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(0.75));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(1));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(1.25) == Approx(9.453125));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(1.5));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(1.75));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(2));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(2.25));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(2.5));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(2.75));
+  approval_tests.emplace_back("",monotone_cubic_spline_x(3));
 
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(0)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(0.25)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(0.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(0.75) == Approx(3.515625)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(1)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(1.25)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(1.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(1.75) == Approx(9.453125)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(2)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(2.25)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(2.5)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(2.75)));
-  approval_tests.emplace_back(std::make_pair("",monotone_cubic_spline_y(3)));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(0));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(0.25));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(0.5));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(0.75) == Approx(3.515625));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(1));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(1.25));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(1.5));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(1.75) == Approx(9.453125));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(2));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(2.25));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(2.5));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(2.75));
+  approval_tests.emplace_back("",monotone_cubic_spline_y(3));
 
   std::vector<std::string> approvals;
   for (auto&& value : approval_tests)
@@ -589,12 +589,12 @@ TEST_CASE("WorldBuilder Utilities: Natural Coordinate")
   const Objects::NaturalCoordinate nca1(std::array<double,3> {{1,2,3}},*cartesian);
   CHECK(nca1.get_coordinates() == std::array<double,3> {{1,2,3}});
   CHECK(nca1.get_surface_coordinates() == std::array<double,2> {{1,2}});
-  approval_tests.emplace_back(std::make_pair("",nca1.get_depth_coordinate()));
+  approval_tests.emplace_back("",nca1.get_depth_coordinate());
 
   const Objects::NaturalCoordinate ncp1(Point<3>(1,2,3,CoordinateSystem::cartesian),*cartesian);
   CHECK(ncp1.get_coordinates() == std::array<double,3> {{1,2,3}});
   CHECK(ncp1.get_surface_coordinates() == std::array<double,2> {{1,2}});
-  approval_tests.emplace_back(std::make_pair("",ncp1.get_depth_coordinate()));
+  approval_tests.emplace_back("",ncp1.get_depth_coordinate());
 
 
   const std::unique_ptr<CoordinateSystems::Interface> spherical(CoordinateSystems::Interface::create("spherical",nullptr));
@@ -602,24 +602,24 @@ TEST_CASE("WorldBuilder Utilities: Natural Coordinate")
   // Test the natural coordinate system
   const Objects::NaturalCoordinate nsa1(std::array<double,3> {{1,2,3}},*spherical);
   std::array<double,3> nsa1_array = nsa1.get_coordinates();
-  approval_tests.emplace_back(std::make_pair("",nsa1_array[0]));
-  approval_tests.emplace_back(std::make_pair("",nsa1_array[1]));
-  approval_tests.emplace_back(std::make_pair("",nsa1_array[2]));
+  approval_tests.emplace_back("",nsa1_array[0]);
+  approval_tests.emplace_back("",nsa1_array[1]);
+  approval_tests.emplace_back("",nsa1_array[2]);
   std::array<double,2> nsa1_surface_array = nsa1.get_surface_coordinates();
-  approval_tests.emplace_back(std::make_pair("",nsa1_surface_array[0]));
-  approval_tests.emplace_back(std::make_pair("",nsa1_surface_array[1]));
-  approval_tests.emplace_back(std::make_pair("",nsa1.get_depth_coordinate()));
+  approval_tests.emplace_back("",nsa1_surface_array[0]);
+  approval_tests.emplace_back("",nsa1_surface_array[1]);
+  approval_tests.emplace_back("",nsa1.get_depth_coordinate());
 
 
   const Objects::NaturalCoordinate nsp1(Point<3>(1,2,3,CoordinateSystem::spherical),*spherical);
   std::array<double,3> nsp1_array = nsp1.get_coordinates();
-  approval_tests.emplace_back(std::make_pair("",nsp1_array[0]));
-  approval_tests.emplace_back(std::make_pair("",nsp1_array[1]));
-  approval_tests.emplace_back(std::make_pair("",nsp1_array[2]));
+  approval_tests.emplace_back("",nsp1_array[0]);
+  approval_tests.emplace_back("",nsp1_array[1]);
+  approval_tests.emplace_back("",nsp1_array[2]);
   std::array<double,2> nsp1_surface_array = nsp1.get_surface_coordinates();
-  approval_tests.emplace_back(std::make_pair("",nsp1_surface_array[0]));
-  approval_tests.emplace_back(std::make_pair("",nsp1_surface_array[1]));
-  approval_tests.emplace_back(std::make_pair("",nsp1.get_depth_coordinate()));
+  approval_tests.emplace_back("",nsp1_surface_array[0]);
+  approval_tests.emplace_back("",nsp1_surface_array[1]);
+  approval_tests.emplace_back("",nsp1.get_depth_coordinate());
 
   // Invalid tests
   const std::string file_name = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/subducting_plate_different_angles_cartesian.wb";
@@ -639,7 +639,7 @@ TEST_CASE("WorldBuilder Utilities: Natural Coordinate")
   CHECK_THROWS_WITH(ivp1.get_ref_depth_coordinate(),Contains("Coordinate system not implemented."));
   CHECK(std::isnan(invalid->distance_between_points_at_same_depth(Point<3>(1,2,3,CoordinateSystem::invalid),
                                                                   Point<3>(1,2,3,CoordinateSystem::invalid))));
-  approval_tests.emplace_back(std::make_pair("",invalid->depth_method()));
+  approval_tests.emplace_back("",invalid->depth_method());
 
   std::array<double,3> iv_array = invalid->natural_to_cartesian_coordinates({{1,2,3}});
   CHECK(std::isnan(iv_array[0]));
@@ -688,9 +688,9 @@ TEST_CASE("WorldBuilder Utilities: Coordinate systems transformations")
 
     const Point<3> cartesian_back(Utilities::spherical_to_cartesian_coordinates(spherical.get_array()), CoordinateSystem::cartesian);
 
-    approval_tests.emplace_back(std::make_pair("",cartesian_back.get_array()[0]));
-    approval_tests.emplace_back(std::make_pair("",cartesian_back.get_array()[1]));
-    approval_tests.emplace_back(std::make_pair("",cartesian_back.get_array()[2]));
+    approval_tests.emplace_back("",cartesian_back.get_array()[0]);
+    approval_tests.emplace_back("",cartesian_back.get_array()[1]);
+    approval_tests.emplace_back("",cartesian_back.get_array()[2]);
   }
 
 
@@ -776,7 +776,7 @@ TEST_CASE("WorldBuilder C wrapper")
   }
 
   temperature_2d(*ptr_ptr_world, 1, 2, 0, &temperature);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
   {
     unsigned int properties[1][3] = {{1,0,0}};
     double values[1];
@@ -786,7 +786,7 @@ TEST_CASE("WorldBuilder C wrapper")
   }
 
   temperature_3d(*ptr_ptr_world, 1, 2, 3, 0, &temperature);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
   {
     unsigned int properties[1][3] = {{1,0,0}};
     double values[1];
@@ -796,7 +796,7 @@ TEST_CASE("WorldBuilder C wrapper")
   }
 
   temperature_2d(*ptr_ptr_world, 550e3, 0, 0, &temperature);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
   {
     unsigned int properties[1][3] = {{1,0,0}};
     double values[1];
@@ -806,7 +806,7 @@ TEST_CASE("WorldBuilder C wrapper")
   }
 
   temperature_3d(*ptr_ptr_world, 120e3, 500e3, 0, 0, &temperature);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
   {
     unsigned int properties[1][3] = {{1,0,0}};
     double values[1];
@@ -819,7 +819,7 @@ TEST_CASE("WorldBuilder C wrapper")
   double composition = 0.0;
 
   composition_2d(*ptr_ptr_world, 1, 2, 0, 2, &composition);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
   {
     unsigned int properties[1][3] = {{2,2,0}};
     double values[1];
@@ -829,7 +829,7 @@ TEST_CASE("WorldBuilder C wrapper")
   }
 
   composition_3d(*ptr_ptr_world, 1, 2, 3, 0, 2, &composition);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
   {
     unsigned int properties[1][3] = {{2,2,0}};
     double values[1];
@@ -839,7 +839,7 @@ TEST_CASE("WorldBuilder C wrapper")
   }
 
   composition_2d(*ptr_ptr_world,  550e3, 0, 0, 3, &composition);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
   {
     unsigned int properties[1][3] = {{2,3,0}};
     double values[1];
@@ -849,7 +849,7 @@ TEST_CASE("WorldBuilder C wrapper")
   }
 
   composition_3d(*ptr_ptr_world, 120e3, 500e3, 0, 0, 3, &composition);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
   {
     unsigned int properties[1][3] = {{2,3,0}};
     double values[1];
@@ -875,10 +875,10 @@ TEST_CASE("WorldBuilder C wrapper")
                              "variable in the world builder file has been set. Dim is 3."));
 
   temperature_3d(*ptr_ptr_world, 1, 2, 3, 0, &temperature);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
 
   temperature_3d(*ptr_ptr_world, 120e3, 500e3, 0, 0, &temperature);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
   {
     unsigned int properties[1][3] = {{1,0,0}};
     double values[1];
@@ -892,10 +892,10 @@ TEST_CASE("WorldBuilder C wrapper")
                              "variable in the world builder file has been set. Dim is 3."));
 
   composition_3d(*ptr_ptr_world, 1, 2, 3, 0, 2, &composition);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
 
   composition_3d(*ptr_ptr_world, 120e3, 500e3, 0, 0, 3, &composition);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
   {
     unsigned int properties[1][3] = {{2,3,0}};
     double values[1];
@@ -927,25 +927,25 @@ TEST_CASE("WorldBuilder CPP wrapper")
   double temperature = 0;
 
   temperature = world.temperature_2d(1, 2, 0);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
   temperature = world.temperature_3d(1, 2, 3, 0);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
   temperature = world.temperature_2d(550e3, 0, 0);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
   temperature = world.temperature_3d(120e3, 500e3, 0, 0);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
 
   // Test the compositions
   double composition = 0.0;
 
   composition = world.composition_2d(1, 2, 0, 2);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
   composition = world.composition_3d(1, 2, 3, 0, 2);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
   composition = world.composition_2d(550e3, 0, 0, 3);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
   composition = world.composition_3d(120e3, 500e3, 0, 0, 3);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
 
 
   // Now test a world builder file without a cross section defined
@@ -958,9 +958,9 @@ TEST_CASE("WorldBuilder CPP wrapper")
                     Contains("This function can only be called when the cross section "
                              "variable in the world builder file has been set. Dim is 3."));
   temperature = world2.temperature_3d(1, 2, 3, 0);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
   temperature = world2.temperature_3d(120e3, 500e3, 0, 0);
-  approval_tests.emplace_back(std::make_pair("",temperature));
+  approval_tests.emplace_back("",temperature);
 
   // Test the compositions
   CHECK_THROWS_WITH(world2.composition_2d(1, 2, 0, 2),
@@ -968,9 +968,9 @@ TEST_CASE("WorldBuilder CPP wrapper")
                              "variable in the world builder file has been set. Dim is 3."));
 
   composition = world2.composition_3d(1, 2, 3, 0, 2);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
   composition = world2.composition_3d(120e3, 500e3, 0, 0, 3);
-  approval_tests.emplace_back(std::make_pair("",composition));
+  approval_tests.emplace_back("",composition);
 
 
   std::vector<std::string> approvals;
@@ -1024,8 +1024,8 @@ TEST_CASE("WorldBuilder interface")
   properties = {{{{1,0,0}},{{2,0,0}},{{2,1,0}},{{3,0,15}},{{3,1,15}},{{4,0,0}},{{5,0,0}}}};
   CHECK(world.properties_output_size(properties) == world.properties({{1,2,3}},1., properties).size());
 
-  approval_tests_grains.emplace_back(std::make_pair("",world.grains(std::array<double,3> {{750e3,250e3,100e3}},10e3,0,3)));
-  approval_tests_grains.emplace_back(std::make_pair("",world.grains(std::array<double,2> {{750e3,100e3}},10e3,0,3)));
+  approval_tests_grains.emplace_back("",world.grains(std::array<double,3> {{750e3,250e3,100e3}},10e3,0,3));
+  approval_tests_grains.emplace_back("",world.grains(std::array<double,2> {{750e3,100e3}},10e3,0,3));
 
   std::vector<std::string> approvals;
   for (auto&& value : approval_tests_grains)
@@ -1060,25 +1060,25 @@ TEST_CASE("WorldBuilder World random")
   const std::string file_name = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/oceanic_plate_spherical.wb";
   WorldBuilder::World world1(file_name, false, "", 1);
   // same result as https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine/seed
-  approval_tests.emplace_back(std::make_pair("",world1.get_random_number_engine()()));
-  approval_tests.emplace_back(std::make_pair("",world1.get_random_number_engine()()));
+  approval_tests.emplace_back("",world1.get_random_number_engine()());
+  approval_tests.emplace_back("",world1.get_random_number_engine()());
   std::uniform_real_distribution<> dist(1.0,2.0);
-  approval_tests.emplace_back(std::make_pair("",dist(world1.get_random_number_engine())));
-  approval_tests.emplace_back(std::make_pair("",dist(world1.get_random_number_engine())));
+  approval_tests.emplace_back("",dist(world1.get_random_number_engine()));
+  approval_tests.emplace_back("",dist(world1.get_random_number_engine()));
 
   // test whether the seed indeed changes the results
   WorldBuilder::World world2(file_name, false, "", 2);
-  approval_tests.emplace_back(std::make_pair("",world2.get_random_number_engine()()));
-  approval_tests.emplace_back(std::make_pair("",world2.get_random_number_engine()()));
-  approval_tests.emplace_back(std::make_pair("",dist(world2.get_random_number_engine())));
-  approval_tests.emplace_back(std::make_pair("",dist(world2.get_random_number_engine())));
+  approval_tests.emplace_back("",world2.get_random_number_engine()());
+  approval_tests.emplace_back("",world2.get_random_number_engine()());
+  approval_tests.emplace_back("",dist(world2.get_random_number_engine()));
+  approval_tests.emplace_back("",dist(world2.get_random_number_engine()));
 
   // Test reproducibility with the same seed.
   WorldBuilder::World world3(file_name, false, "", 1);
-  approval_tests.emplace_back(std::make_pair("",world3.get_random_number_engine()()));
-  approval_tests.emplace_back(std::make_pair("",world3.get_random_number_engine()()));
-  approval_tests.emplace_back(std::make_pair("",dist(world3.get_random_number_engine())));
-  approval_tests.emplace_back(std::make_pair("",dist(world3.get_random_number_engine())));
+  approval_tests.emplace_back("",world3.get_random_number_engine()());
+  approval_tests.emplace_back("",world3.get_random_number_engine()());
+  approval_tests.emplace_back("",dist(world3.get_random_number_engine()));
+  approval_tests.emplace_back("",dist(world3.get_random_number_engine()));
 
 
   std::vector<std::string> approvals;
@@ -1109,7 +1109,7 @@ TEST_CASE("WorldBuilder Coordinate Systems: Interface")
   CHECK(interface->cartesian_to_natural_coordinates(std::array<double,3> {{1,2,3}}) == std::array<double,3> {{1,2,3}});
   CHECK(interface->natural_to_cartesian_coordinates(std::array<double,3> {{1,2,3}}) == std::array<double,3> {{1,2,3}});
 
-  approval_tests.emplace_back(std::make_pair("",interface->natural_coordinate_system()));
+  approval_tests.emplace_back("",interface->natural_coordinate_system());
 
 
   std::vector<std::string> approvals;
@@ -1134,7 +1134,7 @@ TEST_CASE("WorldBuilder Coordinate Systems: Cartesian")
   CHECK(cartesian->cartesian_to_natural_coordinates(std::array<double,3> {{1,2,3}}) == std::array<double,3> {{1,2,3}});
   CHECK(cartesian->natural_to_cartesian_coordinates(std::array<double,3> {{1,2,3}}) == std::array<double,3> {{1,2,3}});
 
-  approval_tests.emplace_back(std::make_pair("",cartesian->natural_coordinate_system()));
+  approval_tests.emplace_back("",cartesian->natural_coordinate_system());
 
   // distance between two points at the same depth
   const Point<3> point_1(0.0,0.0,10.0, CoordinateSystem::cartesian);
@@ -1142,9 +1142,9 @@ TEST_CASE("WorldBuilder Coordinate Systems: Cartesian")
   const Point<3> point_3(3.0,2.0,10.0, CoordinateSystem::cartesian);
   const Point<3> point_4(3.0,3.0,10.0, CoordinateSystem::cartesian);
 
-  approval_tests.emplace_back(std::make_pair("",cartesian->distance_between_points_at_same_depth(point_1, point_2)));
-  approval_tests.emplace_back(std::make_pair("",cartesian->distance_between_points_at_same_depth(point_2, point_3)));
-  approval_tests.emplace_back(std::make_pair("",cartesian->distance_between_points_at_same_depth(point_2, point_4)));
+  approval_tests.emplace_back("",cartesian->distance_between_points_at_same_depth(point_1, point_2));
+  approval_tests.emplace_back("",cartesian->distance_between_points_at_same_depth(point_2, point_3));
+  approval_tests.emplace_back("",cartesian->distance_between_points_at_same_depth(point_2, point_4));
 
 
   std::vector<std::string> approvals;
@@ -1179,15 +1179,15 @@ TEST_CASE("WorldBuilder Coordinate Systems: Spherical")
   world.parameters.leave_subsection();
 
   std::array<double,3> spherical_array = spherical->cartesian_to_natural_coordinates(std::array<double,3> {{1,2,3}});
-  approval_tests.emplace_back(std::make_pair("",spherical_array[0]));
-  approval_tests.emplace_back(std::make_pair("",spherical_array[1]));
-  approval_tests.emplace_back(std::make_pair("",spherical_array[2]));
+  approval_tests.emplace_back("",spherical_array[0]);
+  approval_tests.emplace_back("",spherical_array[1]);
+  approval_tests.emplace_back("",spherical_array[2]);
   std::array<double,3> cartesian_array = spherical->natural_to_cartesian_coordinates(std::array<double,3> {{std::sqrt(1.0 * 1.0 + 2.0 * 2.0 + 3.0 * 3.0),1.1071487178,0.9302740141}});
-  approval_tests.emplace_back(std::make_pair("",cartesian_array[0]));
-  approval_tests.emplace_back(std::make_pair("",cartesian_array[1]));
-  approval_tests.emplace_back(std::make_pair("",cartesian_array[2]));
+  approval_tests.emplace_back("",cartesian_array[0]);
+  approval_tests.emplace_back("",cartesian_array[1]);
+  approval_tests.emplace_back("",cartesian_array[2]);
 
-  approval_tests.emplace_back(std::make_pair("",spherical->natural_coordinate_system()));
+  approval_tests.emplace_back("",spherical->natural_coordinate_system());
 
   // distance between two points at the same depth
   const double dtr = Consts::PI / 180.0;
@@ -1200,13 +1200,13 @@ TEST_CASE("WorldBuilder Coordinate Systems: Spherical")
   const Point<3> unit_point_6(1.0, -90.0 * dtr, 0.0 * dtr, CoordinateSystem::spherical);
   const Point<3> unit_point_7(1.0, 90.0 * dtr, 180.0 * dtr, CoordinateSystem::spherical);
 
-  approval_tests.emplace_back(std::make_pair("",spherical->distance_between_points_at_same_depth(unit_point_1, unit_point_2)));
-  approval_tests.emplace_back(std::make_pair("",spherical->distance_between_points_at_same_depth(unit_point_1, unit_point_3)));
+  approval_tests.emplace_back("",spherical->distance_between_points_at_same_depth(unit_point_1, unit_point_2));
+  approval_tests.emplace_back("",spherical->distance_between_points_at_same_depth(unit_point_1, unit_point_3));
   CHECK(spherical->distance_between_points_at_same_depth(unit_point_1, unit_point_4) ==
         Approx(std::acos(std::sin(0) * std::sin(1*dtr) +
                          std::cos(0) * std::cos(1*dtr) * std::cos(1*dtr))));
-  approval_tests.emplace_back(std::make_pair("",spherical->distance_between_points_at_same_depth(unit_point_1, unit_point_5)));
-  approval_tests.emplace_back(std::make_pair("",spherical->distance_between_points_at_same_depth(unit_point_6, unit_point_7)));
+  approval_tests.emplace_back("",spherical->distance_between_points_at_same_depth(unit_point_1, unit_point_5));
+  approval_tests.emplace_back("",spherical->distance_between_points_at_same_depth(unit_point_6, unit_point_7));
 
   // secondly check non-unit radius
   const Point<3> point_1(10.0, 0.0 * dtr, 0.0 * dtr, CoordinateSystem::spherical);
@@ -1217,13 +1217,13 @@ TEST_CASE("WorldBuilder Coordinate Systems: Spherical")
   const Point<3> point_6(10.0, -90.0 * dtr, 0.0 * dtr, CoordinateSystem::spherical);
   const Point<3> point_7(10.0, 90.0 * dtr, 180.0 * dtr, CoordinateSystem::spherical);
 
-  approval_tests.emplace_back(std::make_pair("",spherical->distance_between_points_at_same_depth(point_1, point_2)));
-  approval_tests.emplace_back(std::make_pair("",spherical->distance_between_points_at_same_depth(point_1, point_3)));
+  approval_tests.emplace_back("",spherical->distance_between_points_at_same_depth(point_1, point_2));
+  approval_tests.emplace_back("",spherical->distance_between_points_at_same_depth(point_1, point_3));
   CHECK(spherical->distance_between_points_at_same_depth(point_1, point_4) ==
         Approx(10 * std::acos(std::sin(0) * std::sin(1*dtr) +
                               std::cos(0) * std::cos(1*dtr) * std::cos(1*dtr))));
-  approval_tests.emplace_back(std::make_pair("",spherical->distance_between_points_at_same_depth(point_1, point_5)));
-  approval_tests.emplace_back(std::make_pair("",spherical->distance_between_points_at_same_depth(point_6, point_7)));
+  approval_tests.emplace_back("",spherical->distance_between_points_at_same_depth(point_1, point_5));
+  approval_tests.emplace_back("",spherical->distance_between_points_at_same_depth(point_6, point_7));
 
 
   std::vector<std::string> approvals;
@@ -1267,18 +1267,18 @@ TEST_CASE("WorldBuilder Features: Distance to Feature Plane")
     const std::array<double, 3> point1 = {{250e3,495e3,800e3}};
     const double depth1 = 5.1e3;
     auto plane_distances1 = world1.distance_to_plane(point1, depth1, "First subducting plate");
-    approval_tests.emplace_back(std::make_pair("",plane_distances1.get_distance_from_surface()));
-    approval_tests.emplace_back(std::make_pair("",plane_distances1.get_distance_along_surface()));
+    approval_tests.emplace_back("",plane_distances1.get_distance_from_surface());
+    approval_tests.emplace_back("",plane_distances1.get_distance_along_surface());
     const std::array<double, 3> point2 = {{502e3,500e3,800e3}};
     const double depth2 = 0.45e3;
     auto plane_distances2 = world1.distance_to_plane(point2, depth2, "First subducting plate");
-    approval_tests.emplace_back(std::make_pair("",plane_distances2.get_distance_from_surface()));
-    approval_tests.emplace_back(std::make_pair("",plane_distances2.get_distance_along_surface()));
+    approval_tests.emplace_back("",plane_distances2.get_distance_from_surface());
+    approval_tests.emplace_back("",plane_distances2.get_distance_along_surface());
     const std::array<double, 3> point3 = {{502e3,500e3,800e3}}; // point 3, shallower than point2, thus distance from plane = inf
     const double depth3 = 0.43e3;
     auto plane_distances3 = world1.distance_to_plane(point3, depth3, "First subducting plate");
-    approval_tests.emplace_back(std::make_pair("",plane_distances3.get_distance_from_surface()));
-    approval_tests.emplace_back(std::make_pair("",plane_distances3.get_distance_along_surface()));
+    approval_tests.emplace_back("",plane_distances3.get_distance_from_surface());
+    approval_tests.emplace_back("",plane_distances3.get_distance_along_surface());
 
   }
 
@@ -1296,18 +1296,18 @@ TEST_CASE("WorldBuilder Features: Distance to Feature Plane")
     const std::array<double, 3> point1 = {{250e3,495e3,800e3}};
     const double depth1 = 5.1e3;
     auto plane_distances1 = world2.distance_to_plane(point1, depth1, "First fault");
-    approval_tests.emplace_back(std::make_pair("",plane_distances1.get_distance_from_surface()));
-    approval_tests.emplace_back(std::make_pair("",plane_distances1.get_distance_along_surface()));
+    approval_tests.emplace_back("",plane_distances1.get_distance_from_surface());
+    approval_tests.emplace_back("",plane_distances1.get_distance_along_surface());
     const std::array<double, 3> point2 = {{502e3,500e3,800e3}};
     const double depth2 = 0.45e3;
     auto plane_distances2 = world2.distance_to_plane(point2, depth2, "First fault");
-    approval_tests.emplace_back(std::make_pair("",plane_distances2.get_distance_from_surface()));
-    approval_tests.emplace_back(std::make_pair("",plane_distances2.get_distance_along_surface()));
+    approval_tests.emplace_back("",plane_distances2.get_distance_from_surface());
+    approval_tests.emplace_back("",plane_distances2.get_distance_along_surface());
     const std::array<double, 3> point3 = {{502e3,500e3,800e3}}; // point 3, shallower than point2, thus distance from plane = inf
     const double depth3 = 0.43e3;
     auto plane_distances3 = world2.distance_to_plane(point3, depth3, "First fault");
-    approval_tests.emplace_back(std::make_pair("",plane_distances3.get_distance_from_surface()));
-    approval_tests.emplace_back(std::make_pair("",plane_distances3.get_distance_along_surface()));
+    approval_tests.emplace_back("",plane_distances3.get_distance_from_surface());
+    approval_tests.emplace_back("",plane_distances3.get_distance_along_surface());
 
 
     std::vector<std::string> approvals;
@@ -1348,210 +1348,210 @@ TEST_CASE("WorldBuilder Features: Continental Plate")
 
   // Check continental plate through the world
   std::array<double,3> position = {{0,0,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
 
   // the feature with composition 3
   position = {{250e3,500e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 74e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 76e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 149e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 151e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 224e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 226e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 74e3));
+  approval_tests.emplace_back("",world1.temperature(position, 76e3));
+  approval_tests.emplace_back("",world1.temperature(position, 149e3));
+  approval_tests.emplace_back("",world1.temperature(position, 151e3));
+  approval_tests.emplace_back("",world1.temperature(position, 224e3));
+  approval_tests.emplace_back("",world1.temperature(position, 226e3));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 5)));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 5));
 
   // check grains
   {
     const WorldBuilder::grains grains = world1.grains(position, 0, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   // the feature with composition 2
   position = {{1500e3,1500e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 5)));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 5));
 
   // check grains
   {
     const WorldBuilder::grains grains = world1.grains(position, 0, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   position = {{250e3,1750e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 5)));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 5));
 
   position = {{750e3,250e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 5)));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 5));
 
   // check grains layer 1
   {
     const WorldBuilder::grains grains = world1.grains(position, 0, 0, 2);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   // check grains layer 2
   {
     const WorldBuilder::grains grains = world1.grains(position, 150e3, 0, 2);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
 
   }
 
   // the constant layers test
   position = {{1500e3,250e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 249.5e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 1));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("",world1.temperature(position, 249.5e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3, 8)));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
+  approval_tests.emplace_back("",world1.composition(position, 0, 7));
+  approval_tests.emplace_back("",world1.composition(position, 0, 8));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1, 5));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1, 6));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1, 7));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1, 8));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1, 5));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1, 6));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1, 7));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1, 8));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1, 5));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1, 6));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1, 7));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1, 8));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1, 5));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1, 6));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1, 7));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1, 8));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 7));
+  approval_tests.emplace_back("",world1.composition(position, 240e3, 8));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 7));
+  approval_tests.emplace_back("",world1.composition(position, 260e3, 8));
 
 
   std::vector<std::string> approvals;
@@ -1594,210 +1594,210 @@ TEST_CASE("WorldBuilder Features: Mantle layer")
   }
   // Check continental plate through the world
   std::array<double,3> position = {{0,0,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
 
   position = {{250e3,501e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0+100e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3+100e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3+100e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0+100e3));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3+100e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3+100e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+200e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+200e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+200e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+200e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+200e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+200e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+200e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+200e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+200e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+200e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+200e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+200e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+200e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+200e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+200e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+200e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+200e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+200e3, 5)));
+  approval_tests.emplace_back("",world1.composition(position, 0+200e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0+200e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0+200e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0+200e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0+200e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0+200e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+200e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+200e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+200e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+200e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+200e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+200e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+200e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+200e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+200e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+200e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+200e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+200e3, 5));
 
   // check grains
   {
     const WorldBuilder::grains grains = world1.grains(position, 200e3, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   position = {{1500e3,1500e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0+150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3+150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3+150e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0+150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3+150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3+150e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+150e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+150e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+150e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+150e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+150e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+150e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+150e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+150e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+150e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+150e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+150e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+150e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+150e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+150e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+150e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+150e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+150e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+150e3, 5)));
+  approval_tests.emplace_back("",world1.composition(position, 0+150e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0+150e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0+150e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0+150e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0+150e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0+150e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+150e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+150e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+150e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+150e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+150e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+150e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+150e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+150e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+150e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+150e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+150e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+150e3, 5));
 
   // check grains
   {
     const WorldBuilder::grains grains = world1.grains(position, 150e3, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   position = {{250e3,1750e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0+250e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3+250e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3+250e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0+250e3));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3+250e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3+250e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+250e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+250e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+250e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+250e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+250e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+250e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+250e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+250e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+250e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+250e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+250e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+250e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+250e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+250e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+250e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+250e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+250e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+250e3, 5)));
+  approval_tests.emplace_back("",world1.composition(position, 0+250e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0+250e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0+250e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0+250e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0+250e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0+250e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+250e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+250e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+250e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+250e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+250e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+250e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+250e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+250e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+250e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+250e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+250e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+250e3, 5));
 
   position = {{750e3,250e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0+300e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 95e3+300e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 105e3+300e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 145e3+300e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 155e3+300e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3+300e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0+300e3));
+  approval_tests.emplace_back("",world1.temperature(position, 95e3+300e3));
+  approval_tests.emplace_back("",world1.temperature(position, 105e3+300e3));
+  approval_tests.emplace_back("",world1.temperature(position, 145e3+300e3));
+  approval_tests.emplace_back("",world1.temperature(position, 155e3+300e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3+300e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+300e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+300e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+300e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+300e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+300e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+300e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+300e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+300e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+300e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+300e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+300e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+300e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+300e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+300e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+300e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+300e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+300e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+300e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+300e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+300e3, 5)));
+  approval_tests.emplace_back("",world1.composition(position, 0+300e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0+300e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0+300e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0+300e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0+300e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0+300e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0+300e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+300e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+300e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+300e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+300e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+300e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+300e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+300e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+300e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+300e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+300e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+300e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+300e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+300e3, 5));
 
   // check grains layer 1
   {
     const WorldBuilder::grains grains = world1.grains(position, 0+300e3, 0, 2);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   // check grains layer 2
   {
     const WorldBuilder::grains grains = world1.grains(position, 150e3+300e3, 0, 2);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
 
   }
 
   // the constant layers test
   position = {{1500e3,250e3,0}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0+350e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3+350e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3+350e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0+350e3));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3+350e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3+350e3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0+350e3, 9)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3-1+350e3, 9)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 75e3+1+350e3, 9)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3-1+350e3, 9)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3+1+350e3, 9)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 240e3+350e3, 9)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 6)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 7)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 8)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 260e3+350e3, 9)));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 7));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 8));
+  approval_tests.emplace_back("",world1.composition(position, 0+350e3, 9));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 7));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 8));
+  approval_tests.emplace_back("",world1.composition(position, 75e3-1+350e3, 9));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 7));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 8));
+  approval_tests.emplace_back("",world1.composition(position, 75e3+1+350e3, 9));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 7));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 8));
+  approval_tests.emplace_back("",world1.composition(position, 150e3-1+350e3, 9));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 7));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 8));
+  approval_tests.emplace_back("",world1.composition(position, 150e3+1+350e3, 9));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 7));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 8));
+  approval_tests.emplace_back("",world1.composition(position, 240e3+350e3, 9));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 5));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 6));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 7));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 8));
+  approval_tests.emplace_back("",world1.composition(position, 260e3+350e3, 9));
 
   std::vector<std::string> approvals;
   for (auto&& value : approval_tests)
@@ -1843,192 +1843,192 @@ TEST_CASE("WorldBuilder Features: Oceanic Plate")
   // Check continental plate through the world
   // 2d
   std::array<double,2> position_2d = {{0,0}};
-  approval_tests.emplace_back(std::make_pair("1",world1.temperature(position_2d, 0)));
-  approval_tests.emplace_back(std::make_pair("2",world1.temperature(position_2d, 240e3)));
-  approval_tests.emplace_back(std::make_pair("3",world1.temperature(position_2d, 260e3)));
-  approval_tests.emplace_back(std::make_pair("4",world1.composition(position_2d, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("5",world1.composition(position_2d, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("6",world1.composition(position_2d, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("7",world1.composition(position_2d, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("8",world1.composition(position_2d, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("9",world1.composition(position_2d, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("10",world1.composition(position_2d, 0, 6)));
+  approval_tests.emplace_back("1",world1.temperature(position_2d, 0));
+  approval_tests.emplace_back("2",world1.temperature(position_2d, 240e3));
+  approval_tests.emplace_back("3",world1.temperature(position_2d, 260e3));
+  approval_tests.emplace_back("4",world1.composition(position_2d, 0, 0));
+  approval_tests.emplace_back("5",world1.composition(position_2d, 0, 1));
+  approval_tests.emplace_back("6",world1.composition(position_2d, 0, 2));
+  approval_tests.emplace_back("7",world1.composition(position_2d, 0, 3));
+  approval_tests.emplace_back("8",world1.composition(position_2d, 0, 4));
+  approval_tests.emplace_back("9",world1.composition(position_2d, 0, 5));
+  approval_tests.emplace_back("10",world1.composition(position_2d, 0, 6));
   // 3d
   std::array<double,3> position = {{0,0,0}};
-  approval_tests.emplace_back(std::make_pair("11",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("12",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("13",world1.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("14",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("15",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("16",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("17",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("18",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("19",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("20",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("11",world1.temperature(position, 0));
+  approval_tests.emplace_back("12",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("13",world1.temperature(position, 260e3));
+  approval_tests.emplace_back("14",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("15",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("16",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("17",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("18",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("19",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("20",world1.composition(position, 0, 6));
 
   position = {{250e3,500e3,0}};
-  approval_tests.emplace_back(std::make_pair("21",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("22",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("23",world1.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("24",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("25",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("26",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("27",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("28",world1.composition(position, 240e3, 3)));
-  approval_tests.emplace_back(std::make_pair("29",world1.composition(position, 260e3, 3)));
-  approval_tests.emplace_back(std::make_pair("20",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("31",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("32",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("21",world1.temperature(position, 0));
+  approval_tests.emplace_back("22",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("23",world1.temperature(position, 260e3));
+  approval_tests.emplace_back("24",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("25",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("26",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("27",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("28",world1.composition(position, 240e3, 3));
+  approval_tests.emplace_back("29",world1.composition(position, 260e3, 3));
+  approval_tests.emplace_back("20",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("31",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("32",world1.composition(position, 0, 6));
 
   position = {{1500e3,1500e3,0}};
-  approval_tests.emplace_back(std::make_pair("33",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("34",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("35",world1.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("36",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("37",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("38",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("39",world1.composition(position, 240e3, 2)));
-  approval_tests.emplace_back(std::make_pair("40",world1.composition(position, 260e3, 2)));
-  approval_tests.emplace_back(std::make_pair("41",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("42",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("43",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("44",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("33",world1.temperature(position, 0));
+  approval_tests.emplace_back("34",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("35",world1.temperature(position, 260e3));
+  approval_tests.emplace_back("36",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("37",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("38",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("39",world1.composition(position, 240e3, 2));
+  approval_tests.emplace_back("40",world1.composition(position, 260e3, 2));
+  approval_tests.emplace_back("41",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("42",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("43",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("44",world1.composition(position, 0, 6));
 
   position = {{250e3,1750e3,0}};
-  approval_tests.emplace_back(std::make_pair("45",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("46",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("47",world1.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("48",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("49",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("50",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("51",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("52",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("53",world1.composition(position, 240e3, 4)));
-  approval_tests.emplace_back(std::make_pair("54",world1.composition(position, 260e3, 4)));
-  approval_tests.emplace_back(std::make_pair("55",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("56",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("45",world1.temperature(position, 0));
+  approval_tests.emplace_back("46",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("47",world1.temperature(position, 260e3));
+  approval_tests.emplace_back("48",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("49",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("50",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("51",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("52",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("53",world1.composition(position, 240e3, 4));
+  approval_tests.emplace_back("54",world1.composition(position, 260e3, 4));
+  approval_tests.emplace_back("55",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("56",world1.composition(position, 0, 6));
 
   position = {{750e3,250e3,0}};
-  approval_tests.emplace_back(std::make_pair("57",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("58",world1.temperature(position, 195e3)));
-  approval_tests.emplace_back(std::make_pair("59",world1.temperature(position, 205e3)));
-  approval_tests.emplace_back(std::make_pair("60",world1.temperature(position, 247e3)));
-  approval_tests.emplace_back(std::make_pair("61",world1.temperature(position, 249e3)));
-  approval_tests.emplace_back(std::make_pair("62",world1.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("63",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("64",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("65",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("66",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("67",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("68",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("69",world1.composition(position, 0, 6)));
-  approval_tests.emplace_back(std::make_pair("70",world1.composition(position, 240e3, 5)));
-  approval_tests.emplace_back(std::make_pair("71",world1.composition(position, 240e3, 6)));
-  approval_tests.emplace_back(std::make_pair("72",world1.composition(position, 260e3, 5)));
-  approval_tests.emplace_back(std::make_pair("73",world1.composition(position, 260e3, 6)));
+  approval_tests.emplace_back("57",world1.temperature(position, 0));
+  approval_tests.emplace_back("58",world1.temperature(position, 195e3));
+  approval_tests.emplace_back("59",world1.temperature(position, 205e3));
+  approval_tests.emplace_back("60",world1.temperature(position, 247e3));
+  approval_tests.emplace_back("61",world1.temperature(position, 249e3));
+  approval_tests.emplace_back("62",world1.temperature(position, 260e3));
+  approval_tests.emplace_back("63",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("64",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("65",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("66",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("67",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("68",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("69",world1.composition(position, 0, 6));
+  approval_tests.emplace_back("70",world1.composition(position, 240e3, 5));
+  approval_tests.emplace_back("71",world1.composition(position, 240e3, 6));
+  approval_tests.emplace_back("72",world1.composition(position, 260e3, 5));
+  approval_tests.emplace_back("73",world1.composition(position, 260e3, 6));
 
   position = {{1500e3, 0, 0}};
-  approval_tests.emplace_back(std::make_pair("74",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("75",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("76",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("77",world1.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("78",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("79",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("80",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("81",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("82",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("83",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("84",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("74",world1.temperature(position, 0));
+  approval_tests.emplace_back("75",world1.temperature(position, 10));
+  approval_tests.emplace_back("76",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("77",world1.temperature(position, 260e3));
+  approval_tests.emplace_back("78",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("79",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("80",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("81",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("82",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("83",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("84",world1.composition(position, 0, 6));
 
   // test symmetry
   position = {{1600e3, 0, 0}};
-  approval_tests.emplace_back(std::make_pair("85",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("86",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("87",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("88",world1.temperature(position, 260e3)));
+  approval_tests.emplace_back("85",world1.temperature(position, 0));
+  approval_tests.emplace_back("86",world1.temperature(position, 10));
+  approval_tests.emplace_back("87",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("88",world1.temperature(position, 260e3));
 
   position = {{1400e3, 0, 0}};
-  approval_tests.emplace_back(std::make_pair("89",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("90",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("91",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("92",world1.temperature(position, 260e3)));
+  approval_tests.emplace_back("89",world1.temperature(position, 0));
+  approval_tests.emplace_back("90",world1.temperature(position, 10));
+  approval_tests.emplace_back("91",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("92",world1.temperature(position, 260e3));
 
   // the constant layers test
   position = {{200e3,200e3,0}};
-  approval_tests.emplace_back(std::make_pair("93",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("94",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("95",world1.temperature(position, 260e3)));
+  approval_tests.emplace_back("93",world1.temperature(position, 0));
+  approval_tests.emplace_back("94",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("95",world1.temperature(position, 260e3));
 
-  approval_tests.emplace_back(std::make_pair("96",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("97",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("98",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("99",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("100",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("101",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("102",world1.composition(position, 0, 6)));
-  approval_tests.emplace_back(std::make_pair("103",world1.composition(position, 0, 7)));
-  approval_tests.emplace_back(std::make_pair("104",world1.composition(position, 0, 8)));
-  approval_tests.emplace_back(std::make_pair("105",world1.composition(position, 0, 9)));
-  approval_tests.emplace_back(std::make_pair("106",world1.composition(position, 75e3-1, 0)));
-  approval_tests.emplace_back(std::make_pair("107",world1.composition(position, 75e3-1, 1)));
-  approval_tests.emplace_back(std::make_pair("108",world1.composition(position, 75e3-1, 2)));
-  approval_tests.emplace_back(std::make_pair("109",world1.composition(position, 75e3-1, 3)));
-  approval_tests.emplace_back(std::make_pair("110",world1.composition(position, 75e3-1, 4)));
-  approval_tests.emplace_back(std::make_pair("111",world1.composition(position, 75e3-1, 5)));
-  approval_tests.emplace_back(std::make_pair("112",world1.composition(position, 75e3-1, 6)));
-  approval_tests.emplace_back(std::make_pair("113",world1.composition(position, 75e3-1, 7)));
-  approval_tests.emplace_back(std::make_pair("114",world1.composition(position, 75e3-1, 8)));
-  approval_tests.emplace_back(std::make_pair("115",world1.composition(position, 75e3-1, 9)));
-  approval_tests.emplace_back(std::make_pair("116",world1.composition(position, 75e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("117",world1.composition(position, 75e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("118",world1.composition(position, 75e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("119",world1.composition(position, 75e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("120",world1.composition(position, 75e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("121",world1.composition(position, 75e3+1, 5)));
-  approval_tests.emplace_back(std::make_pair("122",world1.composition(position, 75e3+1, 6)));
-  approval_tests.emplace_back(std::make_pair("123",world1.composition(position, 75e3+1, 7)));
-  approval_tests.emplace_back(std::make_pair("124",world1.composition(position, 75e3+1, 8)));
-  approval_tests.emplace_back(std::make_pair("125",world1.composition(position, 75e3+1, 9)));
-  approval_tests.emplace_back(std::make_pair("126",world1.composition(position, 150e3-1, 0)));
-  approval_tests.emplace_back(std::make_pair("127",world1.composition(position, 150e3-1, 1)));
-  approval_tests.emplace_back(std::make_pair("128",world1.composition(position, 150e3-1, 2)));
-  approval_tests.emplace_back(std::make_pair("129",world1.composition(position, 150e3-1, 3)));
-  approval_tests.emplace_back(std::make_pair("130",world1.composition(position, 150e3-1, 4)));
-  approval_tests.emplace_back(std::make_pair("131",world1.composition(position, 150e3-1, 5)));
-  approval_tests.emplace_back(std::make_pair("132",world1.composition(position, 150e3-1, 6)));
-  approval_tests.emplace_back(std::make_pair("133",world1.composition(position, 150e3-1, 7)));
-  approval_tests.emplace_back(std::make_pair("134",world1.composition(position, 150e3-1, 8)));
-  approval_tests.emplace_back(std::make_pair("135",world1.composition(position, 150e3-1, 9)));
-  approval_tests.emplace_back(std::make_pair("136",world1.composition(position, 150e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("137",world1.composition(position, 150e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("138",world1.composition(position, 150e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("139",world1.composition(position, 150e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("140",world1.composition(position, 150e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("141",world1.composition(position, 150e3+1, 5)));
-  approval_tests.emplace_back(std::make_pair("142",world1.composition(position, 150e3+1, 6)));
-  approval_tests.emplace_back(std::make_pair("143",world1.composition(position, 150e3+1, 7)));
-  approval_tests.emplace_back(std::make_pair("144",world1.composition(position, 150e3+1, 8)));
-  approval_tests.emplace_back(std::make_pair("145",world1.composition(position, 150e3+1, 9)));
-  approval_tests.emplace_back(std::make_pair("146",world1.composition(position, 240e3, 0)));
-  approval_tests.emplace_back(std::make_pair("147",world1.composition(position, 240e3, 1)));
-  approval_tests.emplace_back(std::make_pair("148",world1.composition(position, 240e3, 2)));
-  approval_tests.emplace_back(std::make_pair("149",world1.composition(position, 240e3, 3)));
-  approval_tests.emplace_back(std::make_pair("150",world1.composition(position, 240e3, 4)));
-  approval_tests.emplace_back(std::make_pair("151",world1.composition(position, 240e3, 5)));
-  approval_tests.emplace_back(std::make_pair("152",world1.composition(position, 240e3, 6)));
-  approval_tests.emplace_back(std::make_pair("153",world1.composition(position, 240e3, 7)));
-  approval_tests.emplace_back(std::make_pair("154",world1.composition(position, 240e3, 8)));
-  approval_tests.emplace_back(std::make_pair("155",world1.composition(position, 240e3, 9)));
-  approval_tests.emplace_back(std::make_pair("156",world1.composition(position, 260e3, 0)));
-  approval_tests.emplace_back(std::make_pair("157",world1.composition(position, 260e3, 1)));
-  approval_tests.emplace_back(std::make_pair("158",world1.composition(position, 260e3, 2)));
-  approval_tests.emplace_back(std::make_pair("159",world1.composition(position, 260e3, 3)));
-  approval_tests.emplace_back(std::make_pair("160",world1.composition(position, 260e3, 4)));
-  approval_tests.emplace_back(std::make_pair("161",world1.composition(position, 260e3, 5)));
-  approval_tests.emplace_back(std::make_pair("162",world1.composition(position, 260e3, 6)));
-  approval_tests.emplace_back(std::make_pair("163",world1.composition(position, 260e3, 7)));
-  approval_tests.emplace_back(std::make_pair("164",world1.composition(position, 260e3, 8)));
-  approval_tests.emplace_back(std::make_pair("165",world1.composition(position, 260e3, 9)));
+  approval_tests.emplace_back("96",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("97",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("98",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("99",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("100",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("101",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("102",world1.composition(position, 0, 6));
+  approval_tests.emplace_back("103",world1.composition(position, 0, 7));
+  approval_tests.emplace_back("104",world1.composition(position, 0, 8));
+  approval_tests.emplace_back("105",world1.composition(position, 0, 9));
+  approval_tests.emplace_back("106",world1.composition(position, 75e3-1, 0));
+  approval_tests.emplace_back("107",world1.composition(position, 75e3-1, 1));
+  approval_tests.emplace_back("108",world1.composition(position, 75e3-1, 2));
+  approval_tests.emplace_back("109",world1.composition(position, 75e3-1, 3));
+  approval_tests.emplace_back("110",world1.composition(position, 75e3-1, 4));
+  approval_tests.emplace_back("111",world1.composition(position, 75e3-1, 5));
+  approval_tests.emplace_back("112",world1.composition(position, 75e3-1, 6));
+  approval_tests.emplace_back("113",world1.composition(position, 75e3-1, 7));
+  approval_tests.emplace_back("114",world1.composition(position, 75e3-1, 8));
+  approval_tests.emplace_back("115",world1.composition(position, 75e3-1, 9));
+  approval_tests.emplace_back("116",world1.composition(position, 75e3+1, 0));
+  approval_tests.emplace_back("117",world1.composition(position, 75e3+1, 1));
+  approval_tests.emplace_back("118",world1.composition(position, 75e3+1, 2));
+  approval_tests.emplace_back("119",world1.composition(position, 75e3+1, 3));
+  approval_tests.emplace_back("120",world1.composition(position, 75e3+1, 4));
+  approval_tests.emplace_back("121",world1.composition(position, 75e3+1, 5));
+  approval_tests.emplace_back("122",world1.composition(position, 75e3+1, 6));
+  approval_tests.emplace_back("123",world1.composition(position, 75e3+1, 7));
+  approval_tests.emplace_back("124",world1.composition(position, 75e3+1, 8));
+  approval_tests.emplace_back("125",world1.composition(position, 75e3+1, 9));
+  approval_tests.emplace_back("126",world1.composition(position, 150e3-1, 0));
+  approval_tests.emplace_back("127",world1.composition(position, 150e3-1, 1));
+  approval_tests.emplace_back("128",world1.composition(position, 150e3-1, 2));
+  approval_tests.emplace_back("129",world1.composition(position, 150e3-1, 3));
+  approval_tests.emplace_back("130",world1.composition(position, 150e3-1, 4));
+  approval_tests.emplace_back("131",world1.composition(position, 150e3-1, 5));
+  approval_tests.emplace_back("132",world1.composition(position, 150e3-1, 6));
+  approval_tests.emplace_back("133",world1.composition(position, 150e3-1, 7));
+  approval_tests.emplace_back("134",world1.composition(position, 150e3-1, 8));
+  approval_tests.emplace_back("135",world1.composition(position, 150e3-1, 9));
+  approval_tests.emplace_back("136",world1.composition(position, 150e3+1, 0));
+  approval_tests.emplace_back("137",world1.composition(position, 150e3+1, 1));
+  approval_tests.emplace_back("138",world1.composition(position, 150e3+1, 2));
+  approval_tests.emplace_back("139",world1.composition(position, 150e3+1, 3));
+  approval_tests.emplace_back("140",world1.composition(position, 150e3+1, 4));
+  approval_tests.emplace_back("141",world1.composition(position, 150e3+1, 5));
+  approval_tests.emplace_back("142",world1.composition(position, 150e3+1, 6));
+  approval_tests.emplace_back("143",world1.composition(position, 150e3+1, 7));
+  approval_tests.emplace_back("144",world1.composition(position, 150e3+1, 8));
+  approval_tests.emplace_back("145",world1.composition(position, 150e3+1, 9));
+  approval_tests.emplace_back("146",world1.composition(position, 240e3, 0));
+  approval_tests.emplace_back("147",world1.composition(position, 240e3, 1));
+  approval_tests.emplace_back("148",world1.composition(position, 240e3, 2));
+  approval_tests.emplace_back("149",world1.composition(position, 240e3, 3));
+  approval_tests.emplace_back("150",world1.composition(position, 240e3, 4));
+  approval_tests.emplace_back("151",world1.composition(position, 240e3, 5));
+  approval_tests.emplace_back("152",world1.composition(position, 240e3, 6));
+  approval_tests.emplace_back("153",world1.composition(position, 240e3, 7));
+  approval_tests.emplace_back("154",world1.composition(position, 240e3, 8));
+  approval_tests.emplace_back("155",world1.composition(position, 240e3, 9));
+  approval_tests.emplace_back("156",world1.composition(position, 260e3, 0));
+  approval_tests.emplace_back("157",world1.composition(position, 260e3, 1));
+  approval_tests.emplace_back("158",world1.composition(position, 260e3, 2));
+  approval_tests.emplace_back("159",world1.composition(position, 260e3, 3));
+  approval_tests.emplace_back("160",world1.composition(position, 260e3, 4));
+  approval_tests.emplace_back("161",world1.composition(position, 260e3, 5));
+  approval_tests.emplace_back("162",world1.composition(position, 260e3, 6));
+  approval_tests.emplace_back("163",world1.composition(position, 260e3, 7));
+  approval_tests.emplace_back("164",world1.composition(position, 260e3, 8));
+  approval_tests.emplace_back("165",world1.composition(position, 260e3, 9));
 
   // spherical
   file_name = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/oceanic_plate_spherical.wb";
@@ -2043,148 +2043,148 @@ TEST_CASE("WorldBuilder Features: Oceanic Plate")
 
   // 2d
   position_2d = {{6371000,0}};
-  approval_tests.emplace_back(std::make_pair("166",world2.temperature(position_2d, 0)));
-  approval_tests.emplace_back(std::make_pair("167",world2.composition(position_2d, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("168",world2.composition(position_2d, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("169",world2.composition(position_2d, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("170",world2.composition(position_2d, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("171",world2.composition(position_2d, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("172",world2.composition(position_2d, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("173",world2.composition(position_2d, 0, 6)));
+  approval_tests.emplace_back("166",world2.temperature(position_2d, 0));
+  approval_tests.emplace_back("167",world2.composition(position_2d, 0, 0));
+  approval_tests.emplace_back("168",world2.composition(position_2d, 0, 1));
+  approval_tests.emplace_back("169",world2.composition(position_2d, 0, 2));
+  approval_tests.emplace_back("170",world2.composition(position_2d, 0, 3));
+  approval_tests.emplace_back("171",world2.composition(position_2d, 0, 4));
+  approval_tests.emplace_back("172",world2.composition(position_2d, 0, 5));
+  approval_tests.emplace_back("173",world2.composition(position_2d, 0, 6));
 
   // 3d
   position = {{6371000,0,0}};
-  approval_tests.emplace_back(std::make_pair("174",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("175",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("176",world2.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("177",world2.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("178",world2.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("179",world2.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("180",world2.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("181",world2.composition(position, 0, 6)));
+  approval_tests.emplace_back("174",world2.temperature(position, 0));
+  approval_tests.emplace_back("175",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("176",world2.composition(position, 0, 1));
+  approval_tests.emplace_back("177",world2.composition(position, 0, 2));
+  approval_tests.emplace_back("178",world2.composition(position, 0, 3));
+  approval_tests.emplace_back("179",world2.composition(position, 0, 4));
+  approval_tests.emplace_back("180",world2.composition(position, 0, 5));
+  approval_tests.emplace_back("181",world2.composition(position, 0, 6));
 
   position = {{6371000, -5 * dtr,-5 * dtr}};
   position = coordinate_system->natural_to_cartesian_coordinates(position);
-  approval_tests.emplace_back(std::make_pair("182",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("183",world2.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("184",world2.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("185",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("186",world2.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("187",world2.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("188",world2.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("189",world2.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("190",world2.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("191",world2.composition(position, 0, 6)));
+  approval_tests.emplace_back("182",world2.temperature(position, 0));
+  approval_tests.emplace_back("183",world2.temperature(position, 240e3));
+  approval_tests.emplace_back("184",world2.temperature(position, 260e3));
+  approval_tests.emplace_back("185",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("186",world2.composition(position, 0, 1));
+  approval_tests.emplace_back("187",world2.composition(position, 0, 2));
+  approval_tests.emplace_back("188",world2.composition(position, 0, 3));
+  approval_tests.emplace_back("189",world2.composition(position, 0, 4));
+  approval_tests.emplace_back("190",world2.composition(position, 0, 5));
+  approval_tests.emplace_back("191",world2.composition(position, 0, 6));
 
   position = {{6371000, 5 * dtr,-5 * dtr}};
   position = coordinate_system->natural_to_cartesian_coordinates(position);
-  approval_tests.emplace_back(std::make_pair("192",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("193",world2.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("194",world2.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("195",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("196",world2.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("197",world2.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("198",world2.composition(position, 240e3, 2)));
-  approval_tests.emplace_back(std::make_pair("199",world2.composition(position, 260e3, 2)));
-  approval_tests.emplace_back(std::make_pair("200",world2.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("201",world2.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("202",world2.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("203",world2.composition(position, 0, 6)));
+  approval_tests.emplace_back("192",world2.temperature(position, 0));
+  approval_tests.emplace_back("193",world2.temperature(position, 240e3));
+  approval_tests.emplace_back("194",world2.temperature(position, 260e3));
+  approval_tests.emplace_back("195",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("196",world2.composition(position, 0, 1));
+  approval_tests.emplace_back("197",world2.composition(position, 0, 2));
+  approval_tests.emplace_back("198",world2.composition(position, 240e3, 2));
+  approval_tests.emplace_back("199",world2.composition(position, 260e3, 2));
+  approval_tests.emplace_back("200",world2.composition(position, 0, 3));
+  approval_tests.emplace_back("201",world2.composition(position, 0, 4));
+  approval_tests.emplace_back("202",world2.composition(position, 0, 5));
+  approval_tests.emplace_back("203",world2.composition(position, 0, 6));
 
   // check grains
   {
     const WorldBuilder::grains grains = world2.grains(position, 240e3, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("1",grains));
+    approval_tests_grains.emplace_back("1",grains);
   }
 
   position = {{6371000, 5 * dtr,5 * dtr}};
   position = coordinate_system->natural_to_cartesian_coordinates(position);
-  approval_tests.emplace_back(std::make_pair("204",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("205",world2.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("206",world2.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("207",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("208",world2.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("209",world2.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("210",world2.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("211",world2.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("212",world2.composition(position, 240e3, 4)));
-  approval_tests.emplace_back(std::make_pair("213",world2.composition(position, 260e3, 4)));
-  approval_tests.emplace_back(std::make_pair("214",world2.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("215",world2.composition(position, 0, 6)));
+  approval_tests.emplace_back("204",world2.temperature(position, 0));
+  approval_tests.emplace_back("205",world2.temperature(position, 240e3));
+  approval_tests.emplace_back("206",world2.temperature(position, 260e3));
+  approval_tests.emplace_back("207",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("208",world2.composition(position, 0, 1));
+  approval_tests.emplace_back("209",world2.composition(position, 0, 2));
+  approval_tests.emplace_back("210",world2.composition(position, 0, 3));
+  approval_tests.emplace_back("211",world2.composition(position, 0, 4));
+  approval_tests.emplace_back("212",world2.composition(position, 240e3, 4));
+  approval_tests.emplace_back("213",world2.composition(position, 260e3, 4));
+  approval_tests.emplace_back("214",world2.composition(position, 0, 5));
+  approval_tests.emplace_back("215",world2.composition(position, 0, 6));
 
   // check grains
   {
     const WorldBuilder::grains grains = world2.grains(position, 240e3, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("2",grains));
+    approval_tests_grains.emplace_back("2",grains);
   }
 
   position = {{6371000, -15 * dtr, -15 * dtr}};
   position = coordinate_system->natural_to_cartesian_coordinates(position);
-  approval_tests.emplace_back(std::make_pair("216",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("217",world2.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("218",world2.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("219",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("220",world2.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("221",world2.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("222",world2.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("223",world2.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("224",world2.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("225",world2.composition(position, 0, 6)));
-  approval_tests.emplace_back(std::make_pair("226",world2.composition(position, 240e3, 5)));
-  approval_tests.emplace_back(std::make_pair("227",world2.composition(position, 240e3, 6)));
-  approval_tests.emplace_back(std::make_pair("228",world2.composition(position, 260e3, 5)));
-  approval_tests.emplace_back(std::make_pair("229",world2.composition(position, 260e3, 6)));
+  approval_tests.emplace_back("216",world2.temperature(position, 0));
+  approval_tests.emplace_back("217",world2.temperature(position, 240e3));
+  approval_tests.emplace_back("218",world2.temperature(position, 260e3));
+  approval_tests.emplace_back("219",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("220",world2.composition(position, 0, 1));
+  approval_tests.emplace_back("221",world2.composition(position, 0, 2));
+  approval_tests.emplace_back("222",world2.composition(position, 0, 3));
+  approval_tests.emplace_back("223",world2.composition(position, 0, 4));
+  approval_tests.emplace_back("224",world2.composition(position, 0, 5));
+  approval_tests.emplace_back("225",world2.composition(position, 0, 6));
+  approval_tests.emplace_back("226",world2.composition(position, 240e3, 5));
+  approval_tests.emplace_back("227",world2.composition(position, 240e3, 6));
+  approval_tests.emplace_back("228",world2.composition(position, 260e3, 5));
+  approval_tests.emplace_back("229",world2.composition(position, 260e3, 6));
 
   // check grains layer 1
   {
     const WorldBuilder::grains grains = world2.grains(position, 0, 0, 2);
-    approval_tests_grains.emplace_back(std::make_pair("3",grains));
+    approval_tests_grains.emplace_back("3",grains);
   }
 
   // check grains layer 2
   {
     const WorldBuilder::grains grains = world2.grains(position, 150e3, 0, 2);
-    approval_tests_grains.emplace_back(std::make_pair("4",grains));
+    approval_tests_grains.emplace_back("4",grains);
   }
 
   position = {{6371000, 15 * dtr, -19 * dtr}};
   position = coordinate_system->natural_to_cartesian_coordinates(position);
-  approval_tests.emplace_back(std::make_pair("230",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("231",world2.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("232",world2.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("233",world2.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("234",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("235",world2.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("236",world2.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("237",world2.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("238",world2.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("239",world2.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("240",world2.composition(position, 0, 6)));
-  approval_tests.emplace_back(std::make_pair("241",world2.composition(position, 240e3, 6)));
-  approval_tests.emplace_back(std::make_pair("242",world2.composition(position, 260e3, 6)));
+  approval_tests.emplace_back("230",world2.temperature(position, 0));
+  approval_tests.emplace_back("231",world2.temperature(position, 10));
+  approval_tests.emplace_back("232",world2.temperature(position, 240e3));
+  approval_tests.emplace_back("233",world2.temperature(position, 260e3));
+  approval_tests.emplace_back("234",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("235",world2.composition(position, 0, 1));
+  approval_tests.emplace_back("236",world2.composition(position, 0, 2));
+  approval_tests.emplace_back("237",world2.composition(position, 0, 3));
+  approval_tests.emplace_back("238",world2.composition(position, 0, 4));
+  approval_tests.emplace_back("239",world2.composition(position, 0, 5));
+  approval_tests.emplace_back("240",world2.composition(position, 0, 6));
+  approval_tests.emplace_back("241",world2.composition(position, 240e3, 6));
+  approval_tests.emplace_back("242",world2.composition(position, 260e3, 6));
 
   // test symmetry
   position = {{6371000, 16 * dtr, -19 * dtr}};
   position = coordinate_system->natural_to_cartesian_coordinates(position);
-  approval_tests.emplace_back(std::make_pair("243",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("244",world2.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("245",world2.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("246",world2.temperature(position, 260e3)));
+  approval_tests.emplace_back("243",world2.temperature(position, 0));
+  approval_tests.emplace_back("244",world2.temperature(position, 10));
+  approval_tests.emplace_back("245",world2.temperature(position, 240e3));
+  approval_tests.emplace_back("246",world2.temperature(position, 260e3));
 
   position = {{6371000, 14 * dtr, -19 * dtr}};
   position = coordinate_system->natural_to_cartesian_coordinates(position);
-  approval_tests.emplace_back(std::make_pair("247",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("248",world2.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("249",world2.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("250",world2.temperature(position, 260e3)));
+  approval_tests.emplace_back("247",world2.temperature(position, 0));
+  approval_tests.emplace_back("248",world2.temperature(position, 10));
+  approval_tests.emplace_back("249",world2.temperature(position, 240e3));
+  approval_tests.emplace_back("250",world2.temperature(position, 260e3));
 
   // test bend
   position = {{6371000, 12.5 * dtr, -12.5 * dtr}};
   position = coordinate_system->natural_to_cartesian_coordinates(position);
-  approval_tests.emplace_back(std::make_pair("251",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("252",world2.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("253",world2.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("254",world2.temperature(position, 260e3)));
+  approval_tests.emplace_back("251",world2.temperature(position, 0));
+  approval_tests.emplace_back("252",world2.temperature(position, 10));
+  approval_tests.emplace_back("253",world2.temperature(position, 240e3));
+  approval_tests.emplace_back("254",world2.temperature(position, 260e3));
 
   std::vector<std::string> approvals;
   for (auto&& value : approval_tests)
@@ -2228,150 +2228,150 @@ TEST_CASE("WorldBuilder Features: Subducting Plate")
   }
   // Check continental plate through the world
   std::array<double,3> position = {{0,0,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 240e3));
+  approval_tests.emplace_back("",world1.temperature(position, 260e3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
 
 
   position = {{0,150e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 500)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 25e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 75e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 175e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 1));
+  approval_tests.emplace_back("",world1.temperature(position, 5));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100));
+  approval_tests.emplace_back("",world1.temperature(position, 500));
+  approval_tests.emplace_back("",world1.temperature(position, 1000));
+  approval_tests.emplace_back("",world1.temperature(position, 5000));
+  approval_tests.emplace_back("",world1.temperature(position, 10e3));
+  approval_tests.emplace_back("",world1.temperature(position, 25e3));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3));
+  approval_tests.emplace_back("",world1.temperature(position, 75e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 175e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
 
 
   position = {{10e3,150e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 500)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 25e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 75e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 175e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 1));
+  approval_tests.emplace_back("",world1.temperature(position, 5));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100));
+  approval_tests.emplace_back("",world1.temperature(position, 500));
+  approval_tests.emplace_back("",world1.temperature(position, 1000));
+  approval_tests.emplace_back("",world1.temperature(position, 5000));
+  approval_tests.emplace_back("",world1.temperature(position, 10e3));
+  approval_tests.emplace_back("",world1.temperature(position, 25e3));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3));
+  approval_tests.emplace_back("",world1.temperature(position, 75e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 175e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
 
   position = {{0,160e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 500)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 25e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 75e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 175e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 1));
+  approval_tests.emplace_back("",world1.temperature(position, 5));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100));
+  approval_tests.emplace_back("",world1.temperature(position, 500));
+  approval_tests.emplace_back("",world1.temperature(position, 1000));
+  approval_tests.emplace_back("",world1.temperature(position, 5000));
+  approval_tests.emplace_back("",world1.temperature(position, 10e3));
+  approval_tests.emplace_back("",world1.temperature(position, 25e3));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3));
+  approval_tests.emplace_back("",world1.temperature(position, 75e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 175e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
 
 
   position = {{750e3,175e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 500)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 25e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 75e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 175e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 1));
+  approval_tests.emplace_back("",world1.temperature(position, 5));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100));
+  approval_tests.emplace_back("",world1.temperature(position, 500));
+  approval_tests.emplace_back("",world1.temperature(position, 1000));
+  approval_tests.emplace_back("",world1.temperature(position, 5000));
+  approval_tests.emplace_back("",world1.temperature(position, 10e3));
+  approval_tests.emplace_back("",world1.temperature(position, 25e3));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3));
+  approval_tests.emplace_back("",world1.temperature(position, 75e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 175e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
 
   //position = {{250e3,450e3,800e3}};
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1))); // we are in the plate for sure (colder than anywhere in the mantle)
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5))); // we are in the plate for sure (colder than anywhere in the mantle)
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10))); // we are in the plate for sure (colder than anywhere in the mantle)
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100))); // we are in the plate for sure (colder than anywhere in the mantle)
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 500))); // we are in the plate for sure (colder than anywhere in the mantle)
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1000))); // we are in the plate for sure (colder than anywhere in the mantle)
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5000))); // we are in the plate for sure (colder than anywhere in the mantle)
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10e3)));
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 25e3)));
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3)));
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 75e3)));
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
+  //approval_tests.emplace_back("",world1.temperature(position, 0));
+  //approval_tests.emplace_back("",world1.temperature(position, 1)); // we are in the plate for sure (colder than anywhere in the mantle)
+  //approval_tests.emplace_back("",world1.temperature(position, 5)); // we are in the plate for sure (colder than anywhere in the mantle)
+  //approval_tests.emplace_back("",world1.temperature(position, 10)); // we are in the plate for sure (colder than anywhere in the mantle)
+  //approval_tests.emplace_back("",world1.temperature(position, 100)); // we are in the plate for sure (colder than anywhere in the mantle)
+  //approval_tests.emplace_back("",world1.temperature(position, 500)); // we are in the plate for sure (colder than anywhere in the mantle)
+  //approval_tests.emplace_back("",world1.temperature(position, 1000)); // we are in the plate for sure (colder than anywhere in the mantle)
+  //approval_tests.emplace_back("",world1.temperature(position, 5000)); // we are in the plate for sure (colder than anywhere in the mantle)
+  //approval_tests.emplace_back("",world1.temperature(position, 10e3));
+  //approval_tests.emplace_back("",world1.temperature(position, 25e3));
+  //approval_tests.emplace_back("",world1.temperature(position, 50e3));
+  //approval_tests.emplace_back("",world1.temperature(position, 75e3));
+  //approval_tests.emplace_back("",world1.temperature(position, 150e3));
 
   position = {{250e3,488.750e3,800e3}};
   position = {{250e3,500e3,800e3}};
   // results strongly dependent on the summation number of the McKenzie temperature.
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 500))); // we are in the plate for sure (colder than anywhere in the mantle)
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1000))); // we are in the plate for sure (colder than anywhere in the mantle)
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5000))); // we are in the plate for sure (colder than anywhere in the mantle)
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 25e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 75e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 100e3 - 1)));
-  //approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 100e3 + 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 - 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 + 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 - 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 + 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 66e3 - 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 66e3 + 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 66e3 - 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 66e3 + 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 66e3 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 99e3 - 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 99e3 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 99e3 + 1, 2)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 1));
+  approval_tests.emplace_back("",world1.temperature(position, 5));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100));
+  approval_tests.emplace_back("",world1.temperature(position, 500)); // we are in the plate for sure (colder than anywhere in the mantle)
+  approval_tests.emplace_back("",world1.temperature(position, 1000)); // we are in the plate for sure (colder than anywhere in the mantle)
+  approval_tests.emplace_back("",world1.temperature(position, 5000)); // we are in the plate for sure (colder than anywhere in the mantle)
+  approval_tests.emplace_back("",world1.temperature(position, 10e3));
+  approval_tests.emplace_back("",world1.temperature(position, 25e3));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3));
+  approval_tests.emplace_back("",world1.temperature(position, 75e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  //approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 100e3 - 1));
+  //approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 100e3 + 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 10, 0));
+  approval_tests.emplace_back("",world1.composition(position, 10, 1));
+  approval_tests.emplace_back("",world1.composition(position, 10, 2));
+  approval_tests.emplace_back("",world1.composition(position, 10, 3));
+  approval_tests.emplace_back("",world1.composition(position, 10, 4));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 - 1, 0));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 + 1, 0));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 - 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 + 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 66e3 - 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 66e3 + 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 66e3 - 1, 2));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 66e3 + 1, 2));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 66e3 + 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 99e3 - 1, 2));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 99e3 - 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 99e3 + 1, 2));
   // this comes form the first subducting plate
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 99e3 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 100e3 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 100e3 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 99e3 + 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 100e3 - 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 100e3 + 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
 
   // check grains layer 1
   {
@@ -2379,214 +2379,214 @@ TEST_CASE("WorldBuilder Features: Subducting Plate")
     // these are random numbers, but they should stay the same.
     // note that the values are different from for example the continental plate since
     // this performs a interpolation between segments of the slab.
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
 
     grains = world1.grains(position, std::sqrt(2) * 33e3 - 5e3, 1, 2);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   // check grains layer 2
   {
     const WorldBuilder::grains grains = world1.grains(position, std::sqrt(2) * 66e3 - 1, 0, 2);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   position = {{250e3,550e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 45e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3-1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3+1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 55e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3-1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3+1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 101e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 110e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 155e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 175e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 250e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 300e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 45e3));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3-1));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3+1));
+  approval_tests.emplace_back("",world1.temperature(position, 55e3));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3-1));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3+1));
+  approval_tests.emplace_back("",world1.temperature(position, 101e3));
+  approval_tests.emplace_back("",world1.temperature(position, 110e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 155e3));
+  approval_tests.emplace_back("",world1.temperature(position, 175e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
+  approval_tests.emplace_back("",world1.temperature(position, 250e3));
+  approval_tests.emplace_back("",world1.temperature(position, 300e3));
 
   position = {{250e3,600e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 45e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3-1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3+1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 55e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3-1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3+1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 101e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 110e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 155e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 160e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 165e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 170e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 175e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 180e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 185e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 250e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 300e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3-1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3-1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3-1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3-1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3-1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 45e3));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3-1));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3+1));
+  approval_tests.emplace_back("",world1.temperature(position, 55e3));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3-1));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3+1));
+  approval_tests.emplace_back("",world1.temperature(position, 101e3));
+  approval_tests.emplace_back("",world1.temperature(position, 110e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 155e3));
+  approval_tests.emplace_back("",world1.temperature(position, 160e3));
+  approval_tests.emplace_back("",world1.temperature(position, 165e3));
+  approval_tests.emplace_back("",world1.temperature(position, 170e3));
+  approval_tests.emplace_back("",world1.temperature(position, 175e3));
+  approval_tests.emplace_back("",world1.temperature(position, 180e3));
+  approval_tests.emplace_back("",world1.temperature(position, 185e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
+  approval_tests.emplace_back("",world1.temperature(position, 250e3));
+  approval_tests.emplace_back("",world1.temperature(position, 300e3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 10, 0));
+  approval_tests.emplace_back("",world1.composition(position, 10, 1));
+  approval_tests.emplace_back("",world1.composition(position, 10, 2));
+  approval_tests.emplace_back("",world1.composition(position, 10, 3));
+  approval_tests.emplace_back("",world1.composition(position, 100e3-1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 100e3-1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 100e3-1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 100e3-1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 100e3-1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 101e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
 
   position = {{650e3,650e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3+1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 101e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 110e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3+1));
+  approval_tests.emplace_back("",world1.temperature(position, 101e3));
+  approval_tests.emplace_back("",world1.temperature(position, 110e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 10, 0));
+  approval_tests.emplace_back("",world1.composition(position, 10, 1));
+  approval_tests.emplace_back("",world1.composition(position, 10, 2));
+  approval_tests.emplace_back("",world1.composition(position, 10, 3));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 101e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
 
   position = {{700e3,675e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3+1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 101e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 110e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 100e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 101e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 150e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 200e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3+1));
+  approval_tests.emplace_back("",world1.temperature(position, 101e3));
+  approval_tests.emplace_back("",world1.temperature(position, 110e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 10, 0));
+  approval_tests.emplace_back("",world1.composition(position, 10, 1));
+  approval_tests.emplace_back("",world1.composition(position, 10, 2));
+  approval_tests.emplace_back("",world1.composition(position, 10, 3));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 100e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 100e3+1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 101e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 101e3+1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 150e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 0));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 1));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 2));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 3));
+  approval_tests.emplace_back("",world1.composition(position, 200e3, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
 
   position = {{700e3,155e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 250e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 300e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
+  approval_tests.emplace_back("",world1.temperature(position, 250e3));
+  approval_tests.emplace_back("",world1.temperature(position, 300e3));
 
   // check grains
   {
     {
       // layer 1
       const WorldBuilder::grains grains = world1.grains(position, 80e3, 0, 3);
-      approval_tests_grains.emplace_back(std::make_pair("",grains));
+      approval_tests_grains.emplace_back("",grains);
     }
 
     {
       // layer 2
       const WorldBuilder::grains grains = world1.grains(position, 100e3, 0, 3);
-      approval_tests_grains.emplace_back(std::make_pair("",grains));
+      approval_tests_grains.emplace_back("",grains);
     }
 
     {
       // layer 3
       const WorldBuilder::grains grains = world1.grains(position, 250e3, 0, 3);
-      approval_tests_grains.emplace_back(std::make_pair("",grains));
+      approval_tests_grains.emplace_back("",grains);
     }
   }
 
@@ -2595,95 +2595,95 @@ TEST_CASE("WorldBuilder Features: Subducting Plate")
   const WorldBuilder::World world2(file_name2);
 
   position = {{250e3,500e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 1e3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 10e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 20e3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 20e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 40e3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 40e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 60e3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 60e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 80e3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 80e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 100e3, 0)));
+  approval_tests.emplace_back("",world2.temperature(position, 0));
+  approval_tests.emplace_back("",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 1));
+  approval_tests.emplace_back("",world2.composition(position, 1, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 1e3));
+  approval_tests.emplace_back("",world2.composition(position, 1e3, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 10e3));
+  approval_tests.emplace_back("",world2.composition(position, 10e3, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 20e3));
+  approval_tests.emplace_back("",world2.composition(position, 20e3, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 40e3));
+  approval_tests.emplace_back("",world2.composition(position, 40e3, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 60e3));
+  approval_tests.emplace_back("",world2.composition(position, 60e3, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 80e3));
+  approval_tests.emplace_back("",world2.composition(position, 80e3, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 100e3));
+  approval_tests.emplace_back("",world2.composition(position, 100e3, 0));
 
 
   file_name = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/subducting_plate_different_angles_cartesian_2.wb";
   const WorldBuilder::World world4(file_name);
 
   position = {{250e3,500e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 1e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 10e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 10e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 10e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 10e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 20e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 20e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 20e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 20e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 20e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 30e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 30e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 30e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 30e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 30e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 35e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 35e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 35e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 35e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 35e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 40e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 40e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 40e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 40e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 40e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 45e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 45e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 45e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 45e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 45e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 50e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 50e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 50e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 50e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 60e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 60e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 60e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 60e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 60e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 80e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 80e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 80e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 80e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 80e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 100e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 100e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 100e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 100e3, 3)));
+  approval_tests.emplace_back("",world4.temperature(position, 0));
+  approval_tests.emplace_back("",world4.composition(position, 0, 0));
+  approval_tests.emplace_back("",world4.composition(position, 0, 1));
+  approval_tests.emplace_back("",world4.composition(position, 0, 2));
+  approval_tests.emplace_back("",world4.composition(position, 0, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 1));
+  approval_tests.emplace_back("",world4.composition(position, 1, 0));
+  approval_tests.emplace_back("",world4.composition(position, 1, 1));
+  approval_tests.emplace_back("",world4.composition(position, 1, 2));
+  approval_tests.emplace_back("",world4.composition(position, 1, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 1e3));
+  approval_tests.emplace_back("",world4.composition(position, 1e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 1e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 1e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 1e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 10e3));
+  approval_tests.emplace_back("",world4.composition(position, 10e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 10e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 10e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 10e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 20e3));
+  approval_tests.emplace_back("",world4.composition(position, 20e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 20e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 20e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 20e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 30e3));
+  approval_tests.emplace_back("",world4.composition(position, 30e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 30e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 30e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 30e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 35e3));
+  approval_tests.emplace_back("",world4.composition(position, 35e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 35e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 35e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 35e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 40e3));
+  approval_tests.emplace_back("",world4.composition(position, 40e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 40e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 40e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 40e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 45e3));
+  approval_tests.emplace_back("",world4.composition(position, 45e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 45e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 45e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 45e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 50e3));
+  approval_tests.emplace_back("",world4.composition(position, 50e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 50e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 50e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 50e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 60e3));
+  approval_tests.emplace_back("",world4.composition(position, 60e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 60e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 60e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 60e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 80e3));
+  approval_tests.emplace_back("",world4.composition(position, 80e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 80e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 80e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 80e3, 3));
+  approval_tests.emplace_back("",world4.temperature(position, 100e3));
+  approval_tests.emplace_back("",world4.composition(position, 100e3, 0));
+  approval_tests.emplace_back("",world4.composition(position, 100e3, 1));
+  approval_tests.emplace_back("",world4.composition(position, 100e3, 2));
+  approval_tests.emplace_back("",world4.composition(position, 100e3, 3));
 
 
   std::vector<std::string> approvals;
@@ -2729,109 +2729,109 @@ TEST_CASE("WorldBuilder Features: Fault")
 
   // Check fault plate through the world
   std::array<double,3> position = {{0,0,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 220e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 230e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 220e3));
+  approval_tests.emplace_back("",world1.temperature(position, 230e3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
 
   position = {{250e3,500e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 50e3 - 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 50e3 + 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 50e3 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 50e3 - 1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 50e3 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 50e3 + 1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 50e3 - 1));
+  approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 50e3 + 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 10, 0));
+  approval_tests.emplace_back("",world1.composition(position, 10, 1));
+  approval_tests.emplace_back("",world1.composition(position, 10, 2));
+  approval_tests.emplace_back("",world1.composition(position, 10, 3));
+  approval_tests.emplace_back("",world1.composition(position, 10, 4));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 50e3 - 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 50e3 - 1, 4));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 50e3 + 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 50e3 + 1, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
 
   // check grains
   {
     WorldBuilder::grains grains = world1.grains(position, 10, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
 
     grains = world1.grains(position, 10, 1, 3);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   position = {{50e3,230e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 500)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 50e3/2)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 50e3 - 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 50e3 + 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 25e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 75e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 80e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 90e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 200e3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 1));
+  approval_tests.emplace_back("",world1.temperature(position, 5));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100));
+  approval_tests.emplace_back("",world1.temperature(position, 500));
+  approval_tests.emplace_back("",world1.temperature(position, 1000));
+  approval_tests.emplace_back("",world1.temperature(position, 5000));
+  approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 50e3/2));
+  approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 50e3 - 1));
+  approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 50e3 + 1));
+  approval_tests.emplace_back("",world1.temperature(position, 25e3));
+  approval_tests.emplace_back("",world1.temperature(position, 50e3));
+  approval_tests.emplace_back("",world1.temperature(position, 75e3));
+  approval_tests.emplace_back("",world1.temperature(position, 80e3));
+  approval_tests.emplace_back("",world1.temperature(position, 90e3));
+  approval_tests.emplace_back("",world1.temperature(position, 100e3));
+  approval_tests.emplace_back("",world1.temperature(position, 150e3));
+  approval_tests.emplace_back("",world1.temperature(position, 200e3));
 
   position = {{250e3,250e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 100)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 500)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 5000)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 50e3/2)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 50e3 - 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 50e3 + 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.temperature(position, std::sqrt(2) * 51e3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 3)));
+  approval_tests.emplace_back("",world1.temperature(position, 0));
+  approval_tests.emplace_back("",world1.temperature(position, 1));
+  approval_tests.emplace_back("",world1.temperature(position, 5));
+  approval_tests.emplace_back("",world1.temperature(position, 10));
+  approval_tests.emplace_back("",world1.temperature(position, 100));
+  approval_tests.emplace_back("",world1.temperature(position, 500));
+  approval_tests.emplace_back("",world1.temperature(position, 1000));
+  approval_tests.emplace_back("",world1.temperature(position, 5000));
+  approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 50e3/2));
+  approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 50e3 - 1));
+  approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 50e3 + 1));
+  approval_tests.emplace_back("",world1.temperature(position, std::sqrt(2) * 51e3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 0));
+  approval_tests.emplace_back("",world1.composition(position, 0, 1));
+  approval_tests.emplace_back("",world1.composition(position, 0, 2));
+  approval_tests.emplace_back("",world1.composition(position, 0, 3));
+  approval_tests.emplace_back("",world1.composition(position, 10, 0));
+  approval_tests.emplace_back("",world1.composition(position, 10, 1));
+  approval_tests.emplace_back("",world1.composition(position, 10, 2));
+  approval_tests.emplace_back("",world1.composition(position, 10, 3));
 
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 66e3 * 0.5 - 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 66e3 * 0.5 + 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 99e3 * 0.5 - 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 99e3 * 0.5 + 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 99e3 * 0.5 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 99e3 * 0.5 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 100e3 * 0.5 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, std::sqrt(2) * 100e3 * 0.5 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 0));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 2));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 0));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 2));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 66e3 * 0.5 - 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 66e3 * 0.5 + 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 99e3 * 0.5 - 1, 2));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 99e3 * 0.5 + 1, 2));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 99e3 * 0.5 - 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 99e3 * 0.5 + 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 100e3 * 0.5 - 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, std::sqrt(2) * 100e3 * 0.5 + 1, 3));
+  approval_tests.emplace_back("",world1.composition(position, 0, 4));
+  approval_tests.emplace_back("",world1.composition(position, 0, 5));
+  approval_tests.emplace_back("",world1.composition(position, 0, 6));
 
 
   // check grains
@@ -2839,142 +2839,142 @@ TEST_CASE("WorldBuilder Features: Fault")
     {
       // layer 1
       WorldBuilder::grains grains = world1.grains(position, std::sqrt(2) * 33e3 * 0.5 - 5e3, 0, 3);
-      approval_tests_grains.emplace_back(std::make_pair("",grains));
+      approval_tests_grains.emplace_back("",grains);
 
       grains = world1.grains(position, std::sqrt(2) * 33e3 * 0.5 - 5e3, 1, 3);
-      approval_tests_grains.emplace_back(std::make_pair("",grains));
+      approval_tests_grains.emplace_back("",grains);
     }
 
     {
       // layer 2
       WorldBuilder::grains grains = world1.grains(position, std::sqrt(2) * 33e3 * 0.5 + 1, 0, 3);
-      approval_tests_grains.emplace_back(std::make_pair("",grains));
+      approval_tests_grains.emplace_back("",grains);
 
       grains = world1.grains(position, std::sqrt(2) * 33e3 * 0.5 + 1, 1, 3);
-      approval_tests_grains.emplace_back(std::make_pair("",grains));
+      approval_tests_grains.emplace_back("",grains);
     }
 
     {
       // layer 3
       const WorldBuilder::grains grains = world1.grains(position, std::sqrt(2) * 99e3 * 0.5 - 5e3, 0, 3);
-      approval_tests_grains.emplace_back(std::make_pair("",grains));
+      approval_tests_grains.emplace_back("",grains);
     }
   }
 
 
   position = {{250e3,250e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 2)));
+  approval_tests.emplace_back("",world1.composition(position, 1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 1, 2));
   position = {{250e3,250e3-std::sqrt(2) * 33e3 * 0.5 + 1, 800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 2)));
+  approval_tests.emplace_back("",world1.composition(position, 1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 1, 2));
   position = {{250e3,250e3-std::sqrt(2) * 66e3 * 0.5 + 1, 800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 2)));
+  approval_tests.emplace_back("",world1.composition(position, 1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 1, 2));
   position = {{250e3,250e3-std::sqrt(2) * 99e3 * 0.5 + 1, 800e3}};
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1, 3)));
+  approval_tests.emplace_back("",world1.composition(position, 1, 0));
+  approval_tests.emplace_back("",world1.composition(position, 1, 1));
+  approval_tests.emplace_back("",world1.composition(position, 1, 2));
+  approval_tests.emplace_back("",world1.composition(position, 1, 3));
 
   const std::string file_name2 = WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR + "/tests/data/fault_constant_angles_cartesian_force_temp.wb";
   const WorldBuilder::World world2(file_name2);
 
   // Check fault plate through the world
   position = {{0,0,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 220e3)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 230e3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world2.temperature(position, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 220e3));
+  approval_tests.emplace_back("",world2.temperature(position, 230e3));
+  approval_tests.emplace_back("",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("",world2.composition(position, 0, 1));
+  approval_tests.emplace_back("",world2.composition(position, 0, 2));
+  approval_tests.emplace_back("",world2.composition(position, 0, 3));
+  approval_tests.emplace_back("",world2.composition(position, 0, 4));
+  approval_tests.emplace_back("",world2.composition(position, 0, 5));
+  approval_tests.emplace_back("",world2.composition(position, 0, 6));
 
   position = {{250e3,500e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, std::sqrt(2) * 50e3 - 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, std::sqrt(2) * 50e3 + 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 4)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 50e3 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 50e3 - 1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 50e3 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 50e3 + 1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world2.temperature(position, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 10));
+  approval_tests.emplace_back("",world2.temperature(position, std::sqrt(2) * 50e3 - 1));
+  approval_tests.emplace_back("",world2.temperature(position, std::sqrt(2) * 50e3 + 1));
+  approval_tests.emplace_back("",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("",world2.composition(position, 0, 1));
+  approval_tests.emplace_back("",world2.composition(position, 0, 2));
+  approval_tests.emplace_back("",world2.composition(position, 0, 3));
+  approval_tests.emplace_back("",world2.composition(position, 10, 0));
+  approval_tests.emplace_back("",world2.composition(position, 10, 1));
+  approval_tests.emplace_back("",world2.composition(position, 10, 2));
+  approval_tests.emplace_back("",world1.composition(position, 10, 3));
+  approval_tests.emplace_back("",world1.composition(position, 10, 4));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 50e3 - 1, 3));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 50e3 - 1, 4));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 50e3 + 1, 3));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 50e3 + 1, 4));
+  approval_tests.emplace_back("",world2.composition(position, 0, 4));
+  approval_tests.emplace_back("",world2.composition(position, 0, 5));
+  approval_tests.emplace_back("",world2.composition(position, 0, 6));
 
 
   position = {{250e3,250e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 5)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 100)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 500)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 1000)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, 5000)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, std::sqrt(2) * 50e3/2)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, std::sqrt(2) * 50e3 - 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.temperature(position, std::sqrt(2) * 50e3 + 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 10, 3)));
+  approval_tests.emplace_back("",world2.temperature(position, 0));
+  approval_tests.emplace_back("",world2.temperature(position, 1));
+  approval_tests.emplace_back("",world2.temperature(position, 5));
+  approval_tests.emplace_back("",world2.temperature(position, 10));
+  approval_tests.emplace_back("",world2.temperature(position, 100));
+  approval_tests.emplace_back("",world2.temperature(position, 500));
+  approval_tests.emplace_back("",world2.temperature(position, 1000));
+  approval_tests.emplace_back("",world2.temperature(position, 5000));
+  approval_tests.emplace_back("",world2.temperature(position, std::sqrt(2) * 50e3/2));
+  approval_tests.emplace_back("",world2.temperature(position, std::sqrt(2) * 50e3 - 1));
+  approval_tests.emplace_back("",world2.temperature(position, std::sqrt(2) * 50e3 + 1));
+  approval_tests.emplace_back("",world2.composition(position, 0, 0));
+  approval_tests.emplace_back("",world2.composition(position, 0, 1));
+  approval_tests.emplace_back("",world2.composition(position, 0, 2));
+  approval_tests.emplace_back("",world2.composition(position, 0, 3));
+  approval_tests.emplace_back("",world2.composition(position, 10, 0));
+  approval_tests.emplace_back("",world2.composition(position, 10, 1));
+  approval_tests.emplace_back("",world2.composition(position, 10, 2));
+  approval_tests.emplace_back("",world2.composition(position, 10, 3));
 
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 66e3 * 0.5 - 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 66e3 * 0.5 + 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 99e3 * 0.5 - 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 99e3 * 0.5 + 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 99e3 * 0.5 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 99e3 * 0.5 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 100e3 * 0.5 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, std::sqrt(2) * 100e3 * 0.5 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 0));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 1));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 - 1, 2));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 0));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 1));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 33e3 * 0.5 + 1, 2));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 66e3 * 0.5 - 1, 1));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 66e3 * 0.5 + 1, 1));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 99e3 * 0.5 - 1, 2));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 99e3 * 0.5 + 1, 2));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 99e3 * 0.5 - 1, 3));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 99e3 * 0.5 + 1, 3));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 100e3 * 0.5 - 1, 3));
+  approval_tests.emplace_back("",world2.composition(position, std::sqrt(2) * 100e3 * 0.5 + 1, 3));
+  approval_tests.emplace_back("",world2.composition(position, 0, 4));
+  approval_tests.emplace_back("",world2.composition(position, 0, 5));
+  approval_tests.emplace_back("",world2.composition(position, 0, 6));
 
   position = {{250e3,250e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 2)));
+  approval_tests.emplace_back("",world2.composition(position, 1, 0));
+  approval_tests.emplace_back("",world2.composition(position, 1, 1));
+  approval_tests.emplace_back("",world2.composition(position, 1, 2));
   position = {{250e3,250e3-std::sqrt(2) * 33e3 * 0.5 + 1, 800e3}};
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 2)));
+  approval_tests.emplace_back("",world2.composition(position, 1, 0));
+  approval_tests.emplace_back("",world2.composition(position, 1, 1));
+  approval_tests.emplace_back("",world2.composition(position, 1, 2));
   position = {{250e3,250e3-std::sqrt(2) * 66e3 * 0.5 + 1, 800e3}};
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 2)));
+  approval_tests.emplace_back("",world2.composition(position, 1, 0));
+  approval_tests.emplace_back("",world2.composition(position, 1, 1));
+  approval_tests.emplace_back("",world2.composition(position, 1, 2));
   position = {{250e3,250e3-std::sqrt(2) * 99e3 * 0.5 + 1, 800e3}};
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world2.composition(position, 1, 3)));
+  approval_tests.emplace_back("",world2.composition(position, 1, 0));
+  approval_tests.emplace_back("",world2.composition(position, 1, 1));
+  approval_tests.emplace_back("",world2.composition(position, 1, 2));
+  approval_tests.emplace_back("",world2.composition(position, 1, 3));
 
 
   // Cartesian
@@ -2986,253 +2986,253 @@ TEST_CASE("WorldBuilder Features: Fault")
 
   // Check fault through the world
   position = {{0,0,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 240e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 260e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world3.temperature(position, 0));
+  approval_tests.emplace_back("",world3.temperature(position, 240e3));
+  approval_tests.emplace_back("",world3.temperature(position, 260e3));
+  approval_tests.emplace_back("",world3.composition(position, 0, 0));
+  approval_tests.emplace_back("",world3.composition(position, 0, 1));
+  approval_tests.emplace_back("",world3.composition(position, 0, 2));
+  approval_tests.emplace_back("",world3.composition(position, 0, 3));
+  approval_tests.emplace_back("",world3.composition(position, 0, 4));
+  approval_tests.emplace_back("",world3.composition(position, 0, 5));
+  approval_tests.emplace_back("",world3.composition(position, 0, 6));
 
   position = {{250e3,500e3,800e3}};
   //adibatic temperature
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 5000)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 25e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 75e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 150e3)));
-  //approval_tests.emplace_back(std::make_pair("",world3.temperature(position, std::sqrt(2) * 100e3 - 1)));
-  //approval_tests.emplace_back(std::make_pair("",world3.temperature(position, std::sqrt(2) * 100e3 + 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 4)));
+  approval_tests.emplace_back("",world3.temperature(position, 0));
+  approval_tests.emplace_back("",world3.temperature(position, 1));
+  approval_tests.emplace_back("",world3.temperature(position, 5000));
+  approval_tests.emplace_back("",world3.temperature(position, 10e3));
+  approval_tests.emplace_back("",world3.temperature(position, 25e3));
+  approval_tests.emplace_back("",world3.temperature(position, 50e3));
+  approval_tests.emplace_back("",world3.temperature(position, 75e3));
+  approval_tests.emplace_back("",world3.temperature(position, 150e3));
+  //approval_tests.emplace_back("",world3.temperature(position, std::sqrt(2) * 100e3 - 1));
+  //approval_tests.emplace_back("",world3.temperature(position, std::sqrt(2) * 100e3 + 1));
+  approval_tests.emplace_back("",world3.composition(position, 0, 0));
+  approval_tests.emplace_back("",world3.composition(position, 0, 1));
+  approval_tests.emplace_back("",world3.composition(position, 0, 2));
+  approval_tests.emplace_back("",world3.composition(position, 0, 3));
+  approval_tests.emplace_back("",world3.composition(position, 0, 4));
+  approval_tests.emplace_back("",world3.composition(position, 10, 0));
+  approval_tests.emplace_back("",world3.composition(position, 10, 1));
+  approval_tests.emplace_back("",world3.composition(position, 10, 2));
+  approval_tests.emplace_back("",world3.composition(position, 10, 3));
+  approval_tests.emplace_back("",world3.composition(position, 10, 4));
   //todo: recheck these results
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 16.5e3 - 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 16.5e3 + 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 16.5e3 - 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 16.5e3 + 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 33e3 - 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 33e3 + 1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 33e3 - 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 33e3 + 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 33e3 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 49.5e3 - 1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 49.5e3 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 49.5e3 + 1, 2)));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 16.5e3 - 1, 0));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 16.5e3 + 1, 0));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 16.5e3 - 1, 1));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 16.5e3 + 1, 1));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 33e3 - 1, 1));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 33e3 + 1, 1));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 33e3 - 1, 2));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 33e3 + 1, 2));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 33e3 + 1, 3));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 49.5e3 - 1, 2));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 49.5e3 - 1, 3));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 49.5e3 + 1, 2));
   // this comes form the first subducting plate
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 49.5e3 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 50e3 - 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, std::sqrt(2) * 50e3 + 1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 49.5e3 + 1, 3));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 50e3 - 1, 3));
+  approval_tests.emplace_back("",world3.composition(position, std::sqrt(2) * 50e3 + 1, 3));
+  approval_tests.emplace_back("",world3.composition(position, 0, 4));
+  approval_tests.emplace_back("",world3.composition(position, 0, 5));
+  approval_tests.emplace_back("",world3.composition(position, 0, 6));
 
   {
     const WorldBuilder::grains grains = world3.grains(position, std::sqrt(2) * 33e3 * 0.5 - 1, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   position = {{250e3,600e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 100e3-1)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 100e3+1)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 101e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 110e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 200e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3-1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3-1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3-1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3-1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3-1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world3.temperature(position, 0));
+  approval_tests.emplace_back("",world3.temperature(position, 10));
+  approval_tests.emplace_back("",world3.temperature(position, 100e3-1));
+  approval_tests.emplace_back("",world3.temperature(position, 100e3+1));
+  approval_tests.emplace_back("",world3.temperature(position, 101e3));
+  approval_tests.emplace_back("",world3.temperature(position, 110e3));
+  approval_tests.emplace_back("",world3.temperature(position, 150e3));
+  approval_tests.emplace_back("",world3.temperature(position, 200e3));
+  approval_tests.emplace_back("",world3.composition(position, 0, 0));
+  approval_tests.emplace_back("",world3.composition(position, 0, 1));
+  approval_tests.emplace_back("",world3.composition(position, 0, 2));
+  approval_tests.emplace_back("",world3.composition(position, 0, 3));
+  approval_tests.emplace_back("",world3.composition(position, 10, 0));
+  approval_tests.emplace_back("",world3.composition(position, 10, 1));
+  approval_tests.emplace_back("",world3.composition(position, 10, 2));
+  approval_tests.emplace_back("",world3.composition(position, 10, 3));
+  approval_tests.emplace_back("",world3.composition(position, 100e3-1, 0));
+  approval_tests.emplace_back("",world3.composition(position, 100e3-1, 1));
+  approval_tests.emplace_back("",world3.composition(position, 100e3-1, 2));
+  approval_tests.emplace_back("",world3.composition(position, 100e3-1, 3));
+  approval_tests.emplace_back("",world3.composition(position, 100e3-1, 4));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 0));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 1));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 2));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 3));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 4));
+  approval_tests.emplace_back("",world3.composition(position, 101e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 1));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 2));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 3));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 4));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 1));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 2));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 3));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 4));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 1));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 2));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 3));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 4));
+  approval_tests.emplace_back("",world3.composition(position, 0, 4));
+  approval_tests.emplace_back("",world3.composition(position, 0, 5));
+  approval_tests.emplace_back("",world3.composition(position, 0, 6));
 
   {
     const WorldBuilder::grains grains = world3.grains(position, 101e3+1, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   position = {{650e3,650e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 100e3+1)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 101e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 110e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 200e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world3.temperature(position, 0));
+  approval_tests.emplace_back("",world3.temperature(position, 10));
+  approval_tests.emplace_back("",world3.temperature(position, 100e3));
+  approval_tests.emplace_back("",world3.temperature(position, 100e3+1));
+  approval_tests.emplace_back("",world3.temperature(position, 101e3));
+  approval_tests.emplace_back("",world3.temperature(position, 110e3));
+  approval_tests.emplace_back("",world3.temperature(position, 150e3));
+  approval_tests.emplace_back("",world3.temperature(position, 200e3));
+  approval_tests.emplace_back("",world3.composition(position, 0, 0));
+  approval_tests.emplace_back("",world3.composition(position, 0, 1));
+  approval_tests.emplace_back("",world3.composition(position, 0, 2));
+  approval_tests.emplace_back("",world3.composition(position, 0, 3));
+  approval_tests.emplace_back("",world3.composition(position, 10, 0));
+  approval_tests.emplace_back("",world3.composition(position, 10, 1));
+  approval_tests.emplace_back("",world3.composition(position, 10, 2));
+  approval_tests.emplace_back("",world3.composition(position, 10, 3));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 1));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 2));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 3));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 4));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 0));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 1));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 2));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 3));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 4));
+  approval_tests.emplace_back("",world3.composition(position, 101e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 1));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 2));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 3));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 4));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 1));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 2));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 3));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 4));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 1));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 2));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 3));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 4));
+  approval_tests.emplace_back("",world3.composition(position, 0, 4));
+  approval_tests.emplace_back("",world3.composition(position, 0, 5));
+  approval_tests.emplace_back("",world3.composition(position, 0, 6));
 
   {
     const WorldBuilder::grains grains = world3.grains(position, 100e3+1, 0, 3);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   position = {{700e3,675e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 100e3+1)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 101e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 110e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 200e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 10, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 100e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 101e3+1, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 150e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 1)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 2)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 3)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 200e3, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 4)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 5)));
-  approval_tests.emplace_back(std::make_pair("",world3.composition(position, 0, 6)));
+  approval_tests.emplace_back("",world3.temperature(position, 0));
+  approval_tests.emplace_back("",world3.temperature(position, 10));
+  approval_tests.emplace_back("",world3.temperature(position, 100e3));
+  approval_tests.emplace_back("",world3.temperature(position, 100e3+1));
+  approval_tests.emplace_back("",world3.temperature(position, 101e3));
+  approval_tests.emplace_back("",world3.temperature(position, 110e3));
+  approval_tests.emplace_back("",world3.temperature(position, 150e3));
+  approval_tests.emplace_back("",world3.temperature(position, 200e3));
+  approval_tests.emplace_back("",world3.composition(position, 0, 0));
+  approval_tests.emplace_back("",world3.composition(position, 0, 1));
+  approval_tests.emplace_back("",world3.composition(position, 0, 2));
+  approval_tests.emplace_back("",world3.composition(position, 0, 3));
+  approval_tests.emplace_back("",world3.composition(position, 10, 0));
+  approval_tests.emplace_back("",world3.composition(position, 10, 1));
+  approval_tests.emplace_back("",world3.composition(position, 10, 2));
+  approval_tests.emplace_back("",world3.composition(position, 10, 3));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 1));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 2));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 3));
+  approval_tests.emplace_back("",world3.composition(position, 100e3, 4));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 0));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 1));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 2));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 3));
+  approval_tests.emplace_back("",world3.composition(position, 100e3+1, 4));
+  approval_tests.emplace_back("",world3.composition(position, 101e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 1));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 2));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 3));
+  approval_tests.emplace_back("",world3.composition(position, 101e3+1, 4));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 1));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 2));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 3));
+  approval_tests.emplace_back("",world3.composition(position, 150e3, 4));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 0));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 1));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 2));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 3));
+  approval_tests.emplace_back("",world3.composition(position, 200e3, 4));
+  approval_tests.emplace_back("",world3.composition(position, 0, 4));
+  approval_tests.emplace_back("",world3.composition(position, 0, 5));
+  approval_tests.emplace_back("",world3.composition(position, 0, 6));
 
   position = {{750e3,35e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 10)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 5e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 15e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 20e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 25e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 30e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 35e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 40e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 45e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 55e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 60e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 65e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 70e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 72.5e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 75e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 80e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 85e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 90e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 95e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 105e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 110e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 115e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 120e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 125e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 130e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 135e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 150e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 160e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 170e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 175e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 180e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 190e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 200e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 250e3)));
-  approval_tests.emplace_back(std::make_pair("",world3.temperature(position, 300e3)));
+  approval_tests.emplace_back("",world3.temperature(position, 0));
+  approval_tests.emplace_back("",world3.temperature(position, 10));
+  approval_tests.emplace_back("",world3.temperature(position, 5e3));
+  approval_tests.emplace_back("",world3.temperature(position, 10e3));
+  approval_tests.emplace_back("",world3.temperature(position, 15e3));
+  approval_tests.emplace_back("",world3.temperature(position, 20e3));
+  approval_tests.emplace_back("",world3.temperature(position, 25e3));
+  approval_tests.emplace_back("",world3.temperature(position, 30e3));
+  approval_tests.emplace_back("",world3.temperature(position, 35e3));
+  approval_tests.emplace_back("",world3.temperature(position, 40e3));
+  approval_tests.emplace_back("",world3.temperature(position, 45e3));
+  approval_tests.emplace_back("",world3.temperature(position, 50e3));
+  approval_tests.emplace_back("",world3.temperature(position, 55e3));
+  approval_tests.emplace_back("",world3.temperature(position, 60e3));
+  approval_tests.emplace_back("",world3.temperature(position, 65e3));
+  approval_tests.emplace_back("",world3.temperature(position, 70e3));
+  approval_tests.emplace_back("",world3.temperature(position, 72.5e3));
+  approval_tests.emplace_back("",world3.temperature(position, 75e3));
+  approval_tests.emplace_back("",world3.temperature(position, 80e3));
+  approval_tests.emplace_back("",world3.temperature(position, 85e3));
+  approval_tests.emplace_back("",world3.temperature(position, 90e3));
+  approval_tests.emplace_back("",world3.temperature(position, 95e3));
+  approval_tests.emplace_back("",world3.temperature(position, 100e3));
+  approval_tests.emplace_back("",world3.temperature(position, 105e3));
+  approval_tests.emplace_back("",world3.temperature(position, 110e3));
+  approval_tests.emplace_back("",world3.temperature(position, 115e3));
+  approval_tests.emplace_back("",world3.temperature(position, 120e3));
+  approval_tests.emplace_back("",world3.temperature(position, 125e3));
+  approval_tests.emplace_back("",world3.temperature(position, 130e3));
+  approval_tests.emplace_back("",world3.temperature(position, 135e3));
+  approval_tests.emplace_back("",world3.temperature(position, 150e3));
+  approval_tests.emplace_back("",world3.temperature(position, 160e3));
+  approval_tests.emplace_back("",world3.temperature(position, 170e3));
+  approval_tests.emplace_back("",world3.temperature(position, 175e3));
+  approval_tests.emplace_back("",world3.temperature(position, 180e3));
+  approval_tests.emplace_back("",world3.temperature(position, 190e3));
+  approval_tests.emplace_back("",world3.temperature(position, 200e3));
+  approval_tests.emplace_back("",world3.temperature(position, 250e3));
+  approval_tests.emplace_back("",world3.temperature(position, 300e3));
 
   // check grains layer 1
   {
@@ -3240,22 +3240,22 @@ TEST_CASE("WorldBuilder Features: Fault")
     // these are random numbers, but they should stay the same.
     // note that the values are different from for example the continental plate since
     // this performs a interpolation between segments of the slab.
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
   }
 
   // check grains layer 2 bottom (because of the randomness it will have different values.)
   {
     const WorldBuilder::grains grains = world3.grains(position, 150e3, 0, 2);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
 
   }
 
   // check grains layer 2 top
   {
     const WorldBuilder::grains grains = world3.grains(position, 35e3, 0, 2);
-    approval_tests_grains.emplace_back(std::make_pair("",grains));
+    approval_tests_grains.emplace_back("",grains);
     //compare_vectors_approx(grains.sizes, {0.3512381923,0.6487618077});
-    //approval_tests.emplace_back(std::make_pair("",grains.sizes[0] + grains.sizes[1]));
+    //approval_tests.emplace_back("",grains.sizes[0] + grains.sizes[1]);
     //// these are random numbers, but they should stay the same.
 //
     //std::array<std::array<double, 3>, 3> array_1 = {{{{-0.5760272563,-0.3302260164,0.7477589038}},{{-0.3927671635,-0.6904395086,-0.6074761232}},{{0.7168867103,-0.6436179481,0.26801004}}}};
@@ -3269,32 +3269,32 @@ TEST_CASE("WorldBuilder Features: Fault")
   const WorldBuilder::World world4(file_name);
 
   position = {{250e3,501e3,800e3}};
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 0, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 1)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 1e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 1e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 10e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 10e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 20e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 20e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 30e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 30e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 35e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 35e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 40e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 40e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 45e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 45e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 50e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 50e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 60e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 60e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 80e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 80e3, 0)));
-  approval_tests.emplace_back(std::make_pair("",world4.temperature(position, 100e3)));
-  approval_tests.emplace_back(std::make_pair("",world4.composition(position, 100e3, 0)));
+  approval_tests.emplace_back("",world4.temperature(position, 0));
+  approval_tests.emplace_back("",world4.composition(position, 0, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 1));
+  approval_tests.emplace_back("",world4.composition(position, 1, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 1e3));
+  approval_tests.emplace_back("",world4.composition(position, 1e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 10e3));
+  approval_tests.emplace_back("",world4.composition(position, 10e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 20e3));
+  approval_tests.emplace_back("",world4.composition(position, 20e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 30e3));
+  approval_tests.emplace_back("",world4.composition(position, 30e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 35e3));
+  approval_tests.emplace_back("",world4.composition(position, 35e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 40e3));
+  approval_tests.emplace_back("",world4.composition(position, 40e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 45e3));
+  approval_tests.emplace_back("",world4.composition(position, 45e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 50e3));
+  approval_tests.emplace_back("",world4.composition(position, 50e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 60e3));
+  approval_tests.emplace_back("",world4.composition(position, 60e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 80e3));
+  approval_tests.emplace_back("",world4.composition(position, 80e3, 0));
+  approval_tests.emplace_back("",world4.temperature(position, 100e3));
+  approval_tests.emplace_back("",world4.composition(position, 100e3, 0));
 
   std::vector<std::string> approvals;
   for (auto&& value : approval_tests)
@@ -3321,60 +3321,60 @@ TEST_CASE("WorldBuilder Features: coordinate interpolation")
     const WorldBuilder::World world1(file_name);
 
     std::array<double,3> position = {{374e3,875e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
     position = {{376e3,875e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
     position = {{350e3,900e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
 
     position = {{375e3,874e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
     position = {{375e3,876e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
 
 
     position = {{374e3,625e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
     position = {{376e3,625e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
     position = {{350e3,600e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
 
     position = {{375e3,624e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
     position = {{375e3,626e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 0, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 0));
+    approval_tests.emplace_back("",world1.composition(position, 0, 0));
 
 
     position = {{638e3,425e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 10));
+    approval_tests.emplace_back("",world1.composition(position, 10, 0));
     position = {{637e3,425e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 10));
+    approval_tests.emplace_back("",world1.composition(position, 10, 0));
     position = {{617.5e3,445e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 1e3)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 1e3, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 1e3));
+    approval_tests.emplace_back("",world1.composition(position, 1e3, 0));
 
     position = {{625e3,200e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 10));
+    approval_tests.emplace_back("",world1.composition(position, 10, 0));
     position = {{624e3,200e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 10)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 10, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 10));
+    approval_tests.emplace_back("",world1.composition(position, 10, 0));
     position = {{607e3,180e3,800e3}};
-    approval_tests.emplace_back(std::make_pair("",world1.temperature(position, 3e3)));
-    approval_tests.emplace_back(std::make_pair("",world1.composition(position, 3e3, 0)));
+    approval_tests.emplace_back("",world1.temperature(position, 3e3));
+    approval_tests.emplace_back("",world1.composition(position, 3e3, 0));
   }
 
   std::vector<std::string> approvals;
@@ -3468,7 +3468,7 @@ TEST_CASE("WorldBuilder Types: Point 2d")
   CHECK(type.description == "test");
   CHECK(type.get_type() == Types::type::Point2D);
 
-  Types::TYPE type_copy(type);
+  const Types::TYPE &type_copy(type);
   CHECK(type_copy.value[0] == Approx(TYPE(1,2,cartesian)[0]));
   CHECK(type_copy.value[1] == Approx(TYPE(1,2,cartesian)[1]));
   CHECK(type.default_value[0] == Approx(TYPE(1,2,cartesian)[0]));
@@ -3557,7 +3557,7 @@ TEST_CASE("WorldBuilder Types: Point 3d")
   CHECK(type.description == "test");
   CHECK(type.get_type() == Types::type::Point3D);
 
-  Types::TYPE type_copy(type);
+  const Types::TYPE &type_copy(type);
   CHECK(type_copy.value[0] == Approx(1.0));
   CHECK(type_copy.value[1] == Approx(2.0));
   CHECK(type_copy.value[2] == Approx(3.0));
@@ -3675,7 +3675,7 @@ TEST_CASE("WorldBuilder Types: PluginSystem")
   CHECK(type.allow_multiple == false);
   CHECK(type.get_type() == Types::type::TYPE);
 
-  Types::TYPE type_copy(type);
+  const Types::TYPE &type_copy(type);
   CHECK(type_copy.default_value == "test");
   CHECK(type_copy.required_entries[0] == "test required");
   CHECK(type_copy.allow_multiple == false);
@@ -3713,8 +3713,8 @@ TEST_CASE("WorldBuilder Types: Segment Object")
   CHECK(type.value_angle[0] == Approx(5.0));
   CHECK(type.value_angle[1] == Approx(6.0));
 
-  Objects::TYPE<Features::FaultModels::Temperature::Interface, Features::FaultModels::Composition::Interface, Features::FaultModels::Grains::Interface, Features::FaultModels::Velocity::Interface>
-  type_copy(type);
+  const Objects::TYPE<Features::FaultModels::Temperature::Interface, Features::FaultModels::Composition::Interface, Features::FaultModels::Grains::Interface, Features::FaultModels::Velocity::Interface>
+  &type_copy(type);
   const double &value_length = type_copy.value_length;
   CHECK(value_length == Approx(1.0));
   CHECK(type_copy.value_thickness[0] == Approx(1.0));
@@ -3776,7 +3776,7 @@ TEST_CASE("WorldBuilder Types: Object")
   CHECK(type.additional_properties == true);
   CHECK(type.get_type() == Types::type::TYPE);
 
-  Types::TYPE type_copy(type);
+  const Types::TYPE &type_copy(type);
   CHECK(type_copy.required.size() == 2);
   CHECK(type_copy.required[0] == "test1");
   CHECK(type_copy.required[1] == "test2");
@@ -4001,7 +4001,7 @@ TEST_CASE("WorldBuilder Types: print_tree")
          "     }\n"
          "   }\n"
          " }";
-  approval_tests.emplace_back(std::make_pair("",Utilities::print_tree(tree, 0)));
+  approval_tests.emplace_back("",Utilities::print_tree(tree, 0));
 }*/
 
 TEST_CASE("WorldBuilder Parameters")
@@ -4014,7 +4014,7 @@ TEST_CASE("WorldBuilder Parameters")
   WorldBuilder::World world(file_name);
 
   world.parse_entries(world.parameters);
-  approval_tests.emplace_back(std::make_pair("1",std::isinf(world.parameters.coordinate_system->max_model_depth())));
+  approval_tests.emplace_back("1",std::isinf(world.parameters.coordinate_system->max_model_depth()));
 
   Parameters prm(world);
   prm.initialize(file);
@@ -4087,65 +4087,65 @@ TEST_CASE("WorldBuilder Parameters")
   CHECK_THROWS_WITH(prm.get("value at points non existent",additional_points), Contains("internal error: could not retrieve"));
   std::pair<std::vector<double>,std::vector<double>> v_at_p_one_value = prm.get("one value at points one value",additional_points);
 
-  approval_tests.emplace_back(std::make_pair("2",static_cast<double>(v_at_p_one_value.first.size())));
-  approval_tests.emplace_back(std::make_pair("3",static_cast<double>(v_at_p_one_value.first[0])));
-  approval_tests.emplace_back(std::make_pair("4",static_cast<double>(v_at_p_one_value.second.size())));
+  approval_tests.emplace_back("2",static_cast<double>(v_at_p_one_value.first.size()));
+  approval_tests.emplace_back("3",static_cast<double>(v_at_p_one_value.first[0]));
+  approval_tests.emplace_back("4",static_cast<double>(v_at_p_one_value.second.size()));
 
   {
     const Objects::Surface surface(v_at_p_one_value);
-    approval_tests.emplace_back(std::make_pair("5",surface.local_value(Point<2>(0,0,CoordinateSystem::cartesian)).interpolated_value));
+    approval_tests.emplace_back("5",surface.local_value(Point<2>(0,0,CoordinateSystem::cartesian)).interpolated_value);
   }
   std::pair<std::vector<double>,std::vector<double>> v_at_p_one_array_value = prm.get("array value at points one value",additional_points);
 
-  approval_tests.emplace_back(std::make_pair("6",static_cast<double>(v_at_p_one_array_value.first.size())));
-  approval_tests.emplace_back(std::make_pair("7",static_cast<double>(v_at_p_one_array_value.first[0])));
-  approval_tests.emplace_back(std::make_pair("8",static_cast<double>(v_at_p_one_array_value.second.size())));
+  approval_tests.emplace_back("6",static_cast<double>(v_at_p_one_array_value.first.size()));
+  approval_tests.emplace_back("7",static_cast<double>(v_at_p_one_array_value.first[0]));
+  approval_tests.emplace_back("8",static_cast<double>(v_at_p_one_array_value.second.size()));
 
   std::pair<std::vector<double>,std::vector<double>> v_at_p_full_default = prm.get("value at points",additional_points);
 
-  approval_tests.emplace_back(std::make_pair("9",static_cast<double>(v_at_p_full_default.first.size())));
-  approval_tests.emplace_back(std::make_pair("10",static_cast<double>(v_at_p_full_default.first[0])));
-  approval_tests.emplace_back(std::make_pair("11",static_cast<double>(v_at_p_full_default.second.size())));
+  approval_tests.emplace_back("9",static_cast<double>(v_at_p_full_default.first.size()));
+  approval_tests.emplace_back("10",static_cast<double>(v_at_p_full_default.first[0]));
+  approval_tests.emplace_back("11",static_cast<double>(v_at_p_full_default.second.size()));
 
   std::pair<std::vector<double>,std::vector<double>> v_at_p_dap = prm.get("value at points default ap",additional_points);
 
-  approval_tests.emplace_back(std::make_pair("12",static_cast<double>(v_at_p_dap.first.size())));
-  approval_tests.emplace_back(std::make_pair("13",v_at_p_dap.first[0]));
-  approval_tests.emplace_back(std::make_pair("14",v_at_p_dap.first[1]));
-  approval_tests.emplace_back(std::make_pair("15",v_at_p_dap.first[2]));
-  approval_tests.emplace_back(std::make_pair("16",v_at_p_dap.first[3]));
-  approval_tests.emplace_back(std::make_pair("17",v_at_p_dap.first[4]));
-  approval_tests.emplace_back(std::make_pair("18",v_at_p_dap.first[5]));
-  approval_tests.emplace_back(std::make_pair("19",v_at_p_dap.first[6]));
-  approval_tests.emplace_back(std::make_pair("21",static_cast<double>(v_at_p_dap.second.size())));
-  approval_tests.emplace_back(std::make_pair("22",v_at_p_dap.second[0]));
-  approval_tests.emplace_back(std::make_pair("23",v_at_p_dap.second[1]));
-  approval_tests.emplace_back(std::make_pair("24",v_at_p_dap.second[2]));
-  approval_tests.emplace_back(std::make_pair("25",v_at_p_dap.second[3]));
-  approval_tests.emplace_back(std::make_pair("26",v_at_p_dap.second[4]));
-  approval_tests.emplace_back(std::make_pair("27",v_at_p_dap.second[5]));
-  approval_tests.emplace_back(std::make_pair("28",v_at_p_dap.second[6]));
-  approval_tests.emplace_back(std::make_pair("29",v_at_p_dap.second[7]));
-  approval_tests.emplace_back(std::make_pair("31",v_at_p_dap.second[8]));
-  approval_tests.emplace_back(std::make_pair("32",v_at_p_dap.second[9]));
-  approval_tests.emplace_back(std::make_pair("33",v_at_p_dap.second[10]));
-  approval_tests.emplace_back(std::make_pair("34",v_at_p_dap.second[11]));
-  approval_tests.emplace_back(std::make_pair("35",v_at_p_dap.second[12]));
-  approval_tests.emplace_back(std::make_pair("36",v_at_p_dap.second[13]));
+  approval_tests.emplace_back("12",static_cast<double>(v_at_p_dap.first.size()));
+  approval_tests.emplace_back("13",v_at_p_dap.first[0]);
+  approval_tests.emplace_back("14",v_at_p_dap.first[1]);
+  approval_tests.emplace_back("15",v_at_p_dap.first[2]);
+  approval_tests.emplace_back("16",v_at_p_dap.first[3]);
+  approval_tests.emplace_back("17",v_at_p_dap.first[4]);
+  approval_tests.emplace_back("18",v_at_p_dap.first[5]);
+  approval_tests.emplace_back("19",v_at_p_dap.first[6]);
+  approval_tests.emplace_back("21",static_cast<double>(v_at_p_dap.second.size()));
+  approval_tests.emplace_back("22",v_at_p_dap.second[0]);
+  approval_tests.emplace_back("23",v_at_p_dap.second[1]);
+  approval_tests.emplace_back("24",v_at_p_dap.second[2]);
+  approval_tests.emplace_back("25",v_at_p_dap.second[3]);
+  approval_tests.emplace_back("26",v_at_p_dap.second[4]);
+  approval_tests.emplace_back("27",v_at_p_dap.second[5]);
+  approval_tests.emplace_back("28",v_at_p_dap.second[6]);
+  approval_tests.emplace_back("29",v_at_p_dap.second[7]);
+  approval_tests.emplace_back("31",v_at_p_dap.second[8]);
+  approval_tests.emplace_back("32",v_at_p_dap.second[9]);
+  approval_tests.emplace_back("33",v_at_p_dap.second[10]);
+  approval_tests.emplace_back("34",v_at_p_dap.second[11]);
+  approval_tests.emplace_back("35",v_at_p_dap.second[12]);
+  approval_tests.emplace_back("36",v_at_p_dap.second[13]);
 
   {
     const Objects::Surface surface(v_at_p_dap);
 
-    approval_tests.emplace_back(std::make_pair("37",surface.local_value(Point<2>(0,0,CoordinateSystem::cartesian)).interpolated_value));
-    approval_tests.emplace_back(std::make_pair("38",surface.local_value(Point<2>(0.99,1.99,CoordinateSystem::cartesian)).interpolated_value));
-    approval_tests.emplace_back(std::make_pair("39",surface.local_value(Point<2>(1.01,2.01,CoordinateSystem::cartesian)).interpolated_value));
-    approval_tests.emplace_back(std::make_pair("40",surface.local_value(Point<2>(0.99,0.99,CoordinateSystem::cartesian)).interpolated_value));
-    approval_tests.emplace_back(std::make_pair("41",surface.local_value(Point<2>(1.01,1.01,CoordinateSystem::cartesian)).interpolated_value));
-    approval_tests.emplace_back(std::make_pair("42",surface.local_value(Point<2>(2.99,3.99,CoordinateSystem::cartesian)).interpolated_value));
-    approval_tests.emplace_back(std::make_pair("43",surface.local_value(Point<2>(2.01,4.01,CoordinateSystem::cartesian)).interpolated_value));
-    approval_tests.emplace_back(std::make_pair("44",surface.local_value(Point<2>(-0.5,7.48,CoordinateSystem::cartesian)).interpolated_value));
-    approval_tests.emplace_back(std::make_pair("45",surface.local_value(Point<2>(-1,7.6,CoordinateSystem::cartesian)).interpolated_value));
-    approval_tests.emplace_back(std::make_pair("46",surface.local_value(Point<2>(-2.4,8.2,CoordinateSystem::cartesian)).interpolated_value));
+    approval_tests.emplace_back("37",surface.local_value(Point<2>(0,0,CoordinateSystem::cartesian)).interpolated_value);
+    approval_tests.emplace_back("38",surface.local_value(Point<2>(0.99,1.99,CoordinateSystem::cartesian)).interpolated_value);
+    approval_tests.emplace_back("39",surface.local_value(Point<2>(1.01,2.01,CoordinateSystem::cartesian)).interpolated_value);
+    approval_tests.emplace_back("40",surface.local_value(Point<2>(0.99,0.99,CoordinateSystem::cartesian)).interpolated_value);
+    approval_tests.emplace_back("41",surface.local_value(Point<2>(1.01,1.01,CoordinateSystem::cartesian)).interpolated_value);
+    approval_tests.emplace_back("42",surface.local_value(Point<2>(2.99,3.99,CoordinateSystem::cartesian)).interpolated_value);
+    approval_tests.emplace_back("43",surface.local_value(Point<2>(2.01,4.01,CoordinateSystem::cartesian)).interpolated_value);
+    approval_tests.emplace_back("44",surface.local_value(Point<2>(-0.5,7.48,CoordinateSystem::cartesian)).interpolated_value);
+    approval_tests.emplace_back("45",surface.local_value(Point<2>(-1,7.6,CoordinateSystem::cartesian)).interpolated_value);
+    approval_tests.emplace_back("46",surface.local_value(Point<2>(-2.4,8.2,CoordinateSystem::cartesian)).interpolated_value);
     CHECK_THROWS_WITH(surface.local_value(Point<2>(11,11,CoordinateSystem::cartesian)), Contains("The requested point was not in any triangle."));
   }
 
@@ -4169,7 +4169,7 @@ TEST_CASE("WorldBuilder Parameters")
                     Contains("internal error: could not retrieve the minItems value at"));
 
 
-  typedef std::array<double,3> array_3d;
+  using array_3d = std::array<double,3>;
   CHECK_THROWS_WITH(prm.get_vector<array_3d>("vector of 3d arrays nan"),
                     Contains("Could not convert values of /vector of 3d arrays nan/0 into doubles."));
 
@@ -4196,15 +4196,15 @@ TEST_CASE("WorldBuilder Parameters")
   prm.leave_subsection();
 
   std::vector<unsigned int> v_int = prm.get_vector<unsigned int>("now existent unsigned int vector");
-  approval_tests.emplace_back(std::make_pair("47",static_cast<double>(v_int.size())));
-  approval_tests.emplace_back(std::make_pair("48",static_cast<double>(v_int[0])));
-  approval_tests.emplace_back(std::make_pair("49",static_cast<double>(v_int[1])));
+  approval_tests.emplace_back("47",static_cast<double>(v_int.size()));
+  approval_tests.emplace_back("48",static_cast<double>(v_int[0]));
+  approval_tests.emplace_back("49",static_cast<double>(v_int[1]));
 
   v_int = prm.get_vector<unsigned int>("unsigned int array");
-  approval_tests.emplace_back(std::make_pair("50",static_cast<double>(v_int.size())));
-  approval_tests.emplace_back(std::make_pair("51",static_cast<double>(v_int[0])));
-  approval_tests.emplace_back(std::make_pair("52",static_cast<double>(v_int[1])));
-  approval_tests.emplace_back(std::make_pair("53",static_cast<double>(v_int[2])));
+  approval_tests.emplace_back("50",static_cast<double>(v_int.size()));
+  approval_tests.emplace_back("51",static_cast<double>(v_int[0]));
+  approval_tests.emplace_back("52",static_cast<double>(v_int[1]));
+  approval_tests.emplace_back("53",static_cast<double>(v_int[2]));
 
   CHECK_THROWS_WITH(prm.get_vector<size_t>("non existent unsigned int vector"),
                     Contains("internal error: could not retrieve the minItems value"));
@@ -4212,15 +4212,15 @@ TEST_CASE("WorldBuilder Parameters")
 
 
   std::vector<size_t> v_size_t = prm.get_vector<size_t>("now existent unsigned int vector");
-  approval_tests.emplace_back(std::make_pair("54",static_cast<double>(v_size_t.size())));
-  approval_tests.emplace_back(std::make_pair("55",static_cast<double>(v_size_t[0])));
-  approval_tests.emplace_back(std::make_pair("56",static_cast<double>(v_size_t[1])));
+  approval_tests.emplace_back("54",static_cast<double>(v_size_t.size()));
+  approval_tests.emplace_back("55",static_cast<double>(v_size_t[0]));
+  approval_tests.emplace_back("56",static_cast<double>(v_size_t[1]));
 
   v_size_t = prm.get_vector<size_t>("unsigned int array");
-  approval_tests.emplace_back(std::make_pair("57",static_cast<double>(v_size_t.size())));
-  approval_tests.emplace_back(std::make_pair("58",static_cast<double>(v_size_t[0])));
-  approval_tests.emplace_back(std::make_pair("59",static_cast<double>(v_size_t[1])));
-  approval_tests.emplace_back(std::make_pair("60",static_cast<double>(v_size_t[2])));
+  approval_tests.emplace_back("57",static_cast<double>(v_size_t.size()));
+  approval_tests.emplace_back("58",static_cast<double>(v_size_t[0]));
+  approval_tests.emplace_back("59",static_cast<double>(v_size_t[1]));
+  approval_tests.emplace_back("60",static_cast<double>(v_size_t[2]));
 
 
   CHECK_THROWS_WITH(prm.get_vector<size_t>("non existent unsigned int vector"),
@@ -4235,18 +4235,18 @@ TEST_CASE("WorldBuilder Parameters")
   prm.leave_subsection();
 
   std::vector<bool> v_bool = prm.get_vector<bool>("now existent bool vector");
-  approval_tests.emplace_back(std::make_pair("61",static_cast<double>(v_bool.size())));
-  approval_tests.emplace_back(std::make_pair("62",static_cast<double>(v_bool[0])));
-  approval_tests.emplace_back(std::make_pair("63",static_cast<double>(v_bool[1])));
+  approval_tests.emplace_back("61",static_cast<double>(v_bool.size()));
+  approval_tests.emplace_back("62",static_cast<double>(v_bool[0]));
+  approval_tests.emplace_back("63",static_cast<double>(v_bool[1]));
 
   v_bool = prm.get_vector<bool>("bool array");
-  approval_tests.emplace_back(std::make_pair("64",static_cast<double>(v_bool.size())));
-  approval_tests.emplace_back(std::make_pair("65",static_cast<double>(v_bool[0])));
-  approval_tests.emplace_back(std::make_pair("66",static_cast<double>(v_bool[1])));
-  approval_tests.emplace_back(std::make_pair("67",static_cast<double>(v_bool[2])));
-  approval_tests.emplace_back(std::make_pair("68",static_cast<double>(v_bool[3])));
-  approval_tests.emplace_back(std::make_pair("69",static_cast<double>(v_bool[4])));
-  approval_tests.emplace_back(std::make_pair("70",static_cast<double>(v_bool[1])));
+  approval_tests.emplace_back("64",static_cast<double>(v_bool.size()));
+  approval_tests.emplace_back("65",static_cast<double>(v_bool[0]));
+  approval_tests.emplace_back("66",static_cast<double>(v_bool[1]));
+  approval_tests.emplace_back("67",static_cast<double>(v_bool[2]));
+  approval_tests.emplace_back("68",static_cast<double>(v_bool[3]));
+  approval_tests.emplace_back("69",static_cast<double>(v_bool[4]));
+  approval_tests.emplace_back("70",static_cast<double>(v_bool[1]));
 
   CHECK_THROWS_WITH(prm.get_vector<bool>("bool array nob"),
                     Contains("IsBool()"));
@@ -4264,59 +4264,59 @@ TEST_CASE("WorldBuilder Parameters")
   prm.leave_subsection();
 
   std::vector<double> v_double = prm.get_vector<double>("now existent double vector");
-  approval_tests.emplace_back(std::make_pair("71",static_cast<double>(v_double.size())));
-  approval_tests.emplace_back(std::make_pair("72",v_double[0]));
-  approval_tests.emplace_back(std::make_pair("73",v_double[1]));
+  approval_tests.emplace_back("71",static_cast<double>(v_double.size()));
+  approval_tests.emplace_back("72",v_double[0]);
+  approval_tests.emplace_back("73",v_double[1]);
 
   CHECK_THROWS_WITH(prm.get<Point<2> >("string array"),
                     Contains("Could not convert values of /string array into Point<2>, because it could not convert the sub-elements into doubles."));
 
   v_double = prm.get_vector<double>("double array");
-  approval_tests.emplace_back(std::make_pair("74",static_cast<double>(v_double.size())));
-  approval_tests.emplace_back(std::make_pair("75",v_double[0]));
-  approval_tests.emplace_back(std::make_pair("76",v_double[1]));
-  approval_tests.emplace_back(std::make_pair("77",v_double[2]));
+  approval_tests.emplace_back("74",static_cast<double>(v_double.size()));
+  approval_tests.emplace_back("75",v_double[0]);
+  approval_tests.emplace_back("76",v_double[1]);
+  approval_tests.emplace_back("77",v_double[2]);
 
   CHECK_THROWS_WITH(prm.get_vector<Point<2> >("point<2> array nan"),
                     Contains("Could not convert values of /point<2> array nan/0 into a Point<2> array, because it could not convert the sub-elements into doubles."));
 
   std::vector<std::array<std::array<double,3>,3> > v_3x3_array = prm.get_vector<std::array<std::array<double,3>,3> >("vector of 3x3 arrays");
-  approval_tests.emplace_back(std::make_pair("78",static_cast<double>(v_3x3_array.size())));
-  approval_tests.emplace_back(std::make_pair("79",v_3x3_array[0][0][0]));
-  approval_tests.emplace_back(std::make_pair("80",v_3x3_array[0][0][1]));
-  approval_tests.emplace_back(std::make_pair("81",v_3x3_array[0][0][2]));
-  approval_tests.emplace_back(std::make_pair("82",v_3x3_array[0][1][0]));
-  approval_tests.emplace_back(std::make_pair("83",v_3x3_array[0][1][1]));
-  approval_tests.emplace_back(std::make_pair("84",v_3x3_array[0][1][2]));
-  approval_tests.emplace_back(std::make_pair("85",v_3x3_array[0][2][0]));
-  approval_tests.emplace_back(std::make_pair("86",v_3x3_array[0][2][1]));
-  approval_tests.emplace_back(std::make_pair("87",v_3x3_array[0][2][2]));
+  approval_tests.emplace_back("78",static_cast<double>(v_3x3_array.size()));
+  approval_tests.emplace_back("79",v_3x3_array[0][0][0]);
+  approval_tests.emplace_back("80",v_3x3_array[0][0][1]);
+  approval_tests.emplace_back("81",v_3x3_array[0][0][2]);
+  approval_tests.emplace_back("82",v_3x3_array[0][1][0]);
+  approval_tests.emplace_back("83",v_3x3_array[0][1][1]);
+  approval_tests.emplace_back("84",v_3x3_array[0][1][2]);
+  approval_tests.emplace_back("85",v_3x3_array[0][2][0]);
+  approval_tests.emplace_back("86",v_3x3_array[0][2][1]);
+  approval_tests.emplace_back("87",v_3x3_array[0][2][2]);
 
-  approval_tests.emplace_back(std::make_pair("88",v_3x3_array[1][0][0]));
-  approval_tests.emplace_back(std::make_pair("89",v_3x3_array[1][0][1]));
-  approval_tests.emplace_back(std::make_pair("90",v_3x3_array[1][0][2]));
-  approval_tests.emplace_back(std::make_pair("91",v_3x3_array[1][1][0]));
-  approval_tests.emplace_back(std::make_pair("92",v_3x3_array[1][1][1]));
-  approval_tests.emplace_back(std::make_pair("93",v_3x3_array[1][1][2]));
-  approval_tests.emplace_back(std::make_pair("94",v_3x3_array[1][2][0]));
-  approval_tests.emplace_back(std::make_pair("95",v_3x3_array[1][2][1]));
-  approval_tests.emplace_back(std::make_pair("96",v_3x3_array[1][2][2]));
+  approval_tests.emplace_back("88",v_3x3_array[1][0][0]);
+  approval_tests.emplace_back("89",v_3x3_array[1][0][1]);
+  approval_tests.emplace_back("90",v_3x3_array[1][0][2]);
+  approval_tests.emplace_back("91",v_3x3_array[1][1][0]);
+  approval_tests.emplace_back("92",v_3x3_array[1][1][1]);
+  approval_tests.emplace_back("93",v_3x3_array[1][1][2]);
+  approval_tests.emplace_back("94",v_3x3_array[1][2][0]);
+  approval_tests.emplace_back("95",v_3x3_array[1][2][1]);
+  approval_tests.emplace_back("96",v_3x3_array[1][2][2]);
 
   std::vector<std::vector<Point<2> > > v_v_p2 = prm.get_vector<std::vector<Point<2>>>("vector of vectors of points<2>");
-  approval_tests.emplace_back(std::make_pair("97",static_cast<double>(v_v_p2.size())));
-  approval_tests.emplace_back(std::make_pair("98",static_cast<double>(v_v_p2[0].size())));
-  approval_tests.emplace_back(std::make_pair("99",v_v_p2[0][0][0]));
-  approval_tests.emplace_back(std::make_pair("101",v_v_p2[0][0][1]));
-  approval_tests.emplace_back(std::make_pair("102",v_v_p2[0][1][0]));
-  approval_tests.emplace_back(std::make_pair("103",v_v_p2[0][1][1]));
+  approval_tests.emplace_back("97",static_cast<double>(v_v_p2.size()));
+  approval_tests.emplace_back("98",static_cast<double>(v_v_p2[0].size()));
+  approval_tests.emplace_back("99",v_v_p2[0][0][0]);
+  approval_tests.emplace_back("101",v_v_p2[0][0][1]);
+  approval_tests.emplace_back("102",v_v_p2[0][1][0]);
+  approval_tests.emplace_back("103",v_v_p2[0][1][1]);
 
-  approval_tests.emplace_back(std::make_pair("104",static_cast<double>(v_v_p2[1].size())));
-  approval_tests.emplace_back(std::make_pair("105",v_v_p2[1][0][0]));
-  approval_tests.emplace_back(std::make_pair("106",v_v_p2[1][0][1]));
-  approval_tests.emplace_back(std::make_pair("107",v_v_p2[1][1][0]));
-  approval_tests.emplace_back(std::make_pair("108",v_v_p2[1][1][1]));
-  approval_tests.emplace_back(std::make_pair("109",v_v_p2[1][2][0]));
-  approval_tests.emplace_back(std::make_pair("110",v_v_p2[1][2][1]));
+  approval_tests.emplace_back("104",static_cast<double>(v_v_p2[1].size()));
+  approval_tests.emplace_back("105",v_v_p2[1][0][0]);
+  approval_tests.emplace_back("106",v_v_p2[1][0][1]);
+  approval_tests.emplace_back("107",v_v_p2[1][1][0]);
+  approval_tests.emplace_back("108",v_v_p2[1][1][1]);
+  approval_tests.emplace_back("109",v_v_p2[1][2][0]);
+  approval_tests.emplace_back("110",v_v_p2[1][2][1]);
 
 
   CHECK_THROWS_WITH(prm.get_vector<std::vector<Point<2>>>("vector of vectors of points<2> nan"),
@@ -4324,52 +4324,52 @@ TEST_CASE("WorldBuilder Parameters")
 
 
   std::pair<std::vector<double>,std::vector<double>> value_at_array = prm.get_value_at_array("value at array full");
-  approval_tests.emplace_back(std::make_pair("111",static_cast<double>(value_at_array.first.size())));
-  approval_tests.emplace_back(std::make_pair("112",value_at_array.first[0]));
-  approval_tests.emplace_back(std::make_pair("113",value_at_array.first[1]));
+  approval_tests.emplace_back("111",static_cast<double>(value_at_array.first.size()));
+  approval_tests.emplace_back("112",value_at_array.first[0]);
+  approval_tests.emplace_back("113",value_at_array.first[1]);
 
-  approval_tests.emplace_back(std::make_pair("114",static_cast<double>(value_at_array.second.size())));
-  approval_tests.emplace_back(std::make_pair("115",value_at_array.second[0]));
-  approval_tests.emplace_back(std::make_pair("116",value_at_array.second[1]));
-  approval_tests.emplace_back(std::make_pair("117",value_at_array.second[2]));
-  approval_tests.emplace_back(std::make_pair("118",value_at_array.second[3]));
-  approval_tests.emplace_back(std::make_pair("119",value_at_array.second[4]));
+  approval_tests.emplace_back("114",static_cast<double>(value_at_array.second.size()));
+  approval_tests.emplace_back("115",value_at_array.second[0]);
+  approval_tests.emplace_back("116",value_at_array.second[1]);
+  approval_tests.emplace_back("117",value_at_array.second[2]);
+  approval_tests.emplace_back("118",value_at_array.second[3]);
+  approval_tests.emplace_back("119",value_at_array.second[4]);
 
 
   std::pair<std::vector<double>,std::vector<double>> double_value_at_array = prm.get_value_at_array("one value at points one value");
-  approval_tests.emplace_back(std::make_pair("120",static_cast<double>(double_value_at_array.first.size())));
-  approval_tests.emplace_back(std::make_pair("121",double_value_at_array.first[0]));
-  approval_tests.emplace_back(std::make_pair("122",static_cast<double>(double_value_at_array.second.size())));
-  approval_tests.emplace_back(std::make_pair("123",double_value_at_array.second[0]));
+  approval_tests.emplace_back("120",static_cast<double>(double_value_at_array.first.size()));
+  approval_tests.emplace_back("121",double_value_at_array.first[0]);
+  approval_tests.emplace_back("122",static_cast<double>(double_value_at_array.second.size()));
+  approval_tests.emplace_back("123",double_value_at_array.second[0]);
 
   std::pair<std::vector<double>,std::vector<double>> default_value_at_array = prm.get_value_at_array("value at array");
-  approval_tests.emplace_back(std::make_pair("124",static_cast<double>(default_value_at_array.first.size())));
-  approval_tests.emplace_back(std::make_pair("125",default_value_at_array.first[0]));
-  approval_tests.emplace_back(std::make_pair("126",static_cast<double>(default_value_at_array.second.size())));
-  approval_tests.emplace_back(std::make_pair("127",default_value_at_array.second[0]));
+  approval_tests.emplace_back("124",static_cast<double>(default_value_at_array.first.size()));
+  approval_tests.emplace_back("125",default_value_at_array.first[0]);
+  approval_tests.emplace_back("126",static_cast<double>(default_value_at_array.second.size()));
+  approval_tests.emplace_back("127",default_value_at_array.second[0]);
 
   std::vector<std::vector<double>> vector_for_vector_or_double = prm.get_vector_or_double("vector for vector or double");
-  approval_tests.emplace_back(std::make_pair("128",static_cast<double>(vector_for_vector_or_double.size())));
-  approval_tests.emplace_back(std::make_pair("129",static_cast<double>(vector_for_vector_or_double[0].size())));
-  approval_tests.emplace_back(std::make_pair("130",static_cast<double>(vector_for_vector_or_double[0][0])));
-  approval_tests.emplace_back(std::make_pair("131",static_cast<double>(vector_for_vector_or_double[0][1])));
-  approval_tests.emplace_back(std::make_pair("132",static_cast<double>(vector_for_vector_or_double[0][2])));
-  approval_tests.emplace_back(std::make_pair("133",static_cast<double>(vector_for_vector_or_double[0][3])));
+  approval_tests.emplace_back("128",static_cast<double>(vector_for_vector_or_double.size()));
+  approval_tests.emplace_back("129",static_cast<double>(vector_for_vector_or_double[0].size()));
+  approval_tests.emplace_back("130",static_cast<double>(vector_for_vector_or_double[0][0]));
+  approval_tests.emplace_back("131",static_cast<double>(vector_for_vector_or_double[0][1]));
+  approval_tests.emplace_back("132",static_cast<double>(vector_for_vector_or_double[0][2]));
+  approval_tests.emplace_back("133",static_cast<double>(vector_for_vector_or_double[0][3]));
 
-  approval_tests.emplace_back(std::make_pair("134",static_cast<double>(vector_for_vector_or_double[1].size())));
-  approval_tests.emplace_back(std::make_pair("135",static_cast<double>(vector_for_vector_or_double[1][0])));
-  approval_tests.emplace_back(std::make_pair("136",static_cast<double>(vector_for_vector_or_double[1][1])));
+  approval_tests.emplace_back("134",static_cast<double>(vector_for_vector_or_double[1].size()));
+  approval_tests.emplace_back("135",static_cast<double>(vector_for_vector_or_double[1][0]));
+  approval_tests.emplace_back("136",static_cast<double>(vector_for_vector_or_double[1][1]));
 
   std::vector<std::vector<double>> double_for_vector_or_double = prm.get_vector_or_double("one value at points one value");
-  approval_tests.emplace_back(std::make_pair("137",static_cast<double>(double_for_vector_or_double.size())));
-  approval_tests.emplace_back(std::make_pair("138",static_cast<double>(double_for_vector_or_double[0].size())));
-  approval_tests.emplace_back(std::make_pair("139",static_cast<double>(double_for_vector_or_double[0][0])));
+  approval_tests.emplace_back("137",static_cast<double>(double_for_vector_or_double.size()));
+  approval_tests.emplace_back("138",static_cast<double>(double_for_vector_or_double[0].size()));
+  approval_tests.emplace_back("139",static_cast<double>(double_for_vector_or_double[0][0]));
   /*CHECK_THROWS_WITH(prm.get_vector<std::string>("non existent string vector"),
                     Contains("internal error: could not retrieve the default value at"));
 
   std::vector<std::string> v_string = prm.get_vector<std::string>("string array");
-  approval_tests.emplace_back(std::make_pair("",v_string[0]));
-  approval_tests.emplace_back(std::make_pair("",v_string[1]));*/
+  approval_tests.emplace_back("",v_string[0]);
+  approval_tests.emplace_back("",v_string[1]);*/
 
   //prm.load_entry("Coordinate system", false, Types::CoordinateSystem("cartesian","This determines the coordinate system"));
 
@@ -4478,15 +4478,15 @@ TEST_CASE("WorldBuilder Parameters")
 
     prm.set_entry("new double array", Types::Array(Types::Double(3,"description"),"description"));
     std::vector<Types::Double> set_typed_double =  prm.get_array<Types::Double >("new double array");
-    approval_tests.emplace_back(std::make_pair("",set_typed_double.size()));
+    approval_tests.emplace_back("",set_typed_double.size());
     // This is not desired behavior, but it is not implemented yet.
 
     prm.load_entry("double array", true, Types::Array(Types::Double(4,"description"),"description"));
     std::vector<Types::Double> true_loaded_typed_double =  prm.get_array<Types::Double >("double array");
-    approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double.size()));
-    approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double[0].value));
-    approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double[1].value));
-    approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double[2].value));
+    approval_tests.emplace_back("",true_loaded_typed_double.size());
+    approval_tests.emplace_back("",true_loaded_typed_double[0].value);
+    approval_tests.emplace_back("",true_loaded_typed_double[1].value);
+    approval_tests.emplace_back("",true_loaded_typed_double[2].value);
 
 
     // Test the Array<Types::Point<2> > functions
@@ -4507,12 +4507,12 @@ TEST_CASE("WorldBuilder Parameters")
 
     prm.set_entry("new point<2> array", Types::Array(Types::Point<2>(Point<2>(5,6,cartesian),"description"),"description"));
     std::vector<Types::Point<2> > set_typed_point_2d = prm.get_array<Types::Point<2> >("new point<2> array");
-    approval_tests.emplace_back(std::make_pair("",set_typed_point_2d.size()));
+    approval_tests.emplace_back("",set_typed_point_2d.size());
     // This is not desired behavior, but it is not implemented yet.
 
     prm.load_entry("point<2> array", true, Types::Array(Types::Point<2>(Point<2>(7,8,cartesian),"description"),"description"));
     std::vector<Types::Point<2> > true_loaded_typed_point_2d =  prm.get_array<Types::Point<2> >("point<2> array");
-    approval_tests.emplace_back(std::make_pair("",true_loaded_typed_point_2d.size()));
+    approval_tests.emplace_back("",true_loaded_typed_point_2d.size());
     CHECK(true_loaded_typed_point_2d[0].value.get_array() == std::array<double,2> {10,11});
     CHECK(true_loaded_typed_point_2d[1].value.get_array() == std::array<double,2> {12,13});
     CHECK(true_loaded_typed_point_2d[2].value.get_array() == std::array<double,2> {14,15});
@@ -4536,12 +4536,12 @@ TEST_CASE("WorldBuilder Parameters")
 
     prm.set_entry("new point<3> array", Types::Array(Types::Point<3>(Point<3>(7,8,9,cartesian),"description"),"description"));
     std::vector<Types::Point<3> > set_typed_point_3d = prm.get_array<Types::Point<3> >("new point<3> array");
-    approval_tests.emplace_back(std::make_pair("",set_typed_point_3d.size()));
+    approval_tests.emplace_back("",set_typed_point_3d.size());
     // This is not desired behavior, but it is not implemented yet.
 
     prm.load_entry("point<3> array", true, Types::Array(Types::Point<3>(Point<3>(10,11,12,cartesian),"description"),"description"));
     std::vector<Types::Point<3> > true_loaded_typed_point_3d =  prm.get_array<Types::Point<3> >("point<3> array");
-    approval_tests.emplace_back(std::make_pair("",true_loaded_typed_point_3d.size()));
+    approval_tests.emplace_back("",true_loaded_typed_point_3d.size());
     CHECK(true_loaded_typed_point_3d[0].value.get_array() == std::array<double,3> {20,21,22});
     CHECK(true_loaded_typed_point_3d[1].value.get_array() == std::array<double,3> {23,24,25});
     CHECK(true_loaded_typed_point_3d[2].value.get_array() == std::array<double,3> {26,27,28});
@@ -4672,15 +4672,15 @@ TEST_CASE("WorldBuilder Parameters")
 
       prm.set_entry("new double array", Types::Array(Types::Double(3,"description"),"description"));
       std::vector<Types::Double > set_typed_double =  prm.get_array<Types::Double >("new double array");
-      approval_tests.emplace_back(std::make_pair("",set_typed_double.size()));
+      approval_tests.emplace_back("",set_typed_double.size());
       // This is not desired behavior, but it is not implemented yet.
 
       prm.load_entry("double array", true, Types::Array(Types::Double(4,"description"),"description"));
       std::vector<Types::Double > true_loaded_typed_double =  prm.get_array<Types::Double >("double array");
-      approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double.size()));
-      approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double[0].value));
-      approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double[1].value));
-      approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double[2].value));
+      approval_tests.emplace_back("",true_loaded_typed_double.size());
+      approval_tests.emplace_back("",true_loaded_typed_double[0].value);
+      approval_tests.emplace_back("",true_loaded_typed_double[1].value);
+      approval_tests.emplace_back("",true_loaded_typed_double[2].value);
 
       // Test the Array<Types::Point<2> > functions
       CHECK_THROWS_WITH(prm.load_entry("non existent point<2> array", true, Types::Array(Types::Point<2>(Point<2>(1,2,cartesian),"description"),"description")),
@@ -4698,12 +4698,12 @@ TEST_CASE("WorldBuilder Parameters")
 
       prm.set_entry("new point<2> array", Types::Array(Types::Point<2>(Point<2>(5,6,cartesian),"description"),"description"));
       std::vector<Types::Point<2> > set_typed_point_2d = prm.get_array<Types::Point<2> >("new point<2> array");
-      approval_tests.emplace_back(std::make_pair("",set_typed_point_2d.size()));
+      approval_tests.emplace_back("",set_typed_point_2d.size());
       // This is not desired behavior, but it is not implemented yet.
 
       prm.load_entry("point<2> array", true, Types::Array(Types::Point<2>(Point<2>(7,8,cartesian),"description"),"description"));
       std::vector<Types::Point<2> > true_loaded_typed_point_2d =  prm.get_array<Types::Point<2> >("point<2> array");
-      approval_tests.emplace_back(std::make_pair("",true_loaded_typed_point_2d.size()));
+      approval_tests.emplace_back("",true_loaded_typed_point_2d.size());
       CHECK(true_loaded_typed_point_2d[0].value.get_array() == std::array<double,2> {20,21});
       CHECK(true_loaded_typed_point_2d[1].value.get_array() == std::array<double,2> {22,23});
       CHECK(true_loaded_typed_point_2d[2].value.get_array() == std::array<double,2> {24,25});
@@ -4725,12 +4725,12 @@ TEST_CASE("WorldBuilder Parameters")
 
       prm.set_entry("new point<3> array", Types::Array(Types::Point<3>(Point<3>(7,8,9,cartesian),"description"),"description"));
       std::vector<Types::Point<3> > set_typed_point_3d = prm.get_array<Types::Point<3> >("new point<3> array");
-      approval_tests.emplace_back(std::make_pair("",set_typed_point_3d.size()));
+      approval_tests.emplace_back("",set_typed_point_3d.size());
       // This is not desired behavior, but it is not implemented yet.
 
       prm.load_entry("point<3> array", true, Types::Array(Types::Point<3>(Point<3>(10,11,12,cartesian),"description"),"description"));
       std::vector<Types::Point<3> > true_loaded_typed_point_3d =  prm.get_array<Types::Point<3> >("point<3> array");
-      approval_tests.emplace_back(std::make_pair("",true_loaded_typed_point_3d.size()));
+      approval_tests.emplace_back("",true_loaded_typed_point_3d.size());
       CHECK(true_loaded_typed_point_3d[0].value.get_array() == std::array<double,3> {30,31,32});
       CHECK(true_loaded_typed_point_3d[1].value.get_array() == std::array<double,3> {33,34,35});
       CHECK(true_loaded_typed_point_3d[2].value.get_array() == std::array<double,3> {36,37,38});
@@ -4860,15 +4860,15 @@ TEST_CASE("WorldBuilder Parameters")
 
         prm.set_entry("new double array", Types::Array(Types::Double(3,"description"),"description"));
         std::vector<Types::Double > set_typed_double =  prm.get_array<Types::Double >("new double array");
-        approval_tests.emplace_back(std::make_pair("",set_typed_double.size()));
+        approval_tests.emplace_back("",set_typed_double.size());
         // This is not desired behavior, but it is not implemented yet.
 
         prm.load_entry("double array", true, Types::Array(Types::Double(4,"description"),"description"));
         std::vector<Types::Double > true_loaded_typed_double =  prm.get_array<Types::Double >("double array");
-        approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double.size()));
-        approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double[0].value));
-        approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double[1].value));
-        approval_tests.emplace_back(std::make_pair("",true_loaded_typed_double[2].value));
+        approval_tests.emplace_back("",true_loaded_typed_double.size());
+        approval_tests.emplace_back("",true_loaded_typed_double[0].value);
+        approval_tests.emplace_back("",true_loaded_typed_double[1].value);
+        approval_tests.emplace_back("",true_loaded_typed_double[2].value);
 
 
         // Test the Array<Types::Point<2> > functions
@@ -4890,12 +4890,12 @@ TEST_CASE("WorldBuilder Parameters")
 
         prm.set_entry("new point<2> array", Types::Array(Types::Point<2>(Point<2>(5,6,cartesian),"description"),"description"));
         std::vector<Types::Point<2> > set_typed_point_2d = prm.get_array<Types::Point<2> >("new point<2> array");
-        approval_tests.emplace_back(std::make_pair("",set_typed_point_2d.size()));
+        approval_tests.emplace_back("",set_typed_point_2d.size());
         // This is not desired behavior, but it is not implemented yet.
 
         prm.load_entry("point<2> array", true, Types::Array(Types::Point<2>(Point<2>(7,8,cartesian),"description"),"description"));
         std::vector<Types::Point<2> > true_loaded_typed_point_2d =  prm.get_array<Types::Point<2> >("point<2> array");
-        approval_tests.emplace_back(std::make_pair("",true_loaded_typed_point_2d.size()));
+        approval_tests.emplace_back("",true_loaded_typed_point_2d.size());
         CHECK(true_loaded_typed_point_2d[0].value.get_array() == std::array<double,2> {40,41});
         CHECK(true_loaded_typed_point_2d[1].value.get_array() == std::array<double,2> {42,43});
         CHECK(true_loaded_typed_point_2d[2].value.get_array() == std::array<double,2> {44,45});
@@ -4920,12 +4920,12 @@ TEST_CASE("WorldBuilder Parameters")
 
         prm.set_entry("new point<3> array", Types::Array(Types::Point<3>(Point<3>(7,8,9,cartesian),"description"),"description"));
         std::vector<Types::Point<3> > set_typed_point_3d = prm.get_array<Types::Point<3> >("new point<3> array");
-        approval_tests.emplace_back(std::make_pair("",set_typed_point_3d.size()));
+        approval_tests.emplace_back("",set_typed_point_3d.size());
         // This is not desired behavior, but it is not implemented yet.
 
         prm.load_entry("point<3> array", true, Types::Array(Types::Point<3>(Point<3>(10,11,12,cartesian),"description"),"description"));
         std::vector<Types::Point<3> > true_loaded_typed_point_3d =  prm.get_array<Types::Point<3> >("point<3> array");
-        approval_tests.emplace_back(std::make_pair("",true_loaded_typed_point_3d.size()));
+        approval_tests.emplace_back("",true_loaded_typed_point_3d.size());
         CHECK(true_loaded_typed_point_3d[0].value.get_array() == std::array<double,3> {40,41,42});
         CHECK(true_loaded_typed_point_3d[1].value.get_array() == std::array<double,3> {43,44,45});
         CHECK(true_loaded_typed_point_3d[2].value.get_array() == std::array<double,3> {46,47,48});
@@ -5028,33 +5028,33 @@ TEST_CASE("GWB Bezier curve")
 
   const Objects::BezierCurve bezier_curve(coordinates);
 
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,-0.1)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.0)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.1)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.2)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.3)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.4)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.5)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.6)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.7)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.8)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,0.9)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,1.0)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(0,1.1)));
+  approval_tests.emplace_back("",bezier_curve(0,-0.1));
+  approval_tests.emplace_back("",bezier_curve(0,0.0));
+  approval_tests.emplace_back("",bezier_curve(0,0.1));
+  approval_tests.emplace_back("",bezier_curve(0,0.2));
+  approval_tests.emplace_back("",bezier_curve(0,0.3));
+  approval_tests.emplace_back("",bezier_curve(0,0.4));
+  approval_tests.emplace_back("",bezier_curve(0,0.5));
+  approval_tests.emplace_back("",bezier_curve(0,0.6));
+  approval_tests.emplace_back("",bezier_curve(0,0.7));
+  approval_tests.emplace_back("",bezier_curve(0,0.8));
+  approval_tests.emplace_back("",bezier_curve(0,0.9));
+  approval_tests.emplace_back("",bezier_curve(0,1.0));
+  approval_tests.emplace_back("",bezier_curve(0,1.1));
 
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,-0.1)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.0)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.1)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.2)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.3)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.4)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.5)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.6)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.7)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.8)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,0.9)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,1.0)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve(1,1.1)));
+  approval_tests.emplace_back("",bezier_curve(1,-0.1));
+  approval_tests.emplace_back("",bezier_curve(1,0.0));
+  approval_tests.emplace_back("",bezier_curve(1,0.1));
+  approval_tests.emplace_back("",bezier_curve(1,0.2));
+  approval_tests.emplace_back("",bezier_curve(1,0.3));
+  approval_tests.emplace_back("",bezier_curve(1,0.4));
+  approval_tests.emplace_back("",bezier_curve(1,0.5));
+  approval_tests.emplace_back("",bezier_curve(1,0.6));
+  approval_tests.emplace_back("",bezier_curve(1,0.7));
+  approval_tests.emplace_back("",bezier_curve(1,0.8));
+  approval_tests.emplace_back("",bezier_curve(1,0.9));
+  approval_tests.emplace_back("",bezier_curve(1,1.0));
+  approval_tests.emplace_back("",bezier_curve(1,1.1));
 
 
   const Objects::BezierCurve bezier_curve_defined(coordinates,
@@ -5062,33 +5062,33 @@ TEST_CASE("GWB Bezier curve")
     0.,Consts::PI,0.
   });
 
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,-0.1)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.0)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.1)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.2)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.3)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.4)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.5)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.6)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.7)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.8)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,0.9)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,1.0)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(0,1.1)));
+  approval_tests.emplace_back("",bezier_curve_defined(0,-0.1));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.0));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.1));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.2));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.3));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.4));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.5));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.6));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.7));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.8));
+  approval_tests.emplace_back("",bezier_curve_defined(0,0.9));
+  approval_tests.emplace_back("",bezier_curve_defined(0,1.0));
+  approval_tests.emplace_back("",bezier_curve_defined(0,1.1));
 
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,-0.1)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.0)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.1)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.2)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.3)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.4)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.5)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.6)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.7)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.8)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,0.9)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,1.0)));
-  approval_tests.emplace_back(std::make_pair("",bezier_curve_defined(1,1.1)));
+  approval_tests.emplace_back("",bezier_curve_defined(1,-0.1));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.0));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.1));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.2));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.3));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.4));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.5));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.6));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.7));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.8));
+  approval_tests.emplace_back("",bezier_curve_defined(1,0.9));
+  approval_tests.emplace_back("",bezier_curve_defined(1,1.0));
+  approval_tests.emplace_back("",bezier_curve_defined(1,1.1));
 
 
   std::vector<std::string> approvals;
@@ -5142,32 +5142,32 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
 
   Objects::BezierCurve bezier_curve(coordinate_list_local);
 
-  approval_tests.emplace_back(std::make_pair("0",bezier_curve(0,-0.1)[0]));
-  approval_tests.emplace_back(std::make_pair("1",bezier_curve(0,-0.1)[1]));
-  approval_tests.emplace_back(std::make_pair("2",bezier_curve(0,0.0)[0]));
-  approval_tests.emplace_back(std::make_pair("3",bezier_curve(0,0.0)[1]));
-  approval_tests.emplace_back(std::make_pair("4",bezier_curve(0,0.1)[0]));
-  approval_tests.emplace_back(std::make_pair("5",bezier_curve(0,0.1)[1]));
-  approval_tests.emplace_back(std::make_pair("6",bezier_curve(0,0.2)[0]));
-  approval_tests.emplace_back(std::make_pair("7",bezier_curve(0,0.2)[1]));
-  approval_tests.emplace_back(std::make_pair("8",bezier_curve(0,0.3)[0]));
-  approval_tests.emplace_back(std::make_pair("9",bezier_curve(0,0.3)[1]));
-  approval_tests.emplace_back(std::make_pair("10",bezier_curve(0,0.4)[0]));
-  approval_tests.emplace_back(std::make_pair("11",bezier_curve(0,0.4)[1]));
-  approval_tests.emplace_back(std::make_pair("12",bezier_curve(0,0.5)[0]));
-  approval_tests.emplace_back(std::make_pair("13",bezier_curve(0,0.5)[1]));
-  approval_tests.emplace_back(std::make_pair("14",bezier_curve(0,0.6)[0]));
-  approval_tests.emplace_back(std::make_pair("15",bezier_curve(0,0.6)[1]));
-  approval_tests.emplace_back(std::make_pair("16",bezier_curve(0,0.7)[0]));
-  approval_tests.emplace_back(std::make_pair("17",bezier_curve(0,0.7)[1]));
-  approval_tests.emplace_back(std::make_pair("18",bezier_curve(0,0.8)[0]));
-  approval_tests.emplace_back(std::make_pair("19",bezier_curve(0,0.8)[1]));
-  approval_tests.emplace_back(std::make_pair("20",bezier_curve(0,0.9)[0]));
-  approval_tests.emplace_back(std::make_pair("21",bezier_curve(0,0.9)[1]));
-  approval_tests.emplace_back(std::make_pair("22",bezier_curve(0,1.0)[0]));
-  approval_tests.emplace_back(std::make_pair("23",bezier_curve(0,1.0)[1]));
-  approval_tests.emplace_back(std::make_pair("24",bezier_curve(0,1.1)[0]));
-  approval_tests.emplace_back(std::make_pair("25",bezier_curve(0,1.1)[1]));
+  approval_tests.emplace_back("0",bezier_curve(0,-0.1)[0]);
+  approval_tests.emplace_back("1",bezier_curve(0,-0.1)[1]);
+  approval_tests.emplace_back("2",bezier_curve(0,0.0)[0]);
+  approval_tests.emplace_back("3",bezier_curve(0,0.0)[1]);
+  approval_tests.emplace_back("4",bezier_curve(0,0.1)[0]);
+  approval_tests.emplace_back("5",bezier_curve(0,0.1)[1]);
+  approval_tests.emplace_back("6",bezier_curve(0,0.2)[0]);
+  approval_tests.emplace_back("7",bezier_curve(0,0.2)[1]);
+  approval_tests.emplace_back("8",bezier_curve(0,0.3)[0]);
+  approval_tests.emplace_back("9",bezier_curve(0,0.3)[1]);
+  approval_tests.emplace_back("10",bezier_curve(0,0.4)[0]);
+  approval_tests.emplace_back("11",bezier_curve(0,0.4)[1]);
+  approval_tests.emplace_back("12",bezier_curve(0,0.5)[0]);
+  approval_tests.emplace_back("13",bezier_curve(0,0.5)[1]);
+  approval_tests.emplace_back("14",bezier_curve(0,0.6)[0]);
+  approval_tests.emplace_back("15",bezier_curve(0,0.6)[1]);
+  approval_tests.emplace_back("16",bezier_curve(0,0.7)[0]);
+  approval_tests.emplace_back("17",bezier_curve(0,0.7)[1]);
+  approval_tests.emplace_back("18",bezier_curve(0,0.8)[0]);
+  approval_tests.emplace_back("19",bezier_curve(0,0.8)[1]);
+  approval_tests.emplace_back("20",bezier_curve(0,0.9)[0]);
+  approval_tests.emplace_back("21",bezier_curve(0,0.9)[1]);
+  approval_tests.emplace_back("22",bezier_curve(0,1.0)[0]);
+  approval_tests.emplace_back("23",bezier_curve(0,1.0)[1]);
+  approval_tests.emplace_back("24",bezier_curve(0,1.1)[0]);
+  approval_tests.emplace_back("25",bezier_curve(0,1.1)[1]);
 
 
   WorldBuilder::Utilities::PointDistanceFromCurvedPlanes distance_from_planes =
@@ -5182,16 +5182,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("26",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("27",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("28",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("29",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("30",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("31",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("32",distance_from_planes.depth_reference_surface));
-  approval_tests.emplace_back(std::make_pair("33",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("34",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("35",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("26",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("27",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("28",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("29",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("30",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("31",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("32",distance_from_planes.depth_reference_surface);
+  approval_tests.emplace_back("33",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("34",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("35",distance_from_planes.closest_trench_point.get_array()[2]);
 
 
   distance_from_planes =
@@ -5206,17 +5206,17 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("36",std::fabs(distance_from_planes.distance_from_plane) < 1e-4)); // practically zero
-  approval_tests.emplace_back(std::make_pair("37",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("38",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("39",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("40",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("41",std::fabs(distance_from_planes.fraction_of_segment) < 1e-5));
-  approval_tests.emplace_back(std::make_pair("42",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("36",std::fabs(distance_from_planes.distance_from_plane) < 1e-4); // practically zero
+  approval_tests.emplace_back("37",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("38",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("39",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("40",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("41",std::fabs(distance_from_planes.fraction_of_segment) < 1e-5);
+  approval_tests.emplace_back("42",distance_from_planes.depth_reference_surface);
 
-  approval_tests.emplace_back(std::make_pair("43",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("44",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("45",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("43",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("44",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("45",distance_from_planes.closest_trench_point.get_array()[2]);
 
 
 
@@ -5235,16 +5235,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("46",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("47",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("48",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("49",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("50",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("51",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14)); // practically zero
-  approval_tests.emplace_back(std::make_pair("52",distance_from_planes.depth_reference_surface));
-  approval_tests.emplace_back(std::make_pair("53",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("54",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("55",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("46",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("47",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("48",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("49",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("50",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("51",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  approval_tests.emplace_back("52",distance_from_planes.depth_reference_surface);
+  approval_tests.emplace_back("53",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("54",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("55",distance_from_planes.closest_trench_point.get_array()[2]);
 
   // center square test 3
   position[1] = 20;
@@ -5262,16 +5262,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("56",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("57",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("58",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("59",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("60",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("61",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("62",distance_from_planes.depth_reference_surface));
-  approval_tests.emplace_back(std::make_pair("63",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("64",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("65",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("56",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("57",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("58",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("59",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("60",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("61",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("62",distance_from_planes.depth_reference_surface);
+  approval_tests.emplace_back("63",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("64",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("65",distance_from_planes.closest_trench_point.get_array()[2]);
 
   // center square test 4
   reference_point[1] = 0;
@@ -5288,16 +5288,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("66",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("67",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("68",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("69",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("70",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("71",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14)); // practically zero
-  approval_tests.emplace_back(std::make_pair("72",distance_from_planes.depth_reference_surface));
-  approval_tests.emplace_back(std::make_pair("73",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("74",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("75",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("66",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("67",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("68",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("69",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("70",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("71",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  approval_tests.emplace_back("72",distance_from_planes.depth_reference_surface);
+  approval_tests.emplace_back("73",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("74",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("75",distance_from_planes.closest_trench_point.get_array()[2]);
 
   // center square test 5
   position[1] = -10;
@@ -5316,16 +5316,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("76",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("77",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("78",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("79",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("80",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("81",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("82",distance_from_planes.depth_reference_surface));
-  approval_tests.emplace_back(std::make_pair("83",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("84",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("85",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("76",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("77",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("78",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("79",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("80",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("81",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("82",distance_from_planes.depth_reference_surface);
+  approval_tests.emplace_back("83",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("84",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("85",distance_from_planes.closest_trench_point.get_array()[2]);
 
   // begin section square test 6
   position[0] = 0;
@@ -5343,16 +5343,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("86",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("87",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("88",std::fabs(distance_from_planes.fraction_of_section) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("89",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("90",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("91",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("92",std::fabs(distance_from_planes.depth_reference_surface) > 1e-12 ? distance_from_planes.depth_reference_surface : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("93",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("94",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("95",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("86",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("87",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("88",std::fabs(distance_from_planes.fraction_of_section) < 1e-14);
+  approval_tests.emplace_back("89",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("90",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("91",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("92",std::fabs(distance_from_planes.depth_reference_surface) > 1e-12 ? distance_from_planes.depth_reference_surface : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("93",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("94",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("95",distance_from_planes.closest_trench_point.get_array()[2]);
 
 
   // end section square test 7
@@ -5371,16 +5371,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("96",std::fabs(distance_from_planes.distance_from_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("97",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("98",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("99",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("100",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("101",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("102",distance_from_planes.depth_reference_surface));
-  approval_tests.emplace_back(std::make_pair("103",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("104",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("105",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("96",std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  approval_tests.emplace_back("97",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("98",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("99",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("100",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("101",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("102",distance_from_planes.depth_reference_surface);
+  approval_tests.emplace_back("103",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("104",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("105",distance_from_planes.closest_trench_point.get_array()[2]);
 
   // before begin section square test 8
   position[0] = -10;
@@ -5398,13 +5398,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("116",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("117",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("118",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("119",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("120",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("121",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14)); // practically zero
-  approval_tests.emplace_back(std::make_pair("122",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("116",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("117",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("118",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("119",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("120",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("121",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  approval_tests.emplace_back("122",distance_from_planes.depth_reference_surface);
   // The old method for slabs can not provide the corners when out of bounds and returns a nan. The new method can do this,
   // and the old method is planned to be removed.
   //CHECK(distance_from_planes.closest_trench_point.get_array() == std::array<double,3> {{NaN::DSNAN,NaN::DSNAN,10.}});
@@ -5422,17 +5422,17 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("122",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("123",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("124",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("125",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("126",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("127",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14)); // practically zero
-  approval_tests.emplace_back(std::make_pair("128",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("122",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("123",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("124",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("125",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("126",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("127",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  approval_tests.emplace_back("128",distance_from_planes.depth_reference_surface);
 
-  approval_tests.emplace_back(std::make_pair("129",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("130",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("131",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("129",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("130",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("131",distance_from_planes.closest_trench_point.get_array()[2]);
 
   // beyond end section square test 9
   position[0] = 25;
@@ -5450,13 +5450,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("132",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("133",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("134",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("135",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("136",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("137",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14)); // practically zero
-  approval_tests.emplace_back(std::make_pair("138",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("132",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("133",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("134",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("135",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("136",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("137",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  approval_tests.emplace_back("138",distance_from_planes.depth_reference_surface);
   // The old method for slabs can not provide the corners when out of bounds and returns a nan. The new method can do this,
   // and the old method is planned to be removed.
   //CHECK(distance_from_planes.closest_trench_point.get_array() == std::array<double,3> {{NaN::DSNAN,NaN::DSNAN,10.}});
@@ -5474,16 +5474,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("139",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("140",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("141",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("142",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("143",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("144",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14)); // practically zero
-  approval_tests.emplace_back(std::make_pair("145",distance_from_planes.depth_reference_surface));
-  approval_tests.emplace_back(std::make_pair("146",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("147",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("148",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("139",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("140",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("141",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("142",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("143",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("144",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
+  approval_tests.emplace_back("145",distance_from_planes.depth_reference_surface);
+  approval_tests.emplace_back("146",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("147",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("148",distance_from_planes.closest_trench_point.get_array()[2]);
 
 
   // beyond end section square test 10
@@ -5504,16 +5504,16 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("149",distance_from_planes.distance_from_plane));
-  approval_tests.emplace_back(std::make_pair("150",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("151",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("152",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("153",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("154",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("155",distance_from_planes.depth_reference_surface));
-  approval_tests.emplace_back(std::make_pair("156",distance_from_planes.closest_trench_point.get_array()[0]));
-  approval_tests.emplace_back(std::make_pair("157",distance_from_planes.closest_trench_point.get_array()[1]));
-  approval_tests.emplace_back(std::make_pair("158",distance_from_planes.closest_trench_point.get_array()[2]));
+  approval_tests.emplace_back("149",distance_from_planes.distance_from_plane);
+  approval_tests.emplace_back("150",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("151",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("152",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("153",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("154",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("155",distance_from_planes.depth_reference_surface);
+  approval_tests.emplace_back("156",distance_from_planes.closest_trench_point.get_array()[0]);
+  approval_tests.emplace_back("157",distance_from_planes.closest_trench_point.get_array()[1]);
+  approval_tests.emplace_back("158",distance_from_planes.closest_trench_point.get_array()[2]);
 
   // beyond end section square test 10 (only positive version)
   position[0] = 10;
@@ -5533,12 +5533,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  true,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("159",distance_from_planes.distance_from_plane));
-  approval_tests.emplace_back(std::make_pair("160",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("161",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("162",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("163",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("164",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("159",distance_from_planes.distance_from_plane);
+  approval_tests.emplace_back("160",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("161",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("162",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("163",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("164",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
   // beyond end section square test 11
@@ -5559,12 +5559,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("165",distance_from_planes.distance_from_plane));
-  approval_tests.emplace_back(std::make_pair("166",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("167",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("168",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("169",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("170",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("165",distance_from_planes.distance_from_plane);
+  approval_tests.emplace_back("166",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("167",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("168",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("169",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("170",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
   // beyond end section square test 11 (only positive version)
@@ -5585,12 +5585,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  true,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("171",distance_from_planes.distance_from_plane));
-  approval_tests.emplace_back(std::make_pair("172",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("173",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("174",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("175",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("176",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("171",distance_from_planes.distance_from_plane);
+  approval_tests.emplace_back("172",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("173",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("174",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("175",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("176",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // add coordinate
   position[0] = 25;
@@ -5621,12 +5621,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("177",std::fabs(distance_from_planes.distance_from_plane) < 1e-14)); // practically zero
-  approval_tests.emplace_back(std::make_pair("178",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("179",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("180",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("181",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("182",std::fabs(distance_from_planes.fraction_of_segment) < 1e-12));
+  approval_tests.emplace_back("177",std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
+  approval_tests.emplace_back("178",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("179",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("180",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("181",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("182",std::fabs(distance_from_planes.fraction_of_segment) < 1e-12);
 
   // different angle
   slab_segment_angles[0][0][0] = 22.5 * dtr;
@@ -5655,12 +5655,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("183",std::fabs(distance_from_planes.distance_from_plane)<1e-10));
-  approval_tests.emplace_back(std::make_pair("184",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("185",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("186",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("187",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("188",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("183",std::fabs(distance_from_planes.distance_from_plane)<1e-10);
+  approval_tests.emplace_back("184",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("185",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("186",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("187",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("188",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check interpolation 1 (in the middle of a segment with 22.5 degree and a segment with 45)
   position[0] = 25;
@@ -5680,12 +5680,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("189",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("190",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("191",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("192",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("193",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("194",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("189",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("190",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("191",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("192",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("193",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("194",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check interpolation 2 (at the end of the segment at 45 degree)
   position[0] = 30;
@@ -5705,12 +5705,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("195",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("196",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("197",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("198",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("199",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("200",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("195",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("196",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("197",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("198",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("199",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("200",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation with 90 degree angles for simplicity
   // check length interpolation first segment center 1
@@ -5751,12 +5751,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("201",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("202",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("203",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("204",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("205",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("206",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("201",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("202",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("203",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("204",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("205",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("206",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation first segment center 2
   position[0] = 10;
@@ -5776,12 +5776,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("207",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("208",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("209",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("210",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("211",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("212",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("207",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("208",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("209",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("210",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("211",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("212",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation first segment center 3
   position[0] = 10;
@@ -5801,12 +5801,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("213",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("214",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("215",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("216",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("217",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("218",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("213",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("214",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("215",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("216",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("217",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("218",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
 
@@ -5828,13 +5828,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("219",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("220",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("221",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("222",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("223",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("224",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("225",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("219",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("220",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("221",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("222",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("223",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("224",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("225",distance_from_planes.depth_reference_surface);
 
 
   // Now check the center of the second segment, each segment should have a length of 75.
@@ -5856,12 +5856,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("226",std::fabs(distance_from_planes.distance_from_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("227",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("228",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("229",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("230",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("231",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("226",std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  approval_tests.emplace_back("227",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("228",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("229",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("230",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("231",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation second segment center 2
   position[0] = 25;
@@ -5881,12 +5881,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("232",std::fabs(distance_from_planes.distance_from_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("233",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("234",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("235",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("236",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("237",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("232",std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  approval_tests.emplace_back("233",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("234",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("235",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("236",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("237",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation second segment center 3
   position[0] = 25;
@@ -5906,12 +5906,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("238",std::fabs(distance_from_planes.distance_from_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("239",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("240",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("241",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("242",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("243",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("238",std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  approval_tests.emplace_back("239",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("240",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("241",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("242",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("243",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
 
@@ -5933,12 +5933,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("244",distance_from_planes.distance_from_plane));
-  approval_tests.emplace_back(std::make_pair("245",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("246",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("247",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("248",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("249",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("244",distance_from_planes.distance_from_plane);
+  approval_tests.emplace_back("245",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("246",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("247",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("248",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("249",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // Now check the end of the second segment, each segment should have a length of 50.
   // check length interpolation second segment center 1
@@ -5959,12 +5959,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("250",std::fabs(distance_from_planes.distance_from_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("251",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("252",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("253",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("254",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("255",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("250",std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  approval_tests.emplace_back("251",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("252",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("253",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("254",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("255",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation second segment center 2
   position[0] = 30;
@@ -5984,12 +5984,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("256",std::fabs(distance_from_planes.distance_from_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("257",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // practically zero
-  approval_tests.emplace_back(std::make_pair("258",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("259",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("260",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("261",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("256",std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  approval_tests.emplace_back("257",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
+  approval_tests.emplace_back("258",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("259",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("260",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("261",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation second segment center 3
   position[0] = 30;
@@ -6009,12 +6009,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("262",std::fabs(distance_from_planes.distance_from_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("263",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("264",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("265",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("266",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("267",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("262",std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
+  approval_tests.emplace_back("263",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("264",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("265",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("266",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("267",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
 
@@ -6036,12 +6036,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("268",distance_from_planes.distance_from_plane));
-  approval_tests.emplace_back(std::make_pair("269",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("270",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("271",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("272",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("273",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("268",distance_from_planes.distance_from_plane);
+  approval_tests.emplace_back("269",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("270",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("271",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("272",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("273",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   std::vector<std::string> approvals;
   for (auto&& value : approval_tests)
@@ -6138,13 +6138,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) < 1e-10));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) < 1e-10);
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.depth_reference_surface);
 
   // curve test 2
   position[0] = 10;
@@ -6164,13 +6164,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be about 5 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be about 5 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.depth_reference_surface);
 
   // curve test 3
   position[0] = 10;
@@ -6190,13 +6190,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be about -5 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be about -5 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.depth_reference_surface);
 
 
   // curve test 4
@@ -6217,13 +6217,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane);
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.depth_reference_surface);
 
   // curve test 5
   position[0] = 10;
@@ -6243,13 +6243,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be about -10 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be about -10 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.depth_reference_surface);
 
   // curve test 6
   position[0] = 10;
@@ -6269,17 +6269,17 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane))); // checked that it should be about 10 this with a drawing
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane)); // checked that it should be about 10 this with a drawing
   // This is a special case where the point coincides with the center of the circle.
   // Because all the points on the circle are equally close, we have chosen in the
   // code to define this case as that this point belongs to the top of the top segment
   // where the check point has angle 0. This means that the distanceAlongPlate is zero.
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.depth_reference_surface);
 
 
   // curve test 7
@@ -6300,13 +6300,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.depth_reference_surface);
 
   // curve test 8
   slab_segment_lengths[0][0] = 5 * 45 * dtr;
@@ -6331,13 +6331,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.depth_reference_surface);
 
   // curve test 9
   position[0] = 10;
@@ -6357,12 +6357,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
   // curve test 10
@@ -6397,12 +6397,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 11
   position[0] = 10;
@@ -6422,12 +6422,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 12
   position[0] = 10;
@@ -6447,13 +6447,13 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.depth_reference_surface));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.depth_reference_surface);
 
 
   // curve test 13
@@ -6474,12 +6474,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 14
   slab_segment_angles[0][0][0] = 0.0 * dtr;
@@ -6513,12 +6513,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 15
   position[0] = 10;
@@ -6538,12 +6538,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 16
   position[0] = 10;
@@ -6563,12 +6563,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be about -1 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be about -1 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 16
   position[0] = 10;
@@ -6588,12 +6588,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be about -1 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be about -1 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 17
   position[0] = 10;
@@ -6613,12 +6613,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
   // curve test 18
@@ -6639,12 +6639,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be about 1 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be about 1 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 19
   position[0] = 10;
@@ -6664,12 +6664,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be about 1 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be about 1 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
   // curve test 20
@@ -6704,12 +6704,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 21
   position[0] = 10;
@@ -6729,12 +6729,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 21
   position[0] = 10;
@@ -6754,12 +6754,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 22
   position[0] = 10;
@@ -6779,12 +6779,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test start 45 degree 1
   slab_segment_angles[0][0][0] = 45.0 * dtr;
@@ -6821,12 +6821,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be about -7.3 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be about -7.3 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test change reference point 1
   reference_point[0] = 50;
@@ -6850,12 +6850,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  bezier_curve);
 
   // checked that distanceFromPlane should be infinity (it is on the other side of the circle this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test change reference point 2
   position[0] = 10;
@@ -6875,12 +6875,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be about 2.3 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be about 2.3 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test angle interpolation 1
   reference_point[0] = 0;
@@ -6918,12 +6918,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 1
   reference_point[0] = 0;
@@ -6960,12 +6960,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 2
   position[0] = 10;
@@ -6985,12 +6985,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 3
   position[0] = 10;
@@ -7010,12 +7010,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 4
   position[0] = 10;
@@ -7037,12 +7037,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) )); // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) ); // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
   // curve test reverse angle 5
@@ -7063,12 +7063,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 6
   slab_segment_angles[0][0][0] = 0.0 * dtr;
@@ -7102,12 +7102,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) < 1e-10)); // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-10));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) < 1e-10); // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-10);
 
   // curve test reverse angle 6
   position[0] = 10;
@@ -7128,12 +7128,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) < 1e-10));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-10));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) < 1e-10);
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-10);
 
   // curve test reverse angle 6
   position[0] = 10;
@@ -7154,12 +7154,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) < 1e-10));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-10));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) < 1e-10);
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-10);
 
 
   // curve test reverse angle 7
@@ -7181,12 +7181,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane)< 1e-10));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane)< 1e-10);
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
 
@@ -7209,12 +7209,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",fabs(distance_from_planes.distance_from_plane))); // checked that it should be small positive this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",fabs(distance_from_planes.distance_from_plane)); // checked that it should be small positive this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 9
   position[0] = 10;
@@ -7235,12 +7235,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked that it should be small negative this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked that it should be small negative this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 10
   position[0] = 10;
@@ -7261,12 +7261,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
   // global_x_list test 1
@@ -7288,12 +7288,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // global_x_list test 2
   position[0] = 10;
@@ -7313,12 +7313,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // global_x_list test 3
   position[0] = 15;
@@ -7338,12 +7338,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) < 1e-14)); // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // global_x_list test 4
   position[0] = 20;
@@ -7363,12 +7363,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) < 1e-14)); // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // global_x_list test 5
   position[0] = 25;
@@ -7388,12 +7388,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane))); // checked that it should be about 0 this with a drawing
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-12));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane)); // checked that it should be about 0 this with a drawing
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-12);
 
 
 
@@ -7415,12 +7415,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   std::vector<std::string> approvals;
   for (auto&& value : approval_tests)
@@ -7489,12 +7489,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_section) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_section) < 1e-14);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
   // spherical test 2
@@ -7515,12 +7515,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) < 1e-14)); // practically zero
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) < 1e-14));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
   // spherical test 2
@@ -7545,12 +7545,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_from_plane)));
-  approval_tests.emplace_back(std::make_pair("",std::isinf(distance_from_planes.distance_along_plane)));
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_from_plane));
+  approval_tests.emplace_back("",std::isinf(distance_from_planes.distance_along_plane));
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
 // spherical test 3
@@ -7570,12 +7570,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane);
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
   /**
@@ -7604,12 +7604,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane)); // checked it with a geometric drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) < 1e-14)); // checked it with a geometric drawing
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14));
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane); // checked it with a geometric drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) < 1e-14); // checked it with a geometric drawing
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
   // spherical test 5
@@ -7628,12 +7628,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_from_plane) < 1e-14));  // checked it with a geometric drawing
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // checked it with a geometric drawing
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_from_plane) < 1e-14);  // checked it with a geometric drawing
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked it with a geometric drawing
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // spherical curve test 1
   // This test has not been checked analytically or with a drawing, but
@@ -7664,12 +7664,12 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
                                                  false,
                                                  bezier_curve);
 
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.distance_from_plane));  // see comment at the top of the test
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.)); // to make sure the approval test have the same characters for very small numbers // see comment at the top of the test
-  approval_tests.emplace_back(std::make_pair("",distance_from_planes.fraction_of_section));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.section)));
-  approval_tests.emplace_back(std::make_pair("",static_cast<double>(distance_from_planes.segment)));
-  approval_tests.emplace_back(std::make_pair("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.)); // to make sure the approval test have the same characters for very small numbers*/
+  approval_tests.emplace_back("",distance_from_planes.distance_from_plane);  // see comment at the top of the test
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // see comment at the top of the test
+  approval_tests.emplace_back("",distance_from_planes.fraction_of_section);
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back("",static_cast<double>(distance_from_planes.segment));
+  approval_tests.emplace_back("",std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers*/
 
   std::vector<std::string> approvals;
   for (auto&& value : approval_tests)
@@ -7692,44 +7692,44 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
 
     const double dtr = Consts::PI/180.0;
     world.parse_entries(world.parameters);
-    approval_tests.emplace_back(std::make_pair("",world.parameters.coordinate_system->max_model_depth()));
+    approval_tests.emplace_back("",world.parameters.coordinate_system->max_model_depth());
     // slab goes down and up again
     // origin
     std::array<double,3> position = {{6371000 - 0, 0 * dtr, 0 * dtr}};
     position = world.parameters.coordinate_system->natural_to_cartesian_coordinates(position);
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 1)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 200e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 210e3)));
+    approval_tests.emplace_back("",world.temperature(position, 0));
+    approval_tests.emplace_back("",world.temperature(position, 1));
+    approval_tests.emplace_back("",world.temperature(position, 200e3));
+    approval_tests.emplace_back("",world.temperature(position, 210e3));
 
     // ~330 km
     position = {{6371000 - 0, 0 * dtr, -3 * dtr}};
     position = world.parameters.coordinate_system->natural_to_cartesian_coordinates(position);
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 50e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 75e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 250e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 275e3)));
+    approval_tests.emplace_back("",world.temperature(position, 0));
+    approval_tests.emplace_back("",world.temperature(position, 50e3));
+    approval_tests.emplace_back("",world.temperature(position, 75e3));
+    approval_tests.emplace_back("",world.temperature(position, 250e3));
+    approval_tests.emplace_back("",world.temperature(position, 275e3));
 
 
     // ~1100 km
     position = {{6371000 - 0, 0 * dtr, -10 * dtr}};
     position = world.parameters.coordinate_system->natural_to_cartesian_coordinates(position);
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 95e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 100e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 300e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 305e3)));
+    approval_tests.emplace_back("",world.temperature(position, 0));
+    approval_tests.emplace_back("",world.temperature(position, 95e3));
+    approval_tests.emplace_back("",world.temperature(position, 100e3));
+    approval_tests.emplace_back("",world.temperature(position, 300e3));
+    approval_tests.emplace_back("",world.temperature(position, 305e3));
 
 
     // ~2200 km
     position = {{6371000 - 0, 0 * dtr, -20 * dtr}};
     position = world.parameters.coordinate_system->natural_to_cartesian_coordinates(position);
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 1)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 200e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 205e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 570e3)));
+    approval_tests.emplace_back("",world.temperature(position, 0));
+    approval_tests.emplace_back("",world.temperature(position, 1));
+    approval_tests.emplace_back("",world.temperature(position, 200e3));
+    approval_tests.emplace_back("",world.temperature(position, 205e3));
+    approval_tests.emplace_back("",world.temperature(position, 570e3));
   }
 
   {
@@ -7741,39 +7741,39 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
     // origin
     std::array<double,3> position = {{6371000 - 0, 0 * dtr, 0 * dtr}};
     position = world.parameters.coordinate_system->natural_to_cartesian_coordinates(position);
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 1)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 200e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 210e3)));
+    approval_tests.emplace_back("",world.temperature(position, 0));
+    approval_tests.emplace_back("",world.temperature(position, 1));
+    approval_tests.emplace_back("",world.temperature(position, 200e3));
+    approval_tests.emplace_back("",world.temperature(position, 210e3));
 
     // ~330 km
     position = {{6371000 - 0, 0 * dtr, -3 * dtr}};
     position = world.parameters.coordinate_system->natural_to_cartesian_coordinates(position);
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 50e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 75e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 250e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 275e3)));
+    approval_tests.emplace_back("",world.temperature(position, 0));
+    approval_tests.emplace_back("",world.temperature(position, 50e3));
+    approval_tests.emplace_back("",world.temperature(position, 75e3));
+    approval_tests.emplace_back("",world.temperature(position, 250e3));
+    approval_tests.emplace_back("",world.temperature(position, 275e3));
 
 
     // ~1100 km
     position = {{6371000 - 0, 0 * dtr, -10 * dtr}};
     position = world.parameters.coordinate_system->natural_to_cartesian_coordinates(position);
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 150e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 175e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 380e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 385e3)));
+    approval_tests.emplace_back("",world.temperature(position, 0));
+    approval_tests.emplace_back("",world.temperature(position, 150e3));
+    approval_tests.emplace_back("",world.temperature(position, 175e3));
+    approval_tests.emplace_back("",world.temperature(position, 380e3));
+    approval_tests.emplace_back("",world.temperature(position, 385e3));
 
 
     // ~1100 km
     position = {{6371000 - 0, 0 * dtr, -20 * dtr}};
     position = world.parameters.coordinate_system->natural_to_cartesian_coordinates(position);
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 0)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 350e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 355e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 565e3)));
-    approval_tests.emplace_back(std::make_pair("",world.temperature(position, 570e3)));
+    approval_tests.emplace_back("",world.temperature(position, 0));
+    approval_tests.emplace_back("",world.temperature(position, 350e3));
+    approval_tests.emplace_back("",world.temperature(position, 355e3));
+    approval_tests.emplace_back("",world.temperature(position, 565e3));
+    approval_tests.emplace_back("",world.temperature(position, 570e3));
   }
 
   std::vector<std::string> approvals;
@@ -7815,7 +7815,7 @@ TEST_CASE("Fast vs slow distance function")
   const Point<2> cartesian_1(1,2, cartesian);
   const Point<2> cartesian_2(2,3, cartesian);
   // Should be exactly the same.
-  approval_tests.emplace_back(std::make_pair("",sqrt(cartesian_1.cheap_relative_distance_cartesian(cartesian_2))));
+  approval_tests.emplace_back("",sqrt(cartesian_1.cheap_relative_distance_cartesian(cartesian_2)));
 
   const Point<2> spherical_1(1,2, spherical);
   const Point<2> spherical_2(2,3, spherical);
@@ -7891,10 +7891,10 @@ TEST_CASE("WorldBuilder Utilities function: calculate_ridge_distance_and_spreadi
                                       position_in_natural_coordinates_1,
                                       subducting_plate_velocities,
                                       ridge_migration_times);
-  approval_tests.emplace_back(std::make_pair("",result1[0])); // spreading velocity at ridge
-  approval_tests.emplace_back(std::make_pair("",result1[1])); // ridge distance
-  approval_tests.emplace_back(std::make_pair("",result1[2])); // subducting velocity at trench
-  approval_tests.emplace_back(std::make_pair("",result1[3])); // ridge migration time
+  approval_tests.emplace_back("",result1[0]); // spreading velocity at ridge
+  approval_tests.emplace_back("",result1[1]); // ridge distance
+  approval_tests.emplace_back("",result1[2]); // subducting velocity at trench
+  approval_tests.emplace_back("",result1[3]); // ridge migration time
 
   // Query point 2: locates outside of the ridge, current solution is to take the end point as the reference point
   Point<3> position_2(1e3,-2e3,0,cartesian);
@@ -7907,10 +7907,10 @@ TEST_CASE("WorldBuilder Utilities function: calculate_ridge_distance_and_spreadi
                                       position_in_natural_coordinates_2,
                                       subducting_plate_velocities,
                                       ridge_migration_times);
-  approval_tests.emplace_back(std::make_pair("",result2[0])); // spreading velocity at ridge
-  approval_tests.emplace_back(std::make_pair("",result2[1])); // ridge distance
-  approval_tests.emplace_back(std::make_pair("",result2[2])); // subducting velocity at trench
-  approval_tests.emplace_back(std::make_pair("",result2[3])); // ridge migration time
+  approval_tests.emplace_back("",result2[0]); // spreading velocity at ridge
+  approval_tests.emplace_back("",result2[1]); // ridge distance
+  approval_tests.emplace_back("",result2[2]); // subducting velocity at trench
+  approval_tests.emplace_back("",result2[3]); // ridge migration time
 
   // Query point 3: the nearest point on the ridge is in the middle of p2b and p2c
   // thus it should have intermediate velocity values
@@ -7924,10 +7924,10 @@ TEST_CASE("WorldBuilder Utilities function: calculate_ridge_distance_and_spreadi
                                       position_in_natural_coordinates_3,
                                       subducting_plate_velocities,
                                       ridge_migration_times);
-  approval_tests.emplace_back(std::make_pair("",result3[0])); // spreading velocity at ridge
-  approval_tests.emplace_back(std::make_pair("",result3[1])); // ridge distance
-  approval_tests.emplace_back(std::make_pair("",result3[2])); // subducting velocity at trench
-  approval_tests.emplace_back(std::make_pair("",result3[3])); // ridge migration time
+  approval_tests.emplace_back("",result3[0]); // spreading velocity at ridge
+  approval_tests.emplace_back("",result3[1]); // ridge distance
+  approval_tests.emplace_back("",result3[2]); // subducting velocity at trench
+  approval_tests.emplace_back("",result3[3]); // ridge migration time
 
   // Query point 4: the nearest point on the ridge is in the middle of p2a and p2b
   // thus it should have intermediate velocity values
@@ -7941,10 +7941,10 @@ TEST_CASE("WorldBuilder Utilities function: calculate_ridge_distance_and_spreadi
                                       position_in_natural_coordinates_4,
                                       subducting_plate_velocities,
                                       ridge_migration_times);
-  approval_tests.emplace_back(std::make_pair("",result4[0])); // spreading velocity at ridge
-  approval_tests.emplace_back(std::make_pair("",result4[1])); // ridge distance
-  approval_tests.emplace_back(std::make_pair("",result4[2])); // subducting velocity at trench
-  approval_tests.emplace_back(std::make_pair("",result4[3])); // ridge migration time
+  approval_tests.emplace_back("",result4[0]); // spreading velocity at ridge
+  approval_tests.emplace_back("",result4[1]); // ridge distance
+  approval_tests.emplace_back("",result4[2]); // subducting velocity at trench
+  approval_tests.emplace_back("",result4[3]); // ridge migration time
 
 
   std::vector<std::string> approvals;
@@ -8005,10 +8005,10 @@ TEST_CASE("WorldBuilder Utilities function: calculate_ridge_distance_and_spreadi
                                       position_in_natural_coordinates_1,
                                       subducting_plate_velocities,
                                       ridge_migration_times);
-  approval_tests.emplace_back(std::make_pair("",result1[0])); // spreading velocity at ridge
-  approval_tests.emplace_back(std::make_pair("",result1[1])); // ridge distance
-  approval_tests.emplace_back(std::make_pair("",result1[2])); // subducting velocity at trench
-  approval_tests.emplace_back(std::make_pair("",result1[3])); // ridge migration time
+  approval_tests.emplace_back("",result1[0]); // spreading velocity at ridge
+  approval_tests.emplace_back("",result1[1]); // ridge distance
+  approval_tests.emplace_back("",result1[2]); // subducting velocity at trench
+  approval_tests.emplace_back("",result1[3]); // ridge migration time
 
   // Query point 2, the nearest point on the ridge is in the middle of p2b and p2c
   Point<3> position_2(6371e3, 0.3491, 0.5236, spherical);
@@ -8021,10 +8021,10 @@ TEST_CASE("WorldBuilder Utilities function: calculate_ridge_distance_and_spreadi
                                       position_in_natural_coordinates_2,
                                       subducting_plate_velocities,
                                       ridge_migration_times);
-  approval_tests.emplace_back(std::make_pair("",result2[0])); // spreading velocity at ridge
-  approval_tests.emplace_back(std::make_pair("",result2[1])); // ridge distance
-  approval_tests.emplace_back(std::make_pair("",result2[2])); // subducting velocity at trench
-  approval_tests.emplace_back(std::make_pair("",result2[3])); // ridge migration time
+  approval_tests.emplace_back("",result2[0]); // spreading velocity at ridge
+  approval_tests.emplace_back("",result2[1]); // ridge distance
+  approval_tests.emplace_back("",result2[2]); // subducting velocity at trench
+  approval_tests.emplace_back("",result2[3]); // ridge migration time
 
   // Query point 3, the nearest point on the ridge is p2b, the purpose is to test a negative value of longitude
   Point<3> position_3(6371e3, -0.1745, 0.5236, spherical);
@@ -8037,10 +8037,10 @@ TEST_CASE("WorldBuilder Utilities function: calculate_ridge_distance_and_spreadi
                                       position_in_natural_coordinates_3,
                                       subducting_plate_velocities,
                                       ridge_migration_times);
-  approval_tests.emplace_back(std::make_pair("",result3[0])); // spreading velocity at ridge
-  approval_tests.emplace_back(std::make_pair("",result3[1])); // ridge distance
-  approval_tests.emplace_back(std::make_pair("",result3[2])); // subducting velocity at trench
-  approval_tests.emplace_back(std::make_pair("",result3[3])); // ridge migration time
+  approval_tests.emplace_back("",result3[0]); // spreading velocity at ridge
+  approval_tests.emplace_back("",result3[1]); // ridge distance
+  approval_tests.emplace_back("",result3[2]); // subducting velocity at trench
+  approval_tests.emplace_back("",result3[3]); // ridge migration time
 
 
   std::vector<std::string> approvals;
@@ -8063,16 +8063,16 @@ TEST_CASE("WorldBuilder Utilities function: calculate_effective_trench_and_plate
   const double distance_along_plane_1 = 1000e3;
   std::vector<double> result1 = Utilities::calculate_effective_trench_and_plate_ages(ridge_parameters_1, distance_along_plane_1);
 
-  approval_tests.emplace_back(std::make_pair("",result1[0])); // age at trench
-  approval_tests.emplace_back(std::make_pair("",result1[1])); // effective plate age
+  approval_tests.emplace_back("",result1[0]); // age at trench
+  approval_tests.emplace_back("",result1[1]); // effective plate age
 
   // test 2:  2 * spreading velocity = subducting velocity and no ridge migration, trench retreating
   std::vector<double> ridge_parameters_2 = {4.75299e-10, 1.04512e+06, 9.50598e-10, 0.0}; // m/s, m, m/s, s
   const double distance_along_plane_2 = 1000e3;
   std::vector<double> result2 = Utilities::calculate_effective_trench_and_plate_ages(ridge_parameters_2, distance_along_plane_2);
 
-  approval_tests.emplace_back(std::make_pair("",result2[0])); // age at trench
-  approval_tests.emplace_back(std::make_pair("",result2[1])); // effective plate age
+  approval_tests.emplace_back("",result2[0]); // age at trench
+  approval_tests.emplace_back("",result2[1]); // effective plate age
 
 
   std::vector<std::string> approvals;


### PR DESCRIPTION
emplace_back doesn't require std::pair inside anymore, replace typedef by using and replace enum by class enum.