### PR TITLE
Remove world_builder_declarations.tex

### DIFF
--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -116,10 +116,6 @@ namespace WorldBuilder
         // remove Snippets so they don't appear in the documentation:
         remove_key(declarations, "defaultSnippets");
 
-        // write out declarations
-        file.open (output_dir + "world_builder_declarations.tex");
-        WBAssertThrow(file.is_open(), "Error: Could not open file '" + output_dir + "world_builder_declarations.tex' for string the tex declarations.");
-
         LatexWriter<StringBuffer, UTF8<>, UTF8<>, CrtAllocator, kWriteNanAndInfFlag> tex_writer(buffer);
         declarations.Accept(tex_writer);
         file << buffer.GetString();


### PR DESCRIPTION
Several PR's (including some of my own) have accidentally included a large .tex file that is no longer tracked by world builder. After double checking with @MFraters, this file does not need to be output anymore. This PR removes the file from being created.