### PR TITLE
Rename composition_property struct

### DIFF
--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -181,7 +181,7 @@ namespace WorldBuilder
       bool
       check_entry(const std::string &name) const;
 
-      struct composition_properties
+      struct composition_property
       {
         unsigned int index;
         std::string name;
@@ -194,7 +194,7 @@ namespace WorldBuilder
        * If the entry is absent, the vector is empty.
        * \param name The name of the entry to be declared
        */
-      std::vector<composition_properties>
+      std::vector<composition_property>
       get_composition_properties(const std::string &name) const;
 
       /**

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -258,7 +258,7 @@ namespace WorldBuilder
       * Return all composition properties from its index.
       * If the index is unknown, returns fallback properties with a generated name.
       */
-      Parameters::composition_properties get_composition_properties(const unsigned int composition_index) const;
+      Parameters::composition_property get_composition_properties(const unsigned int composition_index) const;
 
       /**
        * This is the parameter class, which stores all the values loaded in
@@ -350,7 +350,7 @@ namespace WorldBuilder
       /**
        * A map from composition index to its properties for quick lookups.
        */
-      std::map<unsigned int, Parameters::composition_properties> composition_properties;
+      std::map<unsigned int, Parameters::composition_property> composition_properties;
 
     private:
       /**

--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -214,28 +214,28 @@ namespace WorldBuilder
     return Pointer((this->get_full_json_path() + "/" + name).c_str()).Get(parameters) != nullptr;
   }
 
-  std::vector<Parameters::composition_properties>
+  std::vector<Parameters::composition_property>
   Parameters::get_composition_properties(const std::string &name) const
   {
     // parse entries as indices linked to names and reference densities
     // struct data type allows easy extension for more properties in the future
-    std::vector<Parameters::composition_properties> composition_properties_output;
+    std::vector<Parameters::composition_property> cp_output;
 
-    const std::string strict_base = this->get_full_json_path();
-    const Value *composition_properties_entries = Pointer((strict_base + "/" + name).c_str()).Get(parameters);
+    const std::string base = this->get_full_json_path();
+    const Value *cp_entries = Pointer((base + "/" + name).c_str()).Get(parameters);
 
-    if (composition_properties_entries == nullptr)
-      return composition_properties_output;
+    if (cp_entries == nullptr)
+      return cp_output;
 
-    WBAssertThrow(composition_properties_entries->IsArray(),
+    WBAssertThrow(cp_entries->IsArray(),
                   "Invalid entry \"" << name << "\": expected an array of objects with required key \"index\" and optional keys \"name\" and \"reference density\".");
 
     std::map<unsigned int, bool> seen_indexes;
-    composition_properties_output.reserve(composition_properties_entries->Size());
+    cp_output.reserve(cp_entries->Size());
 
-    for (SizeType i = 0; i < composition_properties_entries->Size(); ++i)
+    for (SizeType i = 0; i < cp_entries->Size(); ++i)
       {
-        const Value &entry = (*composition_properties_entries)[i];
+        const Value &entry = (*cp_entries)[i];
 
         // index must be unique
         const unsigned int composition_index = entry["index"].GetUint();
@@ -249,13 +249,13 @@ namespace WorldBuilder
         // reference density defaults to value in CompositionProperty unless user defined
         const double reference_density = entry.HasMember("reference density") ? entry["reference density"].GetDouble() : Types::CompositionProperty::get_default_reference_density();
 
-        composition_properties_output.emplace_back(Parameters::composition_properties {composition_index,
-                                                                                       composition_name,
-                                                                                       reference_density
-                                                                                      });
+        cp_output.emplace_back(Parameters::composition_property {composition_index,
+                                                                 composition_name,
+                                                                 reference_density
+                                                                });
       }
 
-    return composition_properties_output;
+    return cp_output;
   }
 
 

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -318,16 +318,13 @@ namespace WorldBuilder
       random_number_engine.seed(static_cast<unsigned int>(local_seed+MPI_RANK));
 
     /**
-     * Mapping of composition properties as a struct
-     * Composition indices (required) mapped to their properties (optional).
+     * A map storing composition indices (required) and their properties (optional).
      * Parsing is handled in parameters.cc
      * Struct with default values is defined in types/composition_property
      */
-    const auto parsed_composition_properties = prm.get_composition_properties("composition properties");
-
-    for (const auto &composition_entry : parsed_composition_properties)
+    for (const Parameters::composition_property &cp_parsed : prm.get_composition_properties("composition properties"))
       {
-        composition_properties.emplace(composition_entry.index, composition_entry);
+        composition_properties.emplace(cp_parsed.index, cp_parsed);
       }
 
     /**


### PR DESCRIPTION
Following #926, renamed Parameters::composition_property (a struct indicating all properties of one composition) to distinguish from composition_properties (a map linking composition indices with their composition_property). All renamed variables are internal so previous results and tests should not be affected.

I have also tested making composition_properties a vector and did not find it a good idea. Since users are allowed to assign arbitrary composition indices (as long as they are unique), handling this cleanly is more cumbersome with a vector.

The feature parser will come shortly after.