### PR TITLE
Fix fraction declaration typos

### DIFF
--- a/source/world_builder/features/continental_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/composition/uniform.cc
@@ -76,7 +76,7 @@ namespace WorldBuilder
                             "A list with the labels of the composition which are present there.");
 
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
-                            "TA list of compositional fractions corresponding to the compositions list.");
+                            "A list of compositional fractions corresponding to the compositions list.");
 
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
                             "Whether the value should replace any value previously defined at this location (replace) or "

--- a/source/world_builder/features/fault_models/composition/uniform.cc
+++ b/source/world_builder/features/fault_models/composition/uniform.cc
@@ -68,7 +68,7 @@ namespace WorldBuilder
           prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
-                            "TA list of compositional fractions corresponding to the compositions list.");
+                            "A list of compositional fractions corresponding to the compositions list.");
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
                             "Whether the value should replace any value previously defined at this location (replace) or "
                             "add the value to the previously define value. Replacing implies that all compositions not "

--- a/source/world_builder/features/mantle_layer_models/composition/uniform.cc
+++ b/source/world_builder/features/mantle_layer_models/composition/uniform.cc
@@ -69,7 +69,7 @@ namespace WorldBuilder
           prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
-                            "TA list of compositional fractions corresponding to the compositions list.");
+                            "A list of compositional fractions corresponding to the compositions list.");
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
                             "Whether the value should replace any value previously defined at this location (replace) or "
                             "add the value to the previously define value. Replacing implies that all compositions not "

--- a/source/world_builder/features/oceanic_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/composition/uniform.cc
@@ -73,7 +73,7 @@ namespace WorldBuilder
           prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
-                            "TA list of compositional fractions corresponding to the compositions list.");
+                            "A list of compositional fractions corresponding to the compositions list.");
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
                             "Whether the value should replace any value previously defined at this location (replace) or "
                             "add the value to the previously define value. Replacing implies that all compositions not "

--- a/source/world_builder/features/plume_models/composition/uniform.cc
+++ b/source/world_builder/features/plume_models/composition/uniform.cc
@@ -71,7 +71,7 @@ namespace WorldBuilder
                             "A list with the labels of the composition which are present there.");
 
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
-                            "TA list of compositional fractions corresponding to the compositions list.");
+                            "A list of compositional fractions corresponding to the compositions list.");
 
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
                             "Whether the value should replace any value previously defined at this location (replace) or "

--- a/source/world_builder/features/subducting_plate_models/composition/uniform.cc
+++ b/source/world_builder/features/subducting_plate_models/composition/uniform.cc
@@ -67,7 +67,7 @@ namespace WorldBuilder
           prm.declare_entry("compositions", Types::Array(Types::UnsignedInt(),0),
                             "A list with the labels of the composition which are present there.");
           prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1),
-                            "TA list of compositional fractions corresponding to the compositions list.");
+                            "A list of compositional fractions corresponding to the compositions list.");
           prm.declare_entry("operation", Types::String("replace", std::vector<std::string> {"replace", "replace defined only", "add", "subtract"}),
                             "Whether the value should replace any value previously defined at this location (replace) or "
                             "add the value to the previously define value. Replacing implies that all compositions not "


### PR DESCRIPTION
Fix the description of `prm.declare_entry("fractions", Types::Array(Types::Double(1.0),1)` in features.