### PR TITLE
fix typo for grains models

### DIFF
--- a/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution.h
@@ -84,7 +84,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.h
@@ -83,7 +83,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/continental_plate_models/grains/uniform.h
+++ b/include/world_builder/features/continental_plate_models/grains/uniform.h
@@ -82,7 +82,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution.h
@@ -83,7 +83,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.h
@@ -83,7 +83,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/fault_models/grains/uniform.h
+++ b/include/world_builder/features/fault_models/grains/uniform.h
@@ -82,7 +82,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.h
@@ -83,7 +83,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.h
@@ -83,7 +83,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/mantle_layer_models/grains/uniform.h
+++ b/include/world_builder/features/mantle_layer_models/grains/uniform.h
@@ -83,7 +83,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.h
@@ -83,7 +83,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.h
@@ -83,7 +83,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/oceanic_plate_models/grains/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/grains/uniform.h
@@ -83,7 +83,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/plume_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/plume_models/grains/random_uniform_distribution_deflected.h
@@ -82,7 +82,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/plume_models/grains/uniform.h
+++ b/include/world_builder/features/plume_models/grains/uniform.h
@@ -82,7 +82,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.h
@@ -82,7 +82,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.h
+++ b/include/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.h
@@ -82,7 +82,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/include/world_builder/features/subducting_plate_models/grains/uniform.h
+++ b/include/world_builder/features/subducting_plate_models/grains/uniform.h
@@ -82,7 +82,7 @@ namespace WorldBuilder
 
             /**
              * Returns a grains based on the given position, composition (e.g.
-             * olivine and/or enstatite)depth in the model, gravity and current grains.
+             * olivine and/or enstatite) depth in the model, gravity and current grains.
              */
             WorldBuilder::grains
             get_grains(const Point<3> &position,

--- a/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution.cc
@@ -144,7 +144,7 @@ namespace WorldBuilder
                               // set a uniform random a_cosine_matrix per grain
                               // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                               // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                              // and is licenend according to this website with the following licence:
+                              // and is licensed according to this website with the following licence:
                               //
                               // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                               // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -181,7 +181,7 @@ namespace WorldBuilder
                               // set a uniform random a_cosine_matrix per grain
                               // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                               // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                              // and is licenend according to this website with the following licence:
+                              // and is licensed according to this website with the following licence:
                               //
                               // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                               // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/fault_models/grains/random_uniform_distribution.cc
@@ -132,7 +132,7 @@ namespace WorldBuilder
                           // set a uniform random a_cosine_matrix per grain
                           // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                           // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                          // and is licenend according to this website with the following licence:
+                          // and is licensed according to this website with the following licence:
                           //
                           // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                           // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.cc
@@ -170,7 +170,7 @@ namespace WorldBuilder
                           // set a uniform random a_cosine_matrix per grain
                           // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                           // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                          // and is licenend according to this website with the following licence:
+                          // and is licensed according to this website with the following licence:
                           //
                           // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                           // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.cc
@@ -138,7 +138,7 @@ namespace WorldBuilder
                               // set a uniform random a_cosine_matrix per grain
                               // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                               // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                              // and is licenend according to this website with the following licence:
+                              // and is licensed according to this website with the following licence:
                               //
                               // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                               // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.cc
@@ -175,7 +175,7 @@ namespace WorldBuilder
                               // set a uniform random a_cosine_matrix per grain
                               // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                               // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                              // and is licenend according to this website with the following licence:
+                              // and is licensed according to this website with the following licence:
                               //
                               // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                               // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -144,7 +144,7 @@ namespace WorldBuilder
                               // set a uniform random a_cosine_matrix per grain
                               // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                               // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                              // and is licenend according to this website with the following licence:
+                              // and is licensed according to this website with the following licence:
                               //
                               // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                               // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -181,7 +181,7 @@ namespace WorldBuilder
                               // set a uniform random a_cosine_matrix per grain
                               // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                               // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                              // and is licenend according to this website with the following licence:
+                              // and is licensed according to this website with the following licence:
                               //
                               // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                               // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/plume_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/plume_models/grains/random_uniform_distribution_deflected.cc
@@ -172,7 +172,7 @@ namespace WorldBuilder
                           // set a uniform random a_cosine_matrix per grain
                           // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                           // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                          // and is licenend according to this website with the following licence:
+                          // and is licensed according to this website with the following licence:
                           //
                           // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                           // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -132,7 +132,7 @@ namespace WorldBuilder
                           // set a uniform random a_cosine_matrix per grain
                           // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                           // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                          // and is licenend according to this website with the following licence:
+                          // and is licensed according to this website with the following licence:
                           //
                           // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                           // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit

--- a/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -170,7 +170,7 @@ namespace WorldBuilder
                           // set a uniform random a_cosine_matrix per grain
                           // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
                           // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
-                          // and is licenend according to this website with the following licence:
+                          // and is licensed according to this website with the following licence:
                           //
                           // "The Graphics Gems code is copyright-protected. In other words, you cannot claim the text of the code as your own and
                           // resell it. Using the code is permitted in any program, product, or library, non-commercial or commercial. Giving credit


### PR DESCRIPTION
This is a small fix for white space and typo in a couple of the grains models.