### PR TITLE
Calculate a reference pressure profile in world.cc to use for isostasy.

### DIFF
--- a/doc/world_builder_declarations.schema.json
+++ b/doc/world_builder_declarations.schema.json
@@ -38,7 +38,7 @@
             "minItems": 0,
             "maxItems": 4294967295,
             "uniqueItems": false,
-            "description": "The material properties of the composition. This stores the user-defined index (required), linked to composition properties (optional) including name and reference density.",
+            "description": "The material properties of the composition. This stores user-defined indices (required), linked to composition properties (optional) including name and reference density.",
             "items": {
                 "type": "object",
                 "description": "",
@@ -15324,6 +15324,25 @@
             "default value": 3300.0,
             "type": "number",
             "description": "Density for the background material without any compositions."
+        },
+        "compensation depth": {
+            "default value": 250000.0,
+            "type": "number",
+            "description": "Compensation depth for isostatic topography."
+        },
+        "number of integration points": {
+            "default value": 100,
+            "type": "integer",
+            "description": "Number of integration points for calculating the compensation pressure."
+        },
+        "Reference profile point": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "description": "This is an array of two points along where the cross section is taken",
+            "items": {
+                "type": "number"
+            }
         }
     }
 }

--- a/doc/world_builder_declarations_closed.md
+++ b/doc/world_builder_declarations_closed.md
@@ -55,7 +55,7 @@
 - **minItems**:0
 - **maxItems**:4294967295
 - **uniqueItems**:false
-- **description**:The material properties of the composition. This stores the user-defined index (required), linked to composition properties (optional) including name and reference density.
+- **description**:The material properties of the composition. This stores user-defined indices (required), linked to composition properties (optional) including name and reference density.
 :::::::::::::::::::::::{dropdown} /composition properties/items
 :name: closed_composition-properties_items
 
@@ -22183,6 +22183,37 @@
 - **default value**:3300.0
 - **type**:number
 - **description**:Density for the background material without any compositions.
+::::::::::::::::::::::::
+
+::::::::::::::::::::::::{dropdown} /compensation depth
+:name: closed_compensation-depth
+
+- **default value**:250000.0
+- **type**:number
+- **description**:Compensation depth for isostatic topography.
+::::::::::::::::::::::::
+
+::::::::::::::::::::::::{dropdown} /number of integration points
+:name: closed_number-of-integration-points
+
+- **default value**:100
+- **type**:integer
+- **description**:Number of integration points for calculating the compensation pressure.
+::::::::::::::::::::::::
+
+::::::::::::::::::::::::{dropdown} /Reference profile point
+:name: closed_Reference-profile-point
+
+- **type**:array
+- **minItems**:2
+- **maxItems**:2
+- **description**:This is an array of two points along where the cross section is taken
+:::::::::::::::::::::::{dropdown} /Reference profile point/items
+:name: closed_Reference-profile-point_items
+
+- **type**:number
+:::::::::::::::::::::::
+
 ::::::::::::::::::::::::
 
 

--- a/doc/world_builder_declarations_open.md
+++ b/doc/world_builder_declarations_open.md
@@ -61,7 +61,7 @@
 - **minItems**:0
 - **maxItems**:4294967295
 - **uniqueItems**:false
-- **description**:The material properties of the composition. This stores the user-defined index (required), linked to composition properties (optional) including name and reference density.
+- **description**:The material properties of the composition. This stores user-defined indices (required), linked to composition properties (optional) including name and reference density.
 :::::::::::::::::::::::{dropdown} /composition properties/items
 :open:
 :name: open_composition-properties_items
@@ -24949,6 +24949,41 @@
 - **default value**:3300.0
 - **type**:number
 - **description**:Density for the background material without any compositions.
+::::::::::::::::::::::::
+
+::::::::::::::::::::::::{dropdown} /compensation depth
+:open:
+:name: open_compensation-depth
+
+- **default value**:250000.0
+- **type**:number
+- **description**:Compensation depth for isostatic topography.
+::::::::::::::::::::::::
+
+::::::::::::::::::::::::{dropdown} /number of integration points
+:open:
+:name: open_number-of-integration-points
+
+- **default value**:100
+- **type**:integer
+- **description**:Number of integration points for calculating the compensation pressure.
+::::::::::::::::::::::::
+
+::::::::::::::::::::::::{dropdown} /Reference profile point
+:open:
+:name: open_Reference-profile-point
+
+- **type**:array
+- **minItems**:2
+- **maxItems**:2
+- **description**:This is an array of two points along where the cross section is taken
+:::::::::::::::::::::::{dropdown} /Reference profile point/items
+:open:
+:name: open_Reference-profile-point_items
+
+- **type**:number
+:::::::::::::::::::::::
+
 ::::::::::::::::::::::::
 
 

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -320,6 +320,26 @@ namespace WorldBuilder
       /**
        * Todo
        */
+      double compensation_depth;
+
+      /**
+       * Todo
+       */
+      unsigned int number_integration_points;
+
+      /**
+       * Todo
+       */
+      double compensation_pressure;
+
+      /**
+       * Todo
+       */
+      Point<2> reference_profile_point;
+
+      /**
+       * Todo
+       */
       std::string interpolation;
 
       /**

--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -520,6 +520,11 @@ namespace WorldBuilder
           }
         return Point<2>(value1,value2,this->coordinate_system->natural_coordinate_system());
       }
+    else
+      {
+        return Point<2>(std::numeric_limits<double>::quiet_NaN(),std::numeric_limits<double>::quiet_NaN(),this->coordinate_system->natural_coordinate_system());
+      }
+
     WBAssertThrow(false, "default values not implemented in get<Point<2> >. Looked in: " + strict_base + "/" << name);
 
     return {invalid};;

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -59,6 +59,8 @@ namespace WorldBuilder
     :
     parameters(*this),
     surface_coord_conversions(invalid),
+    compensation_pressure(0.),
+    reference_profile_point(invalid),
     dim(NaN::ISNAN),
     random_number_engine(random_number_seed),
     limit_debug_consistency_checks(limit_debug_consistency_checks_)
@@ -98,6 +100,36 @@ namespace WorldBuilder
     parameters.initialize(filename, has_output_dir, output_dir);
 
     this->parse_entries(parameters);
+
+    // If values are given, generate reference profile.
+    if (!std::isnan(reference_profile_point[0]) && !std::isnan(reference_profile_point[1]))
+      {
+        // Set the x-y reference point to integrate from.
+        const CoordinateSystem coordinate_system = parameters.coordinate_system->natural_coordinate_system();
+        Point<3> point({{reference_profile_point[0], reference_profile_point[1], 0}}, coordinate_system);
+
+        // Get initial density value. TODO: Does this always start at zero, and
+        // need to test that it works when multiple compositions are present.
+        double density_prev = this->properties(point.get_array(), 0., {{{7,0,0}}})[0];
+
+        // Loop along reference profile to calculate a compensation pressure using the trapezoidal method.
+        const double gravity = this->parameters.gravity_model->gravity_norm(point);
+        const double dz = compensation_depth / (number_integration_points - 1);
+        for (unsigned int i = 1; i < number_integration_points; ++i)
+          {
+            // Calculate position along the line
+            const double z = i * dz;
+
+            // Calculate density at this point
+            double density = this->properties(point.get_array(), z, {{{7,0,0}}})[0];
+
+            // Trapezoidal step
+            compensation_pressure += 0.5 * (density + density_prev) * dz * gravity;
+
+            density_prev = density;
+          }
+      }
+
   }
 
   World::~World()
@@ -154,6 +186,15 @@ namespace WorldBuilder
 
       prm.declare_entry("background density", Types::Double(3300),
                         "Density for the background material without any compositions.");
+
+      prm.declare_entry("compensation depth", Types::Double(250e3),
+                        "Compensation depth for isostatic topography.");
+
+      prm.declare_entry("number of integration points", Types::Int(100),
+                        "Number of integration points for calculating the compensation pressure.");
+
+      prm.declare_entry("Reference profile point", Types::Point<2>(),
+                        "This is an array of two points along where the cross section is taken");
 
     }
     prm.leave_subsection();
@@ -246,6 +287,21 @@ namespace WorldBuilder
      * Density parameters.
      */
     background_density = prm.get<double>("background density");
+
+    /**
+     * Compensation depth for isostasy.
+     */
+    compensation_depth = prm.get<double>("compensation depth");
+
+    /**
+     * Number of integration points for isostasy.
+     */
+    number_integration_points = prm.get<unsigned int>("number of integration points");
+
+    /**
+     * Reference point for isostasy.
+     */
+    reference_profile_point = prm.get<Point<2>>("Reference profile point");
 
     /**
      * Model discretization parameters


### PR DESCRIPTION
This pull request introduces a feature that allows users to specify a compensation depth, a reference profile point, and the number of integration points. These parameters are used to compute a reference compensation pressure.

In a subsequent pull request, this pressure will be used by the initial topography module to equilibrate the topography.

At the moment this has only been tested with a 2D box model.