### PR TITLE
Update reference profile point in declare_entry

### DIFF
--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -193,8 +193,8 @@ namespace WorldBuilder
       prm.declare_entry("number of integration points", Types::Int(100),
                         "Number of integration points for calculating the compensation pressure.");
 
-      prm.declare_entry("Reference profile point", Types::Point<2>(),
-                        "This is an array of two points along where the cross section is taken");
+      prm.declare_entry("reference profile point", Types::Point<2>(),
+                        "This is an X-Y point used to calculate the reference compensation pressure.");
 
     }
     prm.leave_subsection();


### PR DESCRIPTION
This uncapitalizes the world.cc reference profile point declare_entry to align with other parameters. I also updated the description.