### PR TITLE
[Obsolete] A new composition parser for all features

### DIFF
--- a/doc/world_builder_declarations.schema.json
+++ b/doc/world_builder_declarations.schema.json
@@ -853,11 +853,15 @@
                                                     ]
                                                 },
                                                 "operation": {
-                                                    "default value": "replace",
+                                                    "default value": "add",
                                                     "type": "string",
-                                                    "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                    "description": "Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.",
                                                     "enum": [
                                                         "replace",
+                                                        "add",
+                                                        "subtract",
+                                                        "replace",
+                                                        "replace defined only",
                                                         "add",
                                                         "subtract"
                                                     ]
@@ -991,11 +995,6 @@
                                                     "default value": 2.0,
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
-                                                },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
                                                 }
                                             }
                                         },
@@ -1611,11 +1610,6 @@
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
                                                 },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                },
                                                 "operation": {
                                                     "default value": "add",
                                                     "type": "string",
@@ -1753,9 +1747,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "min value": {
@@ -3264,11 +3268,15 @@
                                                                 ]
                                                             },
                                                             "operation": {
-                                                                "default value": "replace",
+                                                                "default value": "add",
                                                                 "type": "string",
-                                                                "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                                "description": "Whether to replace, add, or subtract values.",
                                                                 "enum": [
                                                                     "replace",
+                                                                    "add",
+                                                                    "subtract",
+                                                                    "replace",
+                                                                    "replace defined only",
                                                                     "add",
                                                                     "subtract"
                                                                 ]
@@ -3312,11 +3320,6 @@
                                                                 "default value": 2.0,
                                                                 "type": "number",
                                                                 "description": "Frequency multiplier between octaves."
-                                                            },
-                                                            "seed": {
-                                                                "default value": 0,
-                                                                "type": "integer",
-                                                                "description": "Seed for the random number generator. If 0, a random seed is used."
                                                             }
                                                         }
                                                     },
@@ -3456,11 +3459,6 @@
                                                                 "type": "number",
                                                                 "description": "Frequency multiplier between octaves."
                                                             },
-                                                            "seed": {
-                                                                "default value": 0,
-                                                                "type": "integer",
-                                                                "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                            },
                                                             "operation": {
                                                                 "default value": "add",
                                                                 "type": "string",
@@ -3532,9 +3530,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "operation": {
@@ -3584,9 +3592,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "fractions": {
@@ -4185,11 +4203,15 @@
                                                     ]
                                                 },
                                                 "operation": {
-                                                    "default value": "replace",
+                                                    "default value": "add",
                                                     "type": "string",
-                                                    "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                    "description": "Whether to replace, add, or subtract values.",
                                                     "enum": [
                                                         "replace",
+                                                        "add",
+                                                        "subtract",
+                                                        "replace",
+                                                        "replace defined only",
                                                         "add",
                                                         "subtract"
                                                     ]
@@ -4233,11 +4255,6 @@
                                                     "default value": 2.0,
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
-                                                },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
                                                 }
                                             }
                                         },
@@ -4377,11 +4394,6 @@
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
                                                 },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                },
                                                 "operation": {
                                                     "default value": "add",
                                                     "type": "string",
@@ -4453,9 +4465,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "operation": {
@@ -4505,9 +4527,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "fractions": {
@@ -5176,11 +5208,15 @@
                                                                             ]
                                                                         },
                                                                         "operation": {
-                                                                            "default value": "replace",
+                                                                            "default value": "add",
                                                                             "type": "string",
-                                                                            "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                                            "description": "Whether to replace, add, or subtract values.",
                                                                             "enum": [
                                                                                 "replace",
+                                                                                "add",
+                                                                                "subtract",
+                                                                                "replace",
+                                                                                "replace defined only",
                                                                                 "add",
                                                                                 "subtract"
                                                                             ]
@@ -5224,11 +5260,6 @@
                                                                             "default value": 2.0,
                                                                             "type": "number",
                                                                             "description": "Frequency multiplier between octaves."
-                                                                        },
-                                                                        "seed": {
-                                                                            "default value": 0,
-                                                                            "type": "integer",
-                                                                            "description": "Seed for the random number generator. If 0, a random seed is used."
                                                                         }
                                                                     }
                                                                 },
@@ -5368,11 +5399,6 @@
                                                                             "type": "number",
                                                                             "description": "Frequency multiplier between octaves."
                                                                         },
-                                                                        "seed": {
-                                                                            "default value": 0,
-                                                                            "type": "integer",
-                                                                            "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                                        },
                                                                         "operation": {
                                                                             "default value": "add",
                                                                             "type": "string",
@@ -5444,9 +5470,19 @@
                                                                             "uniqueItems": false,
                                                                             "description": "A list with the labels of the composition which are present there.",
                                                                             "items": {
-                                                                                "default value": 0,
-                                                                                "type": "integer",
-                                                                                "description": ""
+                                                                                "description": "",
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "default value": 0,
+                                                                                        "type": "integer",
+                                                                                        "description": ""
+                                                                                    },
+                                                                                    {
+                                                                                        "default value": "",
+                                                                                        "type": "string",
+                                                                                        "description": ""
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         },
                                                                         "operation": {
@@ -5496,9 +5532,19 @@
                                                                             "uniqueItems": false,
                                                                             "description": "A list with the labels of the composition which are present there.",
                                                                             "items": {
-                                                                                "default value": 0,
-                                                                                "type": "integer",
-                                                                                "description": ""
+                                                                                "description": "",
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "default value": 0,
+                                                                                        "type": "integer",
+                                                                                        "description": ""
+                                                                                    },
+                                                                                    {
+                                                                                        "default value": "",
+                                                                                        "type": "string",
+                                                                                        "description": ""
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         },
                                                                         "fractions": {
@@ -6097,11 +6143,15 @@
                                                                 ]
                                                             },
                                                             "operation": {
-                                                                "default value": "replace",
+                                                                "default value": "add",
                                                                 "type": "string",
-                                                                "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                                "description": "Whether to replace, add, or subtract values.",
                                                                 "enum": [
                                                                     "replace",
+                                                                    "add",
+                                                                    "subtract",
+                                                                    "replace",
+                                                                    "replace defined only",
                                                                     "add",
                                                                     "subtract"
                                                                 ]
@@ -6145,11 +6195,6 @@
                                                                 "default value": 2.0,
                                                                 "type": "number",
                                                                 "description": "Frequency multiplier between octaves."
-                                                            },
-                                                            "seed": {
-                                                                "default value": 0,
-                                                                "type": "integer",
-                                                                "description": "Seed for the random number generator. If 0, a random seed is used."
                                                             }
                                                         }
                                                     },
@@ -6289,11 +6334,6 @@
                                                                 "type": "number",
                                                                 "description": "Frequency multiplier between octaves."
                                                             },
-                                                            "seed": {
-                                                                "default value": 0,
-                                                                "type": "integer",
-                                                                "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                            },
                                                             "operation": {
                                                                 "default value": "add",
                                                                 "type": "string",
@@ -6365,9 +6405,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "operation": {
@@ -6417,9 +6467,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "fractions": {
@@ -7322,11 +7382,15 @@
                                                     ]
                                                 },
                                                 "operation": {
-                                                    "default value": "replace",
+                                                    "default value": "add",
                                                     "type": "string",
-                                                    "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                    "description": "Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.",
                                                     "enum": [
                                                         "replace",
+                                                        "add",
+                                                        "subtract",
+                                                        "replace",
+                                                        "replace defined only",
                                                         "add",
                                                         "subtract"
                                                     ]
@@ -7450,11 +7514,6 @@
                                                     "default value": 2.0,
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
-                                                },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
                                                 }
                                             }
                                         },
@@ -7754,11 +7813,6 @@
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
                                                 },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                },
                                                 "operation": {
                                                     "default value": "add",
                                                     "type": "string",
@@ -7886,9 +7940,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "fractions": {
@@ -9571,11 +9635,15 @@
                                                     ]
                                                 },
                                                 "operation": {
-                                                    "default value": "replace",
+                                                    "default value": "add",
                                                     "type": "string",
-                                                    "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                    "description": "Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.",
                                                     "enum": [
                                                         "replace",
+                                                        "add",
+                                                        "subtract",
+                                                        "replace",
+                                                        "replace defined only",
                                                         "add",
                                                         "subtract"
                                                     ]
@@ -9709,11 +9777,6 @@
                                                     "default value": 2.0,
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
-                                                },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
                                                 }
                                             }
                                         },
@@ -10384,11 +10447,6 @@
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
                                                 },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                },
                                                 "operation": {
                                                     "default value": "add",
                                                     "type": "string",
@@ -10526,9 +10584,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "density": {
@@ -10688,9 +10756,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "fractions": {
@@ -12277,11 +12355,15 @@
                                                     ]
                                                 },
                                                 "operation": {
-                                                    "default value": "replace",
+                                                    "default value": "add",
                                                     "type": "string",
-                                                    "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                    "description": "Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.",
                                                     "enum": [
                                                         "replace",
+                                                        "add",
+                                                        "subtract",
+                                                        "replace",
+                                                        "replace defined only",
                                                         "add",
                                                         "subtract"
                                                     ]
@@ -12325,11 +12407,6 @@
                                                     "default value": 2.0,
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
-                                                },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
                                                 }
                                             }
                                         },
@@ -12469,11 +12546,6 @@
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
                                                 },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                },
                                                 "operation": {
                                                     "default value": "add",
                                                     "type": "string",
@@ -12521,9 +12593,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "fractions": {
@@ -12560,6 +12642,159 @@
                                 "type": "array",
                                 "items": {
                                     "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.",
+                                            "additionalProperties": false,
+                                            "required": [
+                                                "model",
+                                                "compositions"
+                                            ],
+                                            "properties": {
+                                                "model": {
+                                                    "default value": "",
+                                                    "type": "string",
+                                                    "description": "The name of the grains model.",
+                                                    "enum": [
+                                                        "random uniform distribution"
+                                                    ]
+                                                },
+                                                "min depth": {
+                                                    "description": "The depth in meters from which the composition of this feature is present.",
+                                                    "oneOf": [
+                                                        {
+                                                            "default value": 0.0,
+                                                            "type": "number",
+                                                            "description": ""
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "minItems": 0,
+                                                            "maxItems": 4294967295,
+                                                            "uniqueItems": false,
+                                                            "description": "",
+                                                            "items": {
+                                                                "type": "array",
+                                                                "additionalProperties": false,
+                                                                "minItems": 1,
+                                                                "maxItems": 2,
+                                                                "description": "",
+                                                                "items": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "number",
+                                                                            "default value": 0.0
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "minItems": 1,
+                                                                            "maxItems": 4294967295,
+                                                                            "items": {
+                                                                                "type": "array",
+                                                                                "minItems": 1,
+                                                                                "maxItems": 2,
+                                                                                "items": {
+                                                                                    "type": "number"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "max depth": {
+                                                    "description": "The depth in meters to which the composition of this feature is present.",
+                                                    "oneOf": [
+                                                        {
+                                                            "default value": 1.7976931348623157e308,
+                                                            "type": "number",
+                                                            "description": ""
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "minItems": 0,
+                                                            "maxItems": 4294967295,
+                                                            "uniqueItems": false,
+                                                            "description": "",
+                                                            "items": {
+                                                                "type": "array",
+                                                                "additionalProperties": false,
+                                                                "minItems": 1,
+                                                                "maxItems": 2,
+                                                                "description": "",
+                                                                "items": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "number",
+                                                                            "default value": 1.7976931348623157e308
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "minItems": 1,
+                                                                            "maxItems": 4294967295,
+                                                                            "items": {
+                                                                                "type": "array",
+                                                                                "minItems": 1,
+                                                                                "maxItems": 2,
+                                                                                "items": {
+                                                                                    "type": "number"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "compositions": {
+                                                    "type": "array",
+                                                    "minItems": 0,
+                                                    "maxItems": 4294967295,
+                                                    "uniqueItems": false,
+                                                    "description": "A list with the integer labels of the composition which are present there.",
+                                                    "items": {
+                                                        "default value": 0,
+                                                        "type": "integer",
+                                                        "description": ""
+                                                    }
+                                                },
+                                                "orientation operation": {
+                                                    "default value": "replace",
+                                                    "type": "string",
+                                                    "description": "Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.",
+                                                    "enum": [
+                                                        "replace"
+                                                    ]
+                                                },
+                                                "grain sizes": {
+                                                    "type": "array",
+                                                    "minItems": 0,
+                                                    "maxItems": 4294967295,
+                                                    "uniqueItems": false,
+                                                    "description": "A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.",
+                                                    "items": {
+                                                        "default value": 1.0,
+                                                        "type": "number",
+                                                        "description": ""
+                                                    }
+                                                },
+                                                "normalize grain sizes": {
+                                                    "type": "array",
+                                                    "minItems": 0,
+                                                    "maxItems": 4294967295,
+                                                    "uniqueItems": false,
+                                                    "description": "A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.",
+                                                    "items": {
+                                                        "default value": true,
+                                                        "type": "boolean",
+                                                        "description": ""
+                                                    }
+                                                }
+                                            }
+                                        },
                                         {
                                             "type": "object",
                                             "description": "Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.",
@@ -13145,7 +13380,7 @@
                                                     },
                                                     {
                                                         "type": "object",
-                                                        "description": "Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of \"top truncation\" parameter subducting plate. Notes:1) the parameter \"thickness\" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.",
+                                                        "description": "Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of \"top truncation\" parameter subducting plate. Notes:1) the parameter \"thickness\" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.",
                                                         "additionalProperties": false,
                                                         "required": [
                                                             "model",
@@ -13179,7 +13414,7 @@
                                                             "max distance slab top": {
                                                                 "default value": 1.7976931348623157e308,
                                                                 "type": "number",
-                                                                "description": "The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km."
+                                                                "description": "The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km."
                                                             },
                                                             "density": {
                                                                 "default value": 3300.0,
@@ -13364,11 +13599,15 @@
                                                                 ]
                                                             },
                                                             "operation": {
-                                                                "default value": "replace",
+                                                                "default value": "add",
                                                                 "type": "string",
-                                                                "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                                "description": "Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.",
                                                                 "enum": [
                                                                     "replace",
+                                                                    "add",
+                                                                    "subtract",
+                                                                    "replace",
+                                                                    "replace defined only",
                                                                     "add",
                                                                     "subtract"
                                                                 ]
@@ -13412,11 +13651,6 @@
                                                                 "default value": 2.0,
                                                                 "type": "number",
                                                                 "description": "Frequency multiplier between octaves."
-                                                            },
-                                                            "seed": {
-                                                                "default value": 0,
-                                                                "type": "integer",
-                                                                "description": "Seed for the random number generator. If 0, a random seed is used."
                                                             }
                                                         }
                                                     },
@@ -13630,11 +13864,6 @@
                                                                 "type": "number",
                                                                 "description": "Frequency multiplier between octaves."
                                                             },
-                                                            "seed": {
-                                                                "default value": 0,
-                                                                "type": "integer",
-                                                                "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                            },
                                                             "operation": {
                                                                 "default value": "add",
                                                                 "type": "string",
@@ -13706,9 +13935,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "operation": {
@@ -13763,9 +14002,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "lithology": {
@@ -13830,9 +14079,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "fractions": {
@@ -14414,7 +14673,7 @@
                                         },
                                         {
                                             "type": "object",
-                                            "description": "Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of \"top truncation\" parameter subducting plate. Notes:1) the parameter \"thickness\" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.",
+                                            "description": "Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of \"top truncation\" parameter subducting plate. Notes:1) the parameter \"thickness\" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.",
                                             "additionalProperties": false,
                                             "required": [
                                                 "model",
@@ -14448,7 +14707,7 @@
                                                 "max distance slab top": {
                                                     "default value": 1.7976931348623157e308,
                                                     "type": "number",
-                                                    "description": "The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km."
+                                                    "description": "The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km."
                                                 },
                                                 "density": {
                                                     "default value": 3300.0,
@@ -14633,11 +14892,15 @@
                                                     ]
                                                 },
                                                 "operation": {
-                                                    "default value": "replace",
+                                                    "default value": "add",
                                                     "type": "string",
-                                                    "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                    "description": "Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.",
                                                     "enum": [
                                                         "replace",
+                                                        "add",
+                                                        "subtract",
+                                                        "replace",
+                                                        "replace defined only",
                                                         "add",
                                                         "subtract"
                                                     ]
@@ -14681,11 +14944,6 @@
                                                     "default value": 2.0,
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
-                                                },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
                                                 }
                                             }
                                         },
@@ -14899,11 +15157,6 @@
                                                     "type": "number",
                                                     "description": "Frequency multiplier between octaves."
                                                 },
-                                                "seed": {
-                                                    "default value": 0,
-                                                    "type": "integer",
-                                                    "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                },
                                                 "operation": {
                                                     "default value": "add",
                                                     "type": "string",
@@ -14975,9 +15228,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "operation": {
@@ -15032,9 +15295,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "lithology": {
@@ -15099,9 +15372,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "fractions": {
@@ -15753,7 +16036,7 @@
                                                                 },
                                                                 {
                                                                     "type": "object",
-                                                                    "description": "Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of \"top truncation\" parameter subducting plate. Notes:1) the parameter \"thickness\" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.",
+                                                                    "description": "Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of \"top truncation\" parameter subducting plate. Notes:1) the parameter \"thickness\" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.",
                                                                     "additionalProperties": false,
                                                                     "required": [
                                                                         "model",
@@ -15787,7 +16070,7 @@
                                                                         "max distance slab top": {
                                                                             "default value": 1.7976931348623157e308,
                                                                             "type": "number",
-                                                                            "description": "The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km."
+                                                                            "description": "The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km."
                                                                         },
                                                                         "density": {
                                                                             "default value": 3300.0,
@@ -15972,11 +16255,15 @@
                                                                             ]
                                                                         },
                                                                         "operation": {
-                                                                            "default value": "replace",
+                                                                            "default value": "add",
                                                                             "type": "string",
-                                                                            "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                                            "description": "Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.",
                                                                             "enum": [
                                                                                 "replace",
+                                                                                "add",
+                                                                                "subtract",
+                                                                                "replace",
+                                                                                "replace defined only",
                                                                                 "add",
                                                                                 "subtract"
                                                                             ]
@@ -16020,11 +16307,6 @@
                                                                             "default value": 2.0,
                                                                             "type": "number",
                                                                             "description": "Frequency multiplier between octaves."
-                                                                        },
-                                                                        "seed": {
-                                                                            "default value": 0,
-                                                                            "type": "integer",
-                                                                            "description": "Seed for the random number generator. If 0, a random seed is used."
                                                                         }
                                                                     }
                                                                 },
@@ -16238,11 +16520,6 @@
                                                                             "type": "number",
                                                                             "description": "Frequency multiplier between octaves."
                                                                         },
-                                                                        "seed": {
-                                                                            "default value": 0,
-                                                                            "type": "integer",
-                                                                            "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                                        },
                                                                         "operation": {
                                                                             "default value": "add",
                                                                             "type": "string",
@@ -16314,9 +16591,19 @@
                                                                             "uniqueItems": false,
                                                                             "description": "A list with the labels of the composition which are present there.",
                                                                             "items": {
-                                                                                "default value": 0,
-                                                                                "type": "integer",
-                                                                                "description": ""
+                                                                                "description": "",
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "default value": 0,
+                                                                                        "type": "integer",
+                                                                                        "description": ""
+                                                                                    },
+                                                                                    {
+                                                                                        "default value": "",
+                                                                                        "type": "string",
+                                                                                        "description": ""
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         },
                                                                         "operation": {
@@ -16371,9 +16658,19 @@
                                                                             "uniqueItems": false,
                                                                             "description": "A list with the labels of the composition which are present there.",
                                                                             "items": {
-                                                                                "default value": 0,
-                                                                                "type": "integer",
-                                                                                "description": ""
+                                                                                "description": "",
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "default value": 0,
+                                                                                        "type": "integer",
+                                                                                        "description": ""
+                                                                                    },
+                                                                                    {
+                                                                                        "default value": "",
+                                                                                        "type": "string",
+                                                                                        "description": ""
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         },
                                                                         "lithology": {
@@ -16438,9 +16735,19 @@
                                                                             "uniqueItems": false,
                                                                             "description": "A list with the labels of the composition which are present there.",
                                                                             "items": {
-                                                                                "default value": 0,
-                                                                                "type": "integer",
-                                                                                "description": ""
+                                                                                "description": "",
+                                                                                "oneOf": [
+                                                                                    {
+                                                                                        "default value": 0,
+                                                                                        "type": "integer",
+                                                                                        "description": ""
+                                                                                    },
+                                                                                    {
+                                                                                        "default value": "",
+                                                                                        "type": "string",
+                                                                                        "description": ""
+                                                                                    }
+                                                                                ]
                                                                             }
                                                                         },
                                                                         "fractions": {
@@ -17022,7 +17329,7 @@
                                                     },
                                                     {
                                                         "type": "object",
-                                                        "description": "Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of \"top truncation\" parameter subducting plate. Notes:1) the parameter \"thickness\" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.",
+                                                        "description": "Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of \"top truncation\" parameter subducting plate. Notes:1) the parameter \"thickness\" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.",
                                                         "additionalProperties": false,
                                                         "required": [
                                                             "model",
@@ -17056,7 +17363,7 @@
                                                             "max distance slab top": {
                                                                 "default value": 1.7976931348623157e308,
                                                                 "type": "number",
-                                                                "description": "The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km."
+                                                                "description": "The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km."
                                                             },
                                                             "density": {
                                                                 "default value": 3300.0,
@@ -17241,11 +17548,15 @@
                                                                 ]
                                                             },
                                                             "operation": {
-                                                                "default value": "replace",
+                                                                "default value": "add",
                                                                 "type": "string",
-                                                                "description": "Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).",
+                                                                "description": "Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.",
                                                                 "enum": [
                                                                     "replace",
+                                                                    "add",
+                                                                    "subtract",
+                                                                    "replace",
+                                                                    "replace defined only",
                                                                     "add",
                                                                     "subtract"
                                                                 ]
@@ -17289,11 +17600,6 @@
                                                                 "default value": 2.0,
                                                                 "type": "number",
                                                                 "description": "Frequency multiplier between octaves."
-                                                            },
-                                                            "seed": {
-                                                                "default value": 0,
-                                                                "type": "integer",
-                                                                "description": "Seed for the random number generator. If 0, a random seed is used."
                                                             }
                                                         }
                                                     },
@@ -17507,11 +17813,6 @@
                                                                 "type": "number",
                                                                 "description": "Frequency multiplier between octaves."
                                                             },
-                                                            "seed": {
-                                                                "default value": 0,
-                                                                "type": "integer",
-                                                                "description": "Seed for the random number generator. If 0, a random seed is used."
-                                                            },
                                                             "operation": {
                                                                 "default value": "add",
                                                                 "type": "string",
@@ -17583,9 +17884,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "operation": {
@@ -17640,9 +17951,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "lithology": {
@@ -17707,9 +18028,19 @@
                                                                 "uniqueItems": false,
                                                                 "description": "A list with the labels of the composition which are present there.",
                                                                 "items": {
-                                                                    "default value": 0,
-                                                                    "type": "integer",
-                                                                    "description": ""
+                                                                    "description": "",
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "default value": 0,
+                                                                            "type": "integer",
+                                                                            "description": ""
+                                                                        },
+                                                                        {
+                                                                            "default value": "",
+                                                                            "type": "string",
+                                                                            "description": ""
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             "fractions": {

--- a/doc/world_builder_declarations.schema.json
+++ b/doc/world_builder_declarations.schema.json
@@ -1919,9 +1919,19 @@
                                                     "uniqueItems": false,
                                                     "description": "A list with the labels of the composition which are present there.",
                                                     "items": {
-                                                        "default value": 0,
-                                                        "type": "integer",
-                                                        "description": ""
+                                                        "description": "",
+                                                        "oneOf": [
+                                                            {
+                                                                "default value": 0,
+                                                                "type": "integer",
+                                                                "description": ""
+                                                            },
+                                                            {
+                                                                "default value": "",
+                                                                "type": "string",
+                                                                "description": ""
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "fractions": {
@@ -1929,7 +1939,7 @@
                                                     "minItems": 1,
                                                     "maxItems": 4294967295,
                                                     "uniqueItems": false,
-                                                    "description": "TA list of compositional fractions corresponding to the compositions list.",
+                                                    "description": "A list of compositional fractions corresponding to the compositions list.",
                                                     "items": {
                                                         "default value": 1.0,
                                                         "type": "number",

--- a/doc/world_builder_declarations_closed.md
+++ b/doc/world_builder_declarations_closed.md
@@ -1198,10 +1198,10 @@
 ::::::::::::::::{dropdown} /features/items/oneOf/1/temperature models/items/oneOf/4/operation
 :name: closed_features_items_oneOf_1_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/1/temperature models/items/oneOf/4/min depth
@@ -1418,14 +1418,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/1/temperature models/items/oneOf/4/seed
-:name: closed_features_items_oneOf_1_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -2383,14 +2375,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_1_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_1_composition-models_items_oneOf_1_operation
 
@@ -2870,9 +2854,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_1_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_1_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_1_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_1_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -2884,7 +2886,7 @@
 - **minItems**:1
 - **maxItems**:4294967295
 - **uniqueItems**:false
-- **description**:TA list of compositional fractions corresponding to the compositions list.
+- **description**:A list of compositional fractions corresponding to the compositions list.
 :::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/3/fractions/items
 :name: closed_features_items_oneOf_1_composition-models_items_oneOf_3_fractions_items
 
@@ -4885,10 +4887,10 @@
 ::::::::::::::{dropdown} /features/items/oneOf/2/segments/items/temperature models/items/oneOf/3/operation
 :name: closed_features_items_oneOf_2_segments_items_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether to replace, add, or subtract values.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/2/segments/items/temperature models/items/oneOf/3/min distance fault center
@@ -4953,14 +4955,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::
-
-::::::::::::::{dropdown} /features/items/oneOf/2/segments/items/temperature models/items/oneOf/3/seed
-:name: closed_features_items_oneOf_2_segments_items_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::
 
 
@@ -5157,14 +5151,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::
 
-::::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::
-
 ::::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_1_operation
 
@@ -5258,9 +5244,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -5322,9 +5326,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_2_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -6146,10 +6168,10 @@
 ::::::::::::::::{dropdown} /features/items/oneOf/2/temperature models/items/oneOf/3/operation
 :name: closed_features_items_oneOf_2_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether to replace, add, or subtract values.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/2/temperature models/items/oneOf/3/min distance fault center
@@ -6214,14 +6236,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/2/temperature models/items/oneOf/3/seed
-:name: closed_features_items_oneOf_2_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -6418,14 +6432,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_2_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_2_composition-models_items_oneOf_1_operation
 
@@ -6519,9 +6525,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_2_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_2_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_2_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_2_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -6583,9 +6607,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_2_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_2_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_2_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_2_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -7511,10 +7553,10 @@
 ::::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/temperature models/items/oneOf/3/operation
 :name: closed_features_items_oneOf_2_sections_items_segments_items_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether to replace, add, or subtract values.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::
 
 ::::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/temperature models/items/oneOf/3/min distance fault center
@@ -7579,14 +7621,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::
-
-::::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/temperature models/items/oneOf/3/seed
-:name: closed_features_items_oneOf_2_sections_items_segments_items_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::
 
 
@@ -7783,14 +7817,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::
 
-::::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::
-
 ::::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_1_operation
 
@@ -7884,9 +7910,27 @@
 :::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -7948,9 +7992,27 @@
 :::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -8772,10 +8834,10 @@
 ::::::::::::::{dropdown} /features/items/oneOf/2/sections/items/temperature models/items/oneOf/3/operation
 :name: closed_features_items_oneOf_2_sections_items_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether to replace, add, or subtract values.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/2/sections/items/temperature models/items/oneOf/3/min distance fault center
@@ -8840,14 +8902,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::
-
-::::::::::::::{dropdown} /features/items/oneOf/2/sections/items/temperature models/items/oneOf/3/seed
-:name: closed_features_items_oneOf_2_sections_items_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::
 
 
@@ -9044,14 +9098,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::
 
-::::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::
-
 ::::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_1_operation
 
@@ -9145,9 +9191,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -9209,9 +9273,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_2_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -10535,10 +10617,10 @@
 ::::::::::::::::{dropdown} /features/items/oneOf/3/temperature models/items/oneOf/3/operation
 :name: closed_features_items_oneOf_3_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/3/temperature models/items/oneOf/3/min depth
@@ -10739,14 +10821,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/3/temperature models/items/oneOf/3/seed
-:name: closed_features_items_oneOf_3_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -11215,14 +11289,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_3_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_3_composition-models_items_oneOf_1_operation
 
@@ -11416,9 +11482,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_3_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_3_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_3_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_3_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -14005,10 +14089,10 @@
 ::::::::::::::::{dropdown} /features/items/oneOf/4/temperature models/items/oneOf/4/operation
 :name: closed_features_items_oneOf_4_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/4/temperature models/items/oneOf/4/min depth
@@ -14225,14 +14309,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/4/temperature models/items/oneOf/4/seed
-:name: closed_features_items_oneOf_4_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -15280,14 +15356,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_4_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_4_composition-models_items_oneOf_1_operation
 
@@ -15497,9 +15565,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_4_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_4_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_4_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_4_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -15745,9 +15831,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_4_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_4_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_4_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_4_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -18162,10 +18266,10 @@
 ::::::::::::::::{dropdown} /features/items/oneOf/5/temperature models/items/oneOf/2/operation
 :name: closed_features_items_oneOf_5_temperature-models_items_oneOf_2_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/temperature models/items/oneOf/2/min depth
@@ -18230,14 +18334,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/5/temperature models/items/oneOf/2/seed
-:name: closed_features_items_oneOf_5_temperature-models_items_oneOf_2_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -18434,14 +18530,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_5_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_5_composition-models_items_oneOf_1_operation
 
@@ -18499,9 +18587,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_5_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_5_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_5_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_5_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -18568,23 +18674,159 @@
 - **default value**:
 - **type**:string
 - **description**:The name of the grains model.
-- **enum**:[random uniform distribution deflected]
+- **enum**:[random uniform distribution]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth
 :name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth
 
+- **description**:The depth in meters from which the composition of this feature is present.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf
+
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/1
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_1
+
 - **default value**:0.0
 - **type**:number
-- **description**:The depth in meters from which the grains of this feature are present.
+- **description**:
+::::::::::::::
+
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:
+:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items
+
+- **type**:array
+- **additionalProperties**:false
+- **minItems**:1
+- **maxItems**:2
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items
+
+:::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf
+
+::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf/1
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf_1
+
+- **type**:number
+- **default value**:0.0
+::::::::::
+
+::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf/2
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf_2
+
+- **type**:array
+- **minItems**:1
+- **maxItems**:4294967295
+:::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf/2/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf_2_items
+
+- **type**:array
+- **minItems**:1
+- **maxItems**:2
+::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf/2/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf_2_items_items
+
+- **type**:number
+::::::::
+
+:::::::::
+
+::::::::::
+
+
+::::::::::::
+
+:::::::::::::
+
+::::::::::::::
+
+
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth
 :name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth
 
+- **description**:The depth in meters to which the composition of this feature is present.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf
+
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/1
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_1
+
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The depth in meters to which the grains of this feature are present.
+- **description**:
+::::::::::::::
+
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:
+:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items
+
+- **type**:array
+- **additionalProperties**:false
+- **minItems**:1
+- **maxItems**:2
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items
+
+:::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf
+
+::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf/1
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf_1
+
+- **type**:number
+- **default value**:1.7976931348623157e308
+::::::::::
+
+::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf/2
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf_2
+
+- **type**:array
+- **minItems**:1
+- **maxItems**:4294967295
+:::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf/2/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf_2_items
+
+- **type**:array
+- **minItems**:1
+- **maxItems**:2
+::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf/2/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf_2_items_items
+
+- **type**:number
+::::::::
+
+:::::::::
+
+::::::::::
+
+
+::::::::::::
+
+:::::::::::::
+
+::::::::::::::
+
+
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/compositions
@@ -18611,7 +18853,7 @@
 - **default value**:replace
 - **type**:string
 - **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
-- **enum**:[replace, multiply]
+- **enum**:[replace]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/grain sizes
@@ -18650,90 +18892,6 @@
 
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/deflections
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_deflections
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list of the deflections of all of the grains in each composition between 0 and 1.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/deflections/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_deflections_items
-
-- **default value**:1.0
-- **type**:number
-- **description**:
-:::::::::::::::
-
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis rotation matrices
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_basis-rotation-matrices
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list with the rotation matrices of the grains which are present there for each compositions.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis rotation matrices/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_basis-rotation-matrices_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis rotation matrices/items/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_basis-rotation-matrices_items_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis rotation matrices/items/items/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_basis-rotation-matrices_items_items_items
-
-- **default value**:0.0
-- **type**:number
-- **description**:
-:::::::::::::
-
-::::::::::::::
-
-:::::::::::::::
-
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis Euler angles z-x-z
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_basis-Euler-angles-z-x-z
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list with the z-x-z Euler angles of the grains which are present there for each compositions.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis Euler angles z-x-z/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_basis-Euler-angles-z-x-z_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis Euler angles z-x-z/items/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_1_basis-Euler-angles-z-x-z_items_items
-
-- **default value**:0.0
-- **type**:number
-- **description**:
-::::::::::::::
-
-:::::::::::::::
-
-::::::::::::::::
-
 
 
 :::::::::::::::::
@@ -18742,7 +18900,7 @@
 :name: closed_features_items_oneOf_5_grains-models_items_oneOf_2
 
 - **type**:object
-- **description**:Uniform grains model. All grains start exactly the same.
+- **description**:Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
 - **additionalProperties**:false
 - **required**:[model, compositions]
 
@@ -18752,7 +18910,7 @@
 - **default value**:
 - **type**:string
 - **description**:The name of the grains model.
-- **enum**:[uniform]
+- **enum**:[random uniform distribution deflected]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/min depth
@@ -18789,72 +18947,6 @@
 
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/rotation matrices
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_rotation-matrices
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list with the rotation matrices of the grains which are present there for each compositions.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/rotation matrices/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_rotation-matrices_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/rotation matrices/items/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_rotation-matrices_items_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/rotation matrices/items/items/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_rotation-matrices_items_items_items
-
-- **default value**:0.0
-- **type**:number
-- **description**:
-:::::::::::::
-
-::::::::::::::
-
-:::::::::::::::
-
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/Euler angles z-x-z
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_Euler-angles-z-x-z
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list with the z-x-z Euler angles of the grains which are present there for each compositions.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/Euler angles z-x-z/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_Euler-angles-z-x-z_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/Euler angles z-x-z/items/items
-:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_Euler-angles-z-x-z_items_items
-
-- **default value**:0.0
-- **type**:number
-- **description**:
-::::::::::::::
-
-:::::::::::::::
-
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/orientation operation
 :name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_orientation-operation
 
@@ -18871,9 +18963,259 @@
 - **minItems**:0
 - **maxItems**:4294967295
 - **uniqueItems**:false
-- **description**:A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+- **description**:A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
 :::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/grain sizes/items
 :name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_grain-sizes_items
+
+- **default value**:1.0
+- **type**:number
+- **description**:
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/normalize grain sizes
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_normalize-grain-sizes
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/normalize grain sizes/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_normalize-grain-sizes_items
+
+- **default value**:true
+- **type**:boolean
+- **description**:
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/deflections
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_deflections
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list of the deflections of all of the grains in each composition between 0 and 1.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/deflections/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_deflections_items
+
+- **default value**:1.0
+- **type**:number
+- **description**:
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis rotation matrices
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_basis-rotation-matrices
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the rotation matrices of the grains which are present there for each compositions.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis rotation matrices/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_basis-rotation-matrices_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis rotation matrices/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_basis-rotation-matrices_items_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis rotation matrices/items/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_basis-rotation-matrices_items_items_items
+
+- **default value**:0.0
+- **type**:number
+- **description**:
+:::::::::::::
+
+::::::::::::::
+
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis Euler angles z-x-z
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_basis-Euler-angles-z-x-z
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis Euler angles z-x-z/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_basis-Euler-angles-z-x-z_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis Euler angles z-x-z/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_2_basis-Euler-angles-z-x-z_items_items
+
+- **default value**:0.0
+- **type**:number
+- **description**:
+::::::::::::::
+
+:::::::::::::::
+
+::::::::::::::::
+
+
+
+:::::::::::::::::
+
+:::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3
+
+- **type**:object
+- **description**:Uniform grains model. All grains start exactly the same.
+- **additionalProperties**:false
+- **required**:[model, compositions]
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/model
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_model
+
+- **default value**:
+- **type**:string
+- **description**:The name of the grains model.
+- **enum**:[uniform]
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/min depth
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_min-depth
+
+- **default value**:0.0
+- **type**:number
+- **description**:The depth in meters from which the grains of this feature are present.
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/max depth
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_max-depth
+
+- **default value**:1.7976931348623157e308
+- **type**:number
+- **description**:The depth in meters to which the grains of this feature are present.
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/compositions
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_compositions
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the integer labels of the composition which are present there.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/compositions/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_compositions_items
+
+- **default value**:0
+- **type**:integer
+- **description**:
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/rotation matrices
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_rotation-matrices
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the rotation matrices of the grains which are present there for each compositions.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/rotation matrices/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_rotation-matrices_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/rotation matrices/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_rotation-matrices_items_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/rotation matrices/items/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_rotation-matrices_items_items_items
+
+- **default value**:0.0
+- **type**:number
+- **description**:
+:::::::::::::
+
+::::::::::::::
+
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/Euler angles z-x-z
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_Euler-angles-z-x-z
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/Euler angles z-x-z/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_Euler-angles-z-x-z_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/Euler angles z-x-z/items/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_Euler-angles-z-x-z_items_items
+
+- **default value**:0.0
+- **type**:number
+- **description**:
+::::::::::::::
+
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/orientation operation
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_orientation-operation
+
+- **default value**:replace
+- **type**:string
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+- **enum**:[replace, multiply]
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/grain sizes
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_grain-sizes
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/grain sizes/items
+:name: closed_features_items_oneOf_5_grains-models_items_oneOf_3_grain-sizes_items
 
 - **default value**:-1.0
 - **type**:number
@@ -19366,7 +19708,7 @@
 :name: closed_features_items_oneOf_6_segments_items_temperature-models_items_oneOf_3
 
 - **type**:object
-- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
 - **additionalProperties**:false
 - **required**:[model, spreading velocity, subducting velocity]
 
@@ -19401,7 +19743,7 @@
 
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km.
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/temperature models/items/oneOf/3/density
@@ -19689,10 +20031,10 @@
 ::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/temperature models/items/oneOf/4/operation
 :name: closed_features_items_oneOf_6_segments_items_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/temperature models/items/oneOf/4/min distance slab top
@@ -19757,14 +20099,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::
-
-::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/temperature models/items/oneOf/4/seed
-:name: closed_features_items_oneOf_6_segments_items_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::
 
 
@@ -20063,14 +20397,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::
 
-::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::
-
 ::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_1_operation
 
@@ -20164,9 +20490,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -20236,9 +20580,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -20324,9 +20686,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/4/compositions/items
 :name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_4_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/4/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/4/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/4/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -21132,7 +21512,7 @@
 :name: closed_features_items_oneOf_6_temperature-models_items_oneOf_3
 
 - **type**:object
-- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
 - **additionalProperties**:false
 - **required**:[model, spreading velocity, subducting velocity]
 
@@ -21167,7 +21547,7 @@
 
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km.
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/6/temperature models/items/oneOf/3/density
@@ -21455,10 +21835,10 @@
 ::::::::::::::::{dropdown} /features/items/oneOf/6/temperature models/items/oneOf/4/operation
 :name: closed_features_items_oneOf_6_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/6/temperature models/items/oneOf/4/min distance slab top
@@ -21523,14 +21903,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/6/temperature models/items/oneOf/4/seed
-:name: closed_features_items_oneOf_6_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -21829,14 +22201,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_6_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_6_composition-models_items_oneOf_1_operation
 
@@ -21930,9 +22294,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_6_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -22002,9 +22384,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_6_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -22090,9 +22490,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/4/compositions/items
 :name: closed_features_items_oneOf_6_composition-models_items_oneOf_4_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/4/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_composition-models_items_oneOf_4_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/4/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_composition-models_items_oneOf_4_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/4/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_composition-models_items_oneOf_4_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -23002,7 +23420,7 @@
 :name: closed_features_items_oneOf_6_sections_items_segments_items_temperature-models_items_oneOf_3
 
 - **type**:object
-- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
 - **additionalProperties**:false
 - **required**:[model, spreading velocity, subducting velocity]
 
@@ -23037,7 +23455,7 @@
 
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km.
 ::::::::::::
 
 ::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/temperature models/items/oneOf/3/density
@@ -23325,10 +23743,10 @@
 ::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/temperature models/items/oneOf/4/operation
 :name: closed_features_items_oneOf_6_sections_items_segments_items_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::
 
 ::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/temperature models/items/oneOf/4/min distance slab top
@@ -23393,14 +23811,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::
-
-::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/temperature models/items/oneOf/4/seed
-:name: closed_features_items_oneOf_6_sections_items_segments_items_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::
 
 
@@ -23699,14 +24109,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::
 
-::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::
-
 ::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_1_operation
 
@@ -23800,9 +24202,27 @@
 :::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -23872,9 +24292,27 @@
 :::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -23960,9 +24398,27 @@
 :::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/4/compositions/items
 :name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_4_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/4/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/4/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/4/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -24768,7 +25224,7 @@
 :name: closed_features_items_oneOf_6_sections_items_temperature-models_items_oneOf_3
 
 - **type**:object
-- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
 - **additionalProperties**:false
 - **required**:[model, spreading velocity, subducting velocity]
 
@@ -24803,7 +25259,7 @@
 
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km.
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/temperature models/items/oneOf/3/density
@@ -25091,10 +25547,10 @@
 ::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/temperature models/items/oneOf/4/operation
 :name: closed_features_items_oneOf_6_sections_items_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/temperature models/items/oneOf/4/min distance slab top
@@ -25159,14 +25615,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::
-
-::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/temperature models/items/oneOf/4/seed
-:name: closed_features_items_oneOf_6_sections_items_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::
 
 
@@ -25465,14 +25913,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::
 
-::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/1/seed
-:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::
-
 ::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/1/operation
 :name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_1_operation
 
@@ -25566,9 +26006,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -25638,9 +26096,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/3/compositions/items
 :name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/3/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -25726,9 +26202,27 @@
 :::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/4/compositions/items
 :name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_4_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/4/compositions/items/oneOf
+:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_4_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/4/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_4_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/4/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_6_sections_items_composition-models_items_oneOf_4_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::

--- a/doc/world_builder_declarations_closed.md
+++ b/doc/world_builder_declarations_closed.md
@@ -2600,9 +2600,27 @@
 :::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/2/compositions/items
 :name: closed_features_items_oneOf_1_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/2/compositions/items/oneOf
+:name: closed_features_items_oneOf_1_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/2/compositions/items/oneOf/1
+:name: closed_features_items_oneOf_1_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/2/compositions/items/oneOf/2
+:name: closed_features_items_oneOf_1_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::

--- a/doc/world_builder_declarations_open.md
+++ b/doc/world_builder_declarations_open.md
@@ -1358,10 +1358,10 @@
 :open:
 :name: open_features_items_oneOf_1_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/1/temperature models/items/oneOf/4/min depth
@@ -1608,15 +1608,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/1/temperature models/items/oneOf/4/seed
-:open:
-:name: open_features_items_oneOf_1_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -2703,15 +2694,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_1_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_1_composition-models_items_oneOf_1_operation
@@ -3256,9 +3238,30 @@
 :open:
 :name: open_features_items_oneOf_1_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_1_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_1_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_1_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -3271,7 +3274,7 @@
 - **minItems**:1
 - **maxItems**:4294967295
 - **uniqueItems**:false
-- **description**:TA list of compositional fractions corresponding to the compositions list.
+- **description**:A list of compositional fractions corresponding to the compositions list.
 :::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/3/fractions/items
 :open:
 :name: open_features_items_oneOf_1_composition-models_items_oneOf_3_fractions_items
@@ -5534,10 +5537,10 @@
 :open:
 :name: open_features_items_oneOf_2_segments_items_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether to replace, add, or subtract values.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/2/segments/items/temperature models/items/oneOf/3/min distance fault center
@@ -5610,15 +5613,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::
-
-::::::::::::::{dropdown} /features/items/oneOf/2/segments/items/temperature models/items/oneOf/3/seed
-:open:
-:name: open_features_items_oneOf_2_segments_items_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::
 
 
@@ -5838,15 +5832,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::
 
-::::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::
-
 ::::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_1_operation
@@ -5951,9 +5936,30 @@
 :open:
 :name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -6022,9 +6028,30 @@
 :open:
 :name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/2/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_2_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -6940,10 +6967,10 @@
 :open:
 :name: open_features_items_oneOf_2_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether to replace, add, or subtract values.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/2/temperature models/items/oneOf/3/min distance fault center
@@ -7016,15 +7043,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/2/temperature models/items/oneOf/3/seed
-:open:
-:name: open_features_items_oneOf_2_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -7244,15 +7262,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_2_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_2_composition-models_items_oneOf_1_operation
@@ -7357,9 +7366,30 @@
 :open:
 :name: open_features_items_oneOf_2_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_2_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_2_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_2_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -7428,9 +7458,30 @@
 :open:
 :name: open_features_items_oneOf_2_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_2_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_2_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/2/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_2_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -8465,10 +8516,10 @@
 :open:
 :name: open_features_items_oneOf_2_sections_items_segments_items_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether to replace, add, or subtract values.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::
 
 ::::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/temperature models/items/oneOf/3/min distance fault center
@@ -8541,15 +8592,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::
-
-::::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/temperature models/items/oneOf/3/seed
-:open:
-:name: open_features_items_oneOf_2_sections_items_segments_items_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::
 
 
@@ -8769,15 +8811,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::
 
-::::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::
-
 ::::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_1_operation
@@ -8882,9 +8915,30 @@
 :open:
 :name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -8953,9 +9007,30 @@
 :open:
 :name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/2/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_2_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -9871,10 +9946,10 @@
 :open:
 :name: open_features_items_oneOf_2_sections_items_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether to replace, add, or subtract values.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/2/sections/items/temperature models/items/oneOf/3/min distance fault center
@@ -9947,15 +10022,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::
-
-::::::::::::::{dropdown} /features/items/oneOf/2/sections/items/temperature models/items/oneOf/3/seed
-:open:
-:name: open_features_items_oneOf_2_sections_items_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::
 
 
@@ -10175,15 +10241,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::
 
-::::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::
-
 ::::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_1_operation
@@ -10288,9 +10345,30 @@
 :open:
 :name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -10359,9 +10437,30 @@
 :open:
 :name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/2/sections/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_2_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -11850,10 +11949,10 @@
 :open:
 :name: open_features_items_oneOf_3_temperature-models_items_oneOf_3_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/3/temperature models/items/oneOf/3/min depth
@@ -12082,15 +12181,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/3/temperature models/items/oneOf/3/seed
-:open:
-:name: open_features_items_oneOf_3_temperature-models_items_oneOf_3_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -12622,15 +12712,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_3_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_3_composition-models_items_oneOf_1_operation
@@ -12851,9 +12932,30 @@
 :open:
 :name: open_features_items_oneOf_3_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_3_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_3_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/3/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_3_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -15784,10 +15886,10 @@
 :open:
 :name: open_features_items_oneOf_4_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/4/temperature models/items/oneOf/4/min depth
@@ -16034,15 +16136,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/4/temperature models/items/oneOf/4/seed
-:open:
-:name: open_features_items_oneOf_4_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -17231,15 +17324,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_4_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_4_composition-models_items_oneOf_1_operation
@@ -17478,9 +17562,30 @@
 :open:
 :name: open_features_items_oneOf_4_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_4_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_4_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_4_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -17759,9 +17864,30 @@
 :open:
 :name: open_features_items_oneOf_4_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_4_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_4_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/4/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_4_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -20492,10 +20618,10 @@
 :open:
 :name: open_features_items_oneOf_5_temperature-models_items_oneOf_2_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/temperature models/items/oneOf/2/min depth
@@ -20568,15 +20694,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/5/temperature models/items/oneOf/2/seed
-:open:
-:name: open_features_items_oneOf_5_temperature-models_items_oneOf_2_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -20796,15 +20913,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_5_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_5_composition-models_items_oneOf_1_operation
@@ -20869,9 +20977,30 @@
 :open:
 :name: open_features_items_oneOf_5_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_5_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_5_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/5/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_5_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -20946,25 +21075,181 @@
 - **default value**:
 - **type**:string
 - **description**:The name of the grains model.
-- **enum**:[random uniform distribution deflected]
+- **enum**:[random uniform distribution]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth
 :open:
 :name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth
 
+- **description**:The depth in meters from which the composition of this feature is present.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf
+
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/1
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_1
+
 - **default value**:0.0
 - **type**:number
-- **description**:The depth in meters from which the grains of this feature are present.
+- **description**:
+::::::::::::::
+
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:
+:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items
+
+- **type**:array
+- **additionalProperties**:false
+- **minItems**:1
+- **maxItems**:2
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items
+
+:::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf
+
+::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf/1
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf_1
+
+- **type**:number
+- **default value**:0.0
+::::::::::
+
+::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf/2
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf_2
+
+- **type**:array
+- **minItems**:1
+- **maxItems**:4294967295
+:::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf/2/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf_2_items
+
+- **type**:array
+- **minItems**:1
+- **maxItems**:2
+::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/min depth/oneOf/2/items/items/anyOf/2/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_min-depth_oneOf_2_items_items_anyOf_2_items_items
+
+- **type**:number
+::::::::
+
+:::::::::
+
+::::::::::
+
+
+::::::::::::
+
+:::::::::::::
+
+::::::::::::::
+
+
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth
 :open:
 :name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth
 
+- **description**:The depth in meters to which the composition of this feature is present.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf
+
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/1
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_1
+
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The depth in meters to which the grains of this feature are present.
+- **description**:
+::::::::::::::
+
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:
+:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items
+
+- **type**:array
+- **additionalProperties**:false
+- **minItems**:1
+- **maxItems**:2
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items
+
+:::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf
+
+::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf/1
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf_1
+
+- **type**:number
+- **default value**:1.7976931348623157e308
+::::::::::
+
+::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf/2
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf_2
+
+- **type**:array
+- **minItems**:1
+- **maxItems**:4294967295
+:::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf/2/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf_2_items
+
+- **type**:array
+- **minItems**:1
+- **maxItems**:2
+::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/max depth/oneOf/2/items/items/anyOf/2/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_max-depth_oneOf_2_items_items_anyOf_2_items_items
+
+- **type**:number
+::::::::
+
+:::::::::
+
+::::::::::
+
+
+::::::::::::
+
+:::::::::::::
+
+::::::::::::::
+
+
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/compositions
@@ -20994,7 +21279,7 @@
 - **default value**:replace
 - **type**:string
 - **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
-- **enum**:[replace, multiply]
+- **enum**:[replace]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/grain sizes
@@ -21037,99 +21322,6 @@
 
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/deflections
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_deflections
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list of the deflections of all of the grains in each composition between 0 and 1.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/deflections/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_deflections_items
-
-- **default value**:1.0
-- **type**:number
-- **description**:
-:::::::::::::::
-
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis rotation matrices
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_basis-rotation-matrices
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list with the rotation matrices of the grains which are present there for each compositions.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis rotation matrices/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_basis-rotation-matrices_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis rotation matrices/items/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_basis-rotation-matrices_items_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis rotation matrices/items/items/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_basis-rotation-matrices_items_items_items
-
-- **default value**:0.0
-- **type**:number
-- **description**:
-:::::::::::::
-
-::::::::::::::
-
-:::::::::::::::
-
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis Euler angles z-x-z
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_basis-Euler-angles-z-x-z
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list with the z-x-z Euler angles of the grains which are present there for each compositions.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis Euler angles z-x-z/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_basis-Euler-angles-z-x-z_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/1/basis Euler angles z-x-z/items/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_1_basis-Euler-angles-z-x-z_items_items
-
-- **default value**:0.0
-- **type**:number
-- **description**:
-::::::::::::::
-
-:::::::::::::::
-
-::::::::::::::::
-
 
 
 :::::::::::::::::
@@ -21139,7 +21331,7 @@
 :name: open_features_items_oneOf_5_grains-models_items_oneOf_2
 
 - **type**:object
-- **description**:Uniform grains model. All grains start exactly the same.
+- **description**:Random uniform distribution grains model. The size of the grains can be independently set to a single value or to a random distribution.
 - **additionalProperties**:false
 - **required**:[model, compositions]
 
@@ -21150,7 +21342,7 @@
 - **default value**:
 - **type**:string
 - **description**:The name of the grains model.
-- **enum**:[uniform]
+- **enum**:[random uniform distribution deflected]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/min depth
@@ -21191,79 +21383,6 @@
 
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/rotation matrices
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_rotation-matrices
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list with the rotation matrices of the grains which are present there for each compositions.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/rotation matrices/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_rotation-matrices_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/rotation matrices/items/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_rotation-matrices_items_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/rotation matrices/items/items/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_rotation-matrices_items_items_items
-
-- **default value**:0.0
-- **type**:number
-- **description**:
-:::::::::::::
-
-::::::::::::::
-
-:::::::::::::::
-
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/Euler angles z-x-z
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_Euler-angles-z-x-z
-
-- **type**:array
-- **minItems**:0
-- **maxItems**:4294967295
-- **uniqueItems**:false
-- **description**:A list with the z-x-z Euler angles of the grains which are present there for each compositions.
-:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/Euler angles z-x-z/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_Euler-angles-z-x-z_items
-
-- **type**:array
-- **minItems**:3
-- **maxItems**:3
-- **uniqueItems**:false
-- **description**:
-::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/Euler angles z-x-z/items/items
-:open:
-:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_Euler-angles-z-x-z_items_items
-
-- **default value**:0.0
-- **type**:number
-- **description**:
-::::::::::::::
-
-:::::::::::::::
-
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/orientation operation
 :open:
 :name: open_features_items_oneOf_5_grains-models_items_oneOf_2_orientation-operation
@@ -21282,10 +21401,287 @@
 - **minItems**:0
 - **maxItems**:4294967295
 - **uniqueItems**:false
-- **description**:A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+- **description**:A list of the size of all of the grains in each composition. If set to <0, the size will be randomized between 0 and 1.
 :::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/grain sizes/items
 :open:
 :name: open_features_items_oneOf_5_grains-models_items_oneOf_2_grain-sizes_items
+
+- **default value**:1.0
+- **type**:number
+- **description**:
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/normalize grain sizes
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_normalize-grain-sizes
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list of whether the sizes of the grains should be normalized or not. If normalized, the total of the grains of a composition will be equal to 1.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/normalize grain sizes/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_normalize-grain-sizes_items
+
+- **default value**:true
+- **type**:boolean
+- **description**:
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/deflections
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_deflections
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list of the deflections of all of the grains in each composition between 0 and 1.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/deflections/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_deflections_items
+
+- **default value**:1.0
+- **type**:number
+- **description**:
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis rotation matrices
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_basis-rotation-matrices
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the rotation matrices of the grains which are present there for each compositions.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis rotation matrices/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_basis-rotation-matrices_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis rotation matrices/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_basis-rotation-matrices_items_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis rotation matrices/items/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_basis-rotation-matrices_items_items_items
+
+- **default value**:0.0
+- **type**:number
+- **description**:
+:::::::::::::
+
+::::::::::::::
+
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis Euler angles z-x-z
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_basis-Euler-angles-z-x-z
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis Euler angles z-x-z/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_basis-Euler-angles-z-x-z_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/2/basis Euler angles z-x-z/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_2_basis-Euler-angles-z-x-z_items_items
+
+- **default value**:0.0
+- **type**:number
+- **description**:
+::::::::::::::
+
+:::::::::::::::
+
+::::::::::::::::
+
+
+
+:::::::::::::::::
+
+:::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3
+
+- **type**:object
+- **description**:Uniform grains model. All grains start exactly the same.
+- **additionalProperties**:false
+- **required**:[model, compositions]
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/model
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_model
+
+- **default value**:
+- **type**:string
+- **description**:The name of the grains model.
+- **enum**:[uniform]
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/min depth
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_min-depth
+
+- **default value**:0.0
+- **type**:number
+- **description**:The depth in meters from which the grains of this feature are present.
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/max depth
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_max-depth
+
+- **default value**:1.7976931348623157e308
+- **type**:number
+- **description**:The depth in meters to which the grains of this feature are present.
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/compositions
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_compositions
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the integer labels of the composition which are present there.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/compositions/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_compositions_items
+
+- **default value**:0
+- **type**:integer
+- **description**:
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/rotation matrices
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_rotation-matrices
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the rotation matrices of the grains which are present there for each compositions.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/rotation matrices/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_rotation-matrices_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/rotation matrices/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_rotation-matrices_items_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+:::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/rotation matrices/items/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_rotation-matrices_items_items_items
+
+- **default value**:0.0
+- **type**:number
+- **description**:
+:::::::::::::
+
+::::::::::::::
+
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/Euler angles z-x-z
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_Euler-angles-z-x-z
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list with the z-x-z Euler angles of the grains which are present there for each compositions.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/Euler angles z-x-z/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_Euler-angles-z-x-z_items
+
+- **type**:array
+- **minItems**:3
+- **maxItems**:3
+- **uniqueItems**:false
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/Euler angles z-x-z/items/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_Euler-angles-z-x-z_items_items
+
+- **default value**:0.0
+- **type**:number
+- **description**:
+::::::::::::::
+
+:::::::::::::::
+
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/orientation operation
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_orientation-operation
+
+- **default value**:replace
+- **type**:string
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value (add, not implemented). Replacing implies that all values not explicitly defined are set to zero.
+- **enum**:[replace, multiply]
+::::::::::::::::
+
+::::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/grain sizes
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_grain-sizes
+
+- **type**:array
+- **minItems**:0
+- **maxItems**:4294967295
+- **uniqueItems**:false
+- **description**:A list of the size of all of the grains in each composition. If set to <0, the size will be set so that the total is equal to 1.
+:::::::::::::::{dropdown} /features/items/oneOf/5/grains models/items/oneOf/3/grain sizes/items
+:open:
+:name: open_features_items_oneOf_5_grains-models_items_oneOf_3_grain-sizes_items
 
 - **default value**:-1.0
 - **type**:number
@@ -21838,7 +22234,7 @@
 :name: open_features_items_oneOf_6_segments_items_temperature-models_items_oneOf_3
 
 - **type**:object
-- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
 - **additionalProperties**:false
 - **required**:[model, spreading velocity, subducting velocity]
 
@@ -21877,7 +22273,7 @@
 
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km.
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/temperature models/items/oneOf/3/density
@@ -22202,10 +22598,10 @@
 :open:
 :name: open_features_items_oneOf_6_segments_items_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/temperature models/items/oneOf/4/min distance slab top
@@ -22278,15 +22674,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::
-
-::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/temperature models/items/oneOf/4/seed
-:open:
-:name: open_features_items_oneOf_6_segments_items_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::
 
 
@@ -22620,15 +23007,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::
 
-::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::
-
 ::::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_1_operation
@@ -22733,9 +23111,30 @@
 :open:
 :name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -22813,9 +23212,30 @@
 :open:
 :name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -22911,9 +23331,30 @@
 :open:
 :name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_4_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/4/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/4/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/segments/items/composition models/items/oneOf/4/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -23811,7 +24252,7 @@
 :name: open_features_items_oneOf_6_temperature-models_items_oneOf_3
 
 - **type**:object
-- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
 - **additionalProperties**:false
 - **required**:[model, spreading velocity, subducting velocity]
 
@@ -23850,7 +24291,7 @@
 
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km.
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/6/temperature models/items/oneOf/3/density
@@ -24175,10 +24616,10 @@
 :open:
 :name: open_features_items_oneOf_6_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::::
 
 ::::::::::::::::{dropdown} /features/items/oneOf/6/temperature models/items/oneOf/4/min distance slab top
@@ -24251,15 +24692,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::::
-
-::::::::::::::::{dropdown} /features/items/oneOf/6/temperature models/items/oneOf/4/seed
-:open:
-:name: open_features_items_oneOf_6_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::::
 
 
@@ -24593,15 +25025,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::::
 
-::::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_6_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::::
-
 ::::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_6_composition-models_items_oneOf_1_operation
@@ -24706,9 +25129,30 @@
 :open:
 :name: open_features_items_oneOf_6_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -24786,9 +25230,30 @@
 :open:
 :name: open_features_items_oneOf_6_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -24884,9 +25349,30 @@
 :open:
 :name: open_features_items_oneOf_6_composition-models_items_oneOf_4_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/4/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_composition-models_items_oneOf_4_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/4/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_composition-models_items_oneOf_4_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/6/composition models/items/oneOf/4/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_composition-models_items_oneOf_4_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::
@@ -25903,7 +26389,7 @@
 :name: open_features_items_oneOf_6_sections_items_segments_items_temperature-models_items_oneOf_3
 
 - **type**:object
-- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
 - **additionalProperties**:false
 - **required**:[model, spreading velocity, subducting velocity]
 
@@ -25942,7 +26428,7 @@
 
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km.
 ::::::::::::
 
 ::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/temperature models/items/oneOf/3/density
@@ -26267,10 +26753,10 @@
 :open:
 :name: open_features_items_oneOf_6_sections_items_segments_items_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::
 
 ::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/temperature models/items/oneOf/4/min distance slab top
@@ -26343,15 +26829,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::
-
-::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/temperature models/items/oneOf/4/seed
-:open:
-:name: open_features_items_oneOf_6_sections_items_segments_items_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::
 
 
@@ -26685,15 +27162,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::
 
-::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::
-
 ::::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_1_operation
@@ -26798,9 +27266,30 @@
 :open:
 :name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -26878,9 +27367,30 @@
 :open:
 :name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -26976,9 +27486,30 @@
 :open:
 :name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_4_compositions_items
 
+- **description**:
+::::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/4/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/4/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::
+
+:::::::::{dropdown} /features/items/oneOf/6/sections/items/segments/items/composition models/items/oneOf/4/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_sections_items_segments_items_composition-models_items_oneOf_4_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::
+
+
 :::::::::::
 
 ::::::::::::
@@ -27876,7 +28407,7 @@
 :name: open_features_items_oneOf_6_sections_items_temperature-models_items_oneOf_3
 
 - **type**:object
-- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to usedepth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
+- **description**:Mass conserving temperature model. The temperature model uses the heat content (proportional to to thermal mass anomaly) to define a smooth temperature profile that conserves mass along the slab length. An empirical model, using error functions for smooth transitions, is used to  define how the minimum temperature increases with depth and how the location of the minimum temperature shifts into the slab interior. The slab is divided into top and bottom parts, which meet at the location where the minimum temperature occurs in the slab. For the bottom slab, the temperature is defined by a half-space cooling model. For the top of the slab the temperature is defined by one side of a 1D infinite space cooling model: this function was chosen to have a smoother temperature function across the minimum temperature position. The age of the overriding plate is used so the slab temperature at shallow depth smoothly transitions to the temperature of the overriding plate: this is not perfect, and is affected by the value of "top truncation" parameter subducting plate. Notes:1) the parameter "thickness" for the subducting plate segments needs to be defined but is not used. 2) because we use a negative truncation for distance above the slab, it is recommended to use depth method:begin at end segment, in the main part of the world-builder file.Other methods may lead to gpas in temperatures at the segment boundaries.3)the empirical model used to define how Tmin increases with depth and how the position of Tmin shift with depth is expected to change somewhat after better calibrating with further tests.
 - **additionalProperties**:false
 - **required**:[model, spreading velocity, subducting velocity]
 
@@ -27915,7 +28446,7 @@
 
 - **default value**:1.7976931348623157e308
 - **type**:number
-- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of coldtemperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, thisparameters should be about 250 km.
+- **description**:The distance in meters from the top surface of the slab over which the temperature is determined by this feature. This parameter should be positive and approximately 2.5-3.0 times larger than the nominal slab thickness to allow the diffusion of cold temperatures from in the slab into the mantle below the slab surface.For example if the slab starts with cold temperatures over a 100 km wide region, this parameters should be about 250 km.
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/temperature models/items/oneOf/3/density
@@ -28240,10 +28771,10 @@
 :open:
 :name: open_features_items_oneOf_6_sections_items_temperature-models_items_oneOf_4_operation
 
-- **default value**:replace
+- **default value**:add
 - **type**:string
-- **description**:Whether the value should replace any value previously defined at this location (replace), add the value to the previously define value (add) or subtract the value to the previously define value (subtract).
-- **enum**:[replace, add, subtract]
+- **description**:Whether the value should replace any value previously defined at this location (replace) or add the value to the previously define value. Replacing implies that all compositions not explicitly defined are set to zero. To only replace the defined compositions use the replace only defined option.
+- **enum**:[replace, add, subtract, replace, replace defined only, add, subtract]
 ::::::::::::::
 
 ::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/temperature models/items/oneOf/4/min distance slab top
@@ -28316,15 +28847,6 @@
 - **default value**:2.0
 - **type**:number
 - **description**:Frequency multiplier between octaves.
-::::::::::::::
-
-::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/temperature models/items/oneOf/4/seed
-:open:
-:name: open_features_items_oneOf_6_sections_items_temperature-models_items_oneOf_4_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
 ::::::::::::::
 
 
@@ -28658,15 +29180,6 @@
 - **description**:Frequency multiplier between octaves.
 ::::::::::::::
 
-::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/1/seed
-:open:
-:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_1_seed
-
-- **default value**:0
-- **type**:integer
-- **description**:Seed for the random number generator. If 0, a random seed is used.
-::::::::::::::
-
 ::::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/1/operation
 :open:
 :name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_1_operation
@@ -28771,9 +29284,30 @@
 :open:
 :name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -28851,9 +29385,30 @@
 :open:
 :name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_3_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/3/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/3/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/3/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_3_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::
@@ -28949,9 +29504,30 @@
 :open:
 :name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_4_compositions_items
 
+- **description**:
+::::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/4/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_4_compositions_items_oneOf
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/4/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_4_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::
+
+:::::::::::{dropdown} /features/items/oneOf/6/sections/items/composition models/items/oneOf/4/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_6_sections_items_composition-models_items_oneOf_4_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::
+
+
 :::::::::::::
 
 ::::::::::::::

--- a/doc/world_builder_declarations_open.md
+++ b/doc/world_builder_declarations_open.md
@@ -2950,9 +2950,30 @@
 :open:
 :name: open_features_items_oneOf_1_composition-models_items_oneOf_2_compositions_items
 
+- **description**:
+::::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/2/compositions/items/oneOf
+:open:
+:name: open_features_items_oneOf_1_composition-models_items_oneOf_2_compositions_items_oneOf
+
+:::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/2/compositions/items/oneOf/1
+:open:
+:name: open_features_items_oneOf_1_composition-models_items_oneOf_2_compositions_items_oneOf_1
+
 - **default value**:0
 - **type**:integer
 - **description**:
+:::::::::::::
+
+:::::::::::::{dropdown} /features/items/oneOf/1/composition models/items/oneOf/2/compositions/items/oneOf/2
+:open:
+:name: open_features_items_oneOf_1_composition-models_items_oneOf_2_compositions_items_oneOf_2
+
+- **default value**:
+- **type**:string
+- **description**:
+:::::::::::::
+
+
 :::::::::::::::
 
 ::::::::::::::::

--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -89,6 +89,13 @@ namespace WorldBuilder
        */
       ~Parameters();
 
+      struct composition_property
+      {
+        unsigned int index;
+        std::string name;
+        double reference_density;
+      };
+
       /**
        * Initializes the parameter file
        * \param filename A string with the path to the world builder file
@@ -110,10 +117,20 @@ namespace WorldBuilder
 
       /**
        * A specialized version of get which can return vectors/arrays.
+        *
+        * Note: The specialization get_vector<unsigned int>() also supports
+        * mixed input of unsigned-int indices and string composition names for
+        * entries that allow it (e.g. composition identifier arrays). String
+        * names are resolved to indices using the global composition properties
+        * table.
        * \param name The name of the entry to retrieved
        */
       template<class T>
       std::vector<T> get_vector(const std::string &name);
+
+      template<class T>
+      std::vector<T> get_vector(const std::string &name,
+                                const std::vector<Parameters::composition_property> &global_composition_properties);
 
       std::vector<std::vector<double>> get_vector_or_double(const std::string &name);
 
@@ -181,20 +198,13 @@ namespace WorldBuilder
       bool
       check_entry(const std::string &name) const;
 
-      struct composition_properties
-      {
-        unsigned int index;
-        std::string name;
-        double reference_density;
-      };
-
       /**
        * Parse composition properties.
        * The index is required, while name and reference density are optional.
        * If the entry is absent, the vector is empty.
        * \param name The name of the entry to be declared
        */
-      std::vector<composition_properties>
+      std::vector<composition_property>
       get_composition_properties(const std::string &name) const;
 
       /**

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -258,7 +258,7 @@ namespace WorldBuilder
       * Return all composition properties from its index.
       * If the index is unknown, returns fallback properties with a generated name.
       */
-      Parameters::composition_properties get_composition_properties(const unsigned int composition_index) const;
+      Parameters::composition_property get_composition_properties(const unsigned int composition_index) const;
 
       /**
        * This is the parameter class, which stores all the values loaded in
@@ -350,7 +350,7 @@ namespace WorldBuilder
       /**
        * A map from composition index to its properties for quick lookups.
        */
-      std::map<unsigned int, Parameters::composition_properties> composition_properties;
+      std::vector<Parameters::composition_property> composition_properties;
 
     private:
       /**

--- a/source/world_builder/features/continental_plate_models/composition/random.cc
+++ b/source/world_builder/features/continental_plate_models/composition/random.cc
@@ -75,7 +75,7 @@ namespace WorldBuilder
                                                       Types::String("")),
                             "The depth in meters to which the composition of this feature is present.");
 
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
 
           prm.declare_entry("min value", Types::Array(Types::Double(0.0),1),
@@ -101,7 +101,7 @@ namespace WorldBuilder
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
 
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
           min_value    = prm.get_vector<double>("min value");
           max_value    = prm.get_vector<double>("max value");
           operation    = string_operations_to_enum(prm.get<std::string>("operation"));

--- a/source/world_builder/features/continental_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/composition/uniform.cc
@@ -72,11 +72,11 @@ namespace WorldBuilder
                                                       Types::String("")),
                             "The depth in meters to which the composition of this feature is present.");
 
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
 
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
-                            "TA list of compositional fractions corresponding to the compositions list.");
+                            "A list of compositional fractions corresponding to the compositions list.");
 
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
                             "Whether the value should replace any value previously defined at this location (replace) or "
@@ -93,7 +93,7 @@ namespace WorldBuilder
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
 
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
           fractions = prm.get_vector<double>("fractions");
           operation = string_operations_to_enum(prm.get<std::string>("operation"));
 

--- a/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution.cc
@@ -102,7 +102,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           operation = prm.get<std::string>("orientation operation");
           grain_sizes = prm.get_vector<double>("grain sizes");

--- a/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/continental_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -109,7 +109,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("basis Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("basis rotation matrices");

--- a/source/world_builder/features/continental_plate_models/grains/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/grains/uniform.cc
@@ -101,7 +101,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("rotation matrices");

--- a/source/world_builder/features/fault_models/composition/smooth.cc
+++ b/source/world_builder/features/fault_models/composition/smooth.cc
@@ -68,7 +68,7 @@ namespace WorldBuilder
                             "The composition fraction at the center of the fault.");
           prm.declare_entry("side fractions",  Types::Array(Types::Double(0.0),1),
                             "The composition fraction at the sides of this feature.");
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
                             "Whether the value should replace any value previously defined at this location (replace) or "
@@ -85,7 +85,7 @@ namespace WorldBuilder
           operation = string_operations_to_enum(prm.get<std::string>("operation"));
           center_fraction = prm.get_vector<double>("center fractions");
           side_fraction = prm.get_vector<double>("side fractions");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
         }
 
 

--- a/source/world_builder/features/fault_models/composition/uniform.cc
+++ b/source/world_builder/features/fault_models/composition/uniform.cc
@@ -65,7 +65,7 @@ namespace WorldBuilder
                             "The distance in meters from which the composition of this feature is present.");
           prm.declare_entry("max distance fault center", Types::Double(std::numeric_limits<double>::max()),
                             "The distance in meters to which the composition of this feature is present.");
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
                             "TA list of compositional fractions corresponding to the compositions list.");
@@ -81,7 +81,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min distance fault center");
           max_depth = prm.get<double>("max distance fault center");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
           fractions = prm.get_vector<double>("fractions");
           operation = string_operations_to_enum(prm.get<std::string>("operation"));
 

--- a/source/world_builder/features/fault_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/fault_models/grains/random_uniform_distribution.cc
@@ -93,7 +93,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min distance fault center");
           max_depth = prm.get<double>("max distance fault center");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           operation = prm.get<std::string>("orientation operation");
           grain_sizes = prm.get_vector<double>("grain sizes");

--- a/source/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/fault_models/grains/random_uniform_distribution_deflected.cc
@@ -101,7 +101,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min distance fault center");
           max_depth = prm.get<double>("max distance fault center");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("basis Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("basis rotation matrices");

--- a/source/world_builder/features/fault_models/grains/uniform.cc
+++ b/source/world_builder/features/fault_models/grains/uniform.cc
@@ -92,7 +92,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min distance fault center");
           max_depth = prm.get<double>("max distance fault center");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("rotation matrices");

--- a/source/world_builder/features/mantle_layer_models/composition/uniform.cc
+++ b/source/world_builder/features/mantle_layer_models/composition/uniform.cc
@@ -66,7 +66,7 @@ namespace WorldBuilder
                             "The depth in meters from which the composition of this feature is present.");
           prm.declare_entry("max depth", Types::OneOf(Types::Double(std::numeric_limits<double>::max()),Types::Array(Types::ValueAtPoints(std::numeric_limits<double>::max(),2))),
                             "The depth in meters to which the composition of this feature is present.");
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
                             "TA list of compositional fractions corresponding to the compositions list.");
@@ -84,7 +84,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
           fractions = prm.get_vector<double>("fractions");
           operation = string_operations_to_enum(prm.get<std::string>("operation"));
 

--- a/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution.cc
@@ -96,7 +96,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           operation = prm.get<std::string>("orientation operation");
           grain_sizes = prm.get_vector<double>("grain sizes");

--- a/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/mantle_layer_models/grains/random_uniform_distribution_deflected.cc
@@ -103,7 +103,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("basis Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("basis rotation matrices");

--- a/source/world_builder/features/mantle_layer_models/grains/uniform.cc
+++ b/source/world_builder/features/mantle_layer_models/grains/uniform.cc
@@ -96,7 +96,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("rotation matrices");

--- a/source/world_builder/features/oceanic_plate_models/composition/tian2019_water_content.cc
+++ b/source/world_builder/features/oceanic_plate_models/composition/tian2019_water_content.cc
@@ -81,7 +81,7 @@ namespace WorldBuilder
                                                       Types::String("")),
                             "The depth in meters to which the composition of this feature is present.");
 
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("density", Types::Double(3000.0),
                             "The reference density used for determining the lithostatic pressure for calculating "
@@ -110,7 +110,7 @@ namespace WorldBuilder
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
           density = prm.get<double>("density");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
           max_water_content = prm.get<double>("initial water content");
           operation = string_operations_to_enum(prm.get<std::string>("operation"));
           cutoff_pressure = prm.get<double>("cutoff pressure");

--- a/source/world_builder/features/oceanic_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/composition/uniform.cc
@@ -70,7 +70,7 @@ namespace WorldBuilder
                                                       Types::String("")),
                             "The depth in meters to which the composition of this feature is present.");
 
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
                             "TA list of compositional fractions corresponding to the compositions list.");
@@ -88,7 +88,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
           fractions = prm.get_vector<double>("fractions");
           operation = string_operations_to_enum(prm.get<std::string>("operation"));
 

--- a/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution.cc
@@ -102,7 +102,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           operation = prm.get<std::string>("orientation operation");
           grain_sizes = prm.get_vector<double>("grain sizes");

--- a/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -109,7 +109,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("basis Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("basis rotation matrices");

--- a/source/world_builder/features/oceanic_plate_models/grains/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/grains/uniform.cc
@@ -102,7 +102,7 @@ namespace WorldBuilder
           min_depth = min_depth_surface.minimum;
           max_depth_surface = Objects::Surface(prm.get("max depth",coordinates));
           max_depth = max_depth_surface.maximum;
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("rotation matrices");

--- a/source/world_builder/features/plume_models/composition/uniform.cc
+++ b/source/world_builder/features/plume_models/composition/uniform.cc
@@ -67,7 +67,7 @@ namespace WorldBuilder
           prm.declare_entry("max depth", Types::Double(std::numeric_limits<double>::max()),
                             "The depth in meters to which the composition of this feature is present.");
 
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
 
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
@@ -86,7 +86,7 @@ namespace WorldBuilder
           min_depth = prm.get<double>("min depth");
           max_depth = prm.get<double>("max depth");
 
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
           fractions = prm.get_vector<double>("fractions");
           operation = string_operations_to_enum(prm.get<std::string>("operation"));
 

--- a/source/world_builder/features/plume_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/plume_models/grains/random_uniform_distribution_deflected.cc
@@ -103,7 +103,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min depth");
           max_depth = prm.get<double>("max depth");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("basis Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("basis rotation matrices");

--- a/source/world_builder/features/plume_models/grains/uniform.cc
+++ b/source/world_builder/features/plume_models/grains/uniform.cc
@@ -93,7 +93,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min depth");
           max_depth = prm.get<double>("max depth");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("rotation matrices");

--- a/source/world_builder/features/subducting_plate_models/composition/smooth.cc
+++ b/source/world_builder/features/subducting_plate_models/composition/smooth.cc
@@ -68,7 +68,7 @@ namespace WorldBuilder
                             "The composition fraction at the top of the slab (layer).");
           prm.declare_entry("bottom fractions",  Types::Array(Types::Double(0.0),1),
                             "The composition fraction at the bottom of the slab (layer).");
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
                             "Whether the value should replace any value previously defined at this location (replace) or "
@@ -86,7 +86,7 @@ namespace WorldBuilder
           operation = string_operations_to_enum(prm.get<std::string>("operation"));
           top_fraction = prm.get_vector<double>("top fractions");
           bottom_fraction = prm.get_vector<double>("bottom fractions");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
         }
 
 

--- a/source/world_builder/features/subducting_plate_models/composition/tian2019_water_content.cc
+++ b/source/world_builder/features/subducting_plate_models/composition/tian2019_water_content.cc
@@ -75,7 +75,7 @@ namespace WorldBuilder
           prm.declare_entry("density", Types::Double(3000.0),
                             "The reference density used for determining the lithostatic pressure for calculating "
                             "the bound water content.");
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("lithology",  Types::String("peridotite"),
                             "The lithology used to determine which polynomials to use for calculating the water content. Valid options are: "
@@ -100,7 +100,7 @@ namespace WorldBuilder
           min_depth = prm.get<double>("min distance slab top");
           max_depth = prm.get<double>("max distance slab top");
           density = prm.get<double>("density");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
           max_water_content = prm.get<double>("initial water content");
           cutoff_pressure = prm.get<double>("cutoff pressure");
           operation = string_operations_to_enum(prm.get<std::string>("operation"));

--- a/source/world_builder/features/subducting_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/subducting_plate_models/composition/uniform.cc
@@ -64,7 +64,7 @@ namespace WorldBuilder
                             "todo The depth in meters from which the composition of this feature is present.");
           prm.declare_entry("max distance slab top", Types::Double(std::numeric_limits<double>::max()),
                             "todo The depth in meters to which the composition of this feature is present.");
-          prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
+          prm.declare_entry("compositions", Types::Array(Types::OneOf(Types::UnsignedInt(), Types::String("")),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
                             "TA list of compositional fractions corresponding to the compositions list.");
@@ -80,7 +80,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min distance slab top");
           max_depth = prm.get<double>("max distance slab top");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
           fractions = prm.get_vector<double>("fractions");
           operation = string_operations_to_enum(prm.get<std::string>("operation"));
 

--- a/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.cc
+++ b/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution.cc
@@ -93,7 +93,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min distance slab top");
           max_depth = prm.get<double>("max distance slab top");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           operation = prm.get<std::string>("orientation operation");
           grain_sizes = prm.get_vector<double>("grain sizes");

--- a/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.cc
+++ b/source/world_builder/features/subducting_plate_models/grains/random_uniform_distribution_deflected.cc
@@ -101,7 +101,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min distance slab top");
           max_depth = prm.get<double>("max distance slab top");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("basis Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("basis rotation matrices");

--- a/source/world_builder/features/subducting_plate_models/grains/uniform.cc
+++ b/source/world_builder/features/subducting_plate_models/grains/uniform.cc
@@ -92,7 +92,7 @@ namespace WorldBuilder
         {
           min_depth = prm.get<double>("min distance slab top");
           max_depth = prm.get<double>("max distance slab top");
-          compositions = prm.get_vector<unsigned int>("compositions");
+          compositions = prm.get_vector<unsigned int>("compositions", this->world->composition_properties);
 
           const bool set_euler_angles = prm.check_entry("Euler angles z-x-z");
           const bool set_rotation_matrices = prm.check_entry("rotation matrices");

--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -218,28 +218,28 @@ namespace WorldBuilder
     return Pointer((this->get_full_json_path() + "/" + name).c_str()).Get(parameters) != nullptr;
   }
 
-  std::vector<Parameters::composition_properties>
+  std::vector<Parameters::composition_property>
   Parameters::get_composition_properties(const std::string &name) const
   {
     // parse entries as indices linked to names and reference densities
     // struct data type allows easy extension for more properties in the future
-    std::vector<Parameters::composition_properties> composition_properties_output;
+    std::vector<Parameters::composition_property> parsed_composition_entries;
 
     const std::string strict_base = this->get_full_json_path();
-    const Value *composition_properties_entries = Pointer((strict_base + "/" + name).c_str()).Get(parameters);
+    const Value *entries = Pointer((strict_base + "/" + name).c_str()).Get(parameters);
 
-    if (composition_properties_entries == nullptr)
-      return composition_properties_output;
+    if (entries == nullptr)
+      return parsed_composition_entries;
 
-    WBAssertThrow(composition_properties_entries->IsArray(),
+    WBAssertThrow(entries->IsArray(),
                   "Invalid entry \"" << name << "\": expected an array of objects with required key \"index\" and optional keys \"name\" and \"reference density\".");
 
     std::map<unsigned int, bool> seen_indexes;
-    composition_properties_output.reserve(composition_properties_entries->Size());
+    parsed_composition_entries.reserve(entries->Size());
 
-    for (SizeType i = 0; i < composition_properties_entries->Size(); ++i)
+    for (SizeType i = 0; i < entries->Size(); ++i)
       {
-        const Value &entry = (*composition_properties_entries)[i];
+        const Value &entry = (*entries)[i];
 
         // index must be unique
         const unsigned int composition_index = entry["index"].GetUint();
@@ -253,13 +253,13 @@ namespace WorldBuilder
         // reference density defaults to value in CompositionProperty unless user defined
         const double reference_density = entry.HasMember("reference density") ? entry["reference density"].GetDouble() : Types::CompositionProperty::get_default_reference_density();
 
-        composition_properties_output.emplace_back(Parameters::composition_properties {composition_index,
-                                                                                       composition_name,
-                                                                                       reference_density
-                                                                                      });
+        parsed_composition_entries.emplace_back(Parameters::composition_property {composition_index,
+                                                                                     composition_name,
+                                                                                     reference_density
+                                                                                    });
       }
 
-    return composition_properties_output;
+    return parsed_composition_entries;
   }
 
 
@@ -1972,8 +1972,82 @@ namespace WorldBuilder
         for (size_t i = 0; i < array->Size(); ++i )
           {
             const std::string base = (strict_base + "/").append(name).append("/").append(std::to_string(i));
+            Value *entry = Pointer(base.c_str()).Get(parameters);
 
-            vector.push_back(Pointer(base.c_str()).Get(parameters)->GetUint());
+            // if users only use composition indices
+            vector.push_back(entry->GetUint());
+          }
+      }
+    else
+      {
+        const Value *value = Pointer((this->get_full_json_schema_path()  + "/" + name + "/minItems").c_str()).Get(declarations);
+        WBAssertThrow(value != nullptr,
+                      "internal error: could not retrieve the minItems value at: "
+                      << this->get_full_json_schema_path() + "/" + name + "/minItems value");
+
+        const size_t min_size = value->GetUint();
+
+        const unsigned int default_value = Pointer((this->get_full_json_schema_path()  + "/" + name + "/items/default value").c_str()).Get(declarations)->GetUint();
+
+        // set to min size
+        for (size_t i = 0; i < min_size; ++i)
+          {
+            vector.push_back(default_value);
+          }
+      }
+    return vector;
+  }
+
+  template<>
+  std::vector<unsigned int>
+  Parameters::get_vector(const std::string &name,
+                         const std::vector<Parameters::composition_property> &composition_properties)
+  {
+    std::vector<unsigned int> vector;
+    const std::string strict_base = this->get_full_json_path();
+    if (Pointer((strict_base + "/" + name).c_str()).Get(parameters) != nullptr)
+      {
+        Value *array = Pointer((strict_base  + "/" + name).c_str()).Get(parameters);
+
+        for (size_t i = 0; i < array->Size(); ++i )
+          {
+            const std::string base = (strict_base + "/").append(name).append("/").append(std::to_string(i));
+            Value *entry = Pointer(base.c_str()).Get(parameters);
+
+            // user can define either an index (usigned int)
+            // or a compositon name (string)
+            // if latter, assign the corresponding index in the composition properties
+            if (entry->IsUint())
+              {
+                vector.push_back(entry->GetUint());
+              }
+            else if (entry->IsString())
+              {
+                const std::string feature_composition_name = entry->GetString();
+                bool isFoundInCompositionProperties = false;
+
+                for (const Parameters::composition_property &global_composition : composition_properties)
+                  {
+                    // compare globally defined composition name
+                    // with feature-defined composition name
+                    // and assign the corresponding index if found
+                    if (global_composition.name == feature_composition_name)
+                      {
+                        vector.push_back(global_composition.index);
+                        isFoundInCompositionProperties = true;
+                        break;
+                      }
+                  }
+                WBAssertThrow(isFoundInCompositionProperties,
+                              "internal error: could not find the value \"" << feature_composition_name << "\" in the composition properties at: "
+                              << this->get_full_json_schema_path() + "/" + name + "/items/enum");
+              }
+            else
+              {
+                WBAssertThrow(false,
+                              "internal error: expected an unsigned int or a string for the value at: "
+                              << base);
+              }
           }
       }
     else

--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -254,9 +254,9 @@ namespace WorldBuilder
         const double reference_density = entry.HasMember("reference density") ? entry["reference density"].GetDouble() : Types::CompositionProperty::get_default_reference_density();
 
         parsed_composition_entries.emplace_back(Parameters::composition_property {composition_index,
-                                                                                     composition_name,
-                                                                                     reference_density
-                                                                                    });
+                                                                                  composition_name,
+                                                                                  reference_density
+                                                                                 });
       }
 
     return parsed_composition_entries;

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -323,11 +323,10 @@ namespace WorldBuilder
      * Parsing is handled in parameters.cc
      * Struct with default values is defined in types/composition_property
      */
-    const auto parsed_composition_properties = prm.get_composition_properties("composition properties");
 
-    for (const auto &composition_entry : parsed_composition_properties)
+    for (const Parameters::composition_property &parsed_property : prm.get_composition_properties("composition properties"))
       {
-        composition_properties.emplace(composition_entry.index, composition_entry);
+        composition_properties.emplace_back(parsed_property);
       }
 
     /**

--- a/tests/data/composition_properties_map.wb
+++ b/tests/data/composition_properties_map.wb
@@ -25,9 +25,25 @@
       "model":"continental plate",
       "name":"TestPlate",
       "max depth":300e3,
-      "coordinates":[[0,0],[100e3,0],[100e3,100e3],[0,100e3]],
+      "coordinates":[[0,0],[100e3,0],[100e3,50e3],[0,50e3]],
       "temperature models":[{"model":"uniform", "max depth":250e3, "temperature":293.15}],
       "composition models":[{"model":"uniform", "max depth":250e3, "compositions":[0]}]
+    },
+    {
+      "model":"continental plate",
+      "name":"TestPlate2",
+      "max depth":300e3,
+      "coordinates":[[0,50e3],[50e3,50e3],[50e3,100e3],[0,100e3]],
+      "temperature models":[{"model":"uniform", "max depth":250e3, "temperature":293.15}],
+      "composition models":[{"model":"uniform", "max depth":250e3, "compositions":["harzburgite"]}]
+    },
+    {
+      "model":"continental plate",
+      "name":"TestPlate3",
+      "max depth":300e3,
+      "coordinates":[[50e3,50e3],[100e3,50e3],[100e3,100e3],[50e3,100e3]],
+      "temperature models":[{"model":"uniform", "max depth":250e3, "temperature":293.15}],
+      "composition models":[{"model":"uniform", "max depth":250e3, "compositions":["pyroxenite"]}]
     }
   ]
 }

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -8121,4 +8121,8 @@ TEST_CASE("WorldBuilder composition property maps")
 
   CHECK(world.composition_properties[1].name == "harzburgite");
   CHECK(world.composition_properties[3].reference_density == Approx(3350.0));
+
+  CHECK(world.properties({{75e3,50e3,0}},50e3, {{{{2,3,0}}}})[0] == Approx(1.0)); // supposed to be pyroxenite (3)
+  CHECK(world.properties({{75e3,50e3,0}},50e3, {{{{2,2,0}}}})[0] == Approx(0.0)); // not supposed to be compostion index 2
+  CHECK(world.properties({{25e3,50e3,0}},50e3, {{{{2,1,0}}}})[0] == Approx(1.0)); // supposed to be harzburgite (1)
 }


### PR DESCRIPTION
WARNING: "Parameter::composition_properties" (struct) has been renamed to "composition_property" (storing index, name, density, etc. for one composition), while the global composition_properties (vector) indicates the user defined table. These two were named the same in the previous push request.

Users now can assign a composition field using a name (string) that they define in the composition_properties table. The name will be parsed and linked to the corresponding composition index (and default properties). The name output function (what you see in ParaView) has not been updated yet.