### PR TITLE
Move reading of the file into a stringstream outside the initialization function, directly into the constructor.

### DIFF
--- a/include/world_builder/parameters.h
+++ b/include/world_builder/parameters.h
@@ -91,11 +91,11 @@ namespace WorldBuilder
 
       /**
        * Initializes the parameter file
-       * \param filename A string with the path to the world builder file
+       * \param input_stream A string stream with the content of the world builder file
        * \param has_output_dir A bool indicating whether the world builder may write out information.
        * \param output_dir A string with the path to the directory where it can output information if allowed by has_output_dir
        */
-      void initialize(std::string &filename, bool has_output_dir = false, const std::string &output_dir = "");
+      void initialize(std::stringstream &input_stream, bool has_output_dir = false, const std::string &output_dir = "");
 
       /**
        * A generic get function to retrieve setting from the parameter file.

--- a/source/world_builder/parameters.cc
+++ b/source/world_builder/parameters.cc
@@ -96,7 +96,7 @@ namespace WorldBuilder
   Parameters::~Parameters()
     = default;
 
-  void Parameters::initialize(std::string &filename, bool has_output_dir, const std::string &output_dir)
+  void Parameters::initialize(std::stringstream &input_stream, bool has_output_dir, const std::string &output_dir)
   {
 
     if (has_output_dir)
@@ -146,13 +146,12 @@ namespace WorldBuilder
     path_level =0;
     // Now read in the world builder file into a stringstream and
     // put it into a the rapidjson document
-    std::stringstream json_input_stream(WorldBuilder::Utilities::read_and_distribute_file_content(filename));
-    rapidjson::IStreamWrapper isw(json_input_stream);
+    rapidjson::IStreamWrapper isw(input_stream);
 
     // relaxing syntax by allowing comments () for now, maybe also allow trailing commas and (kParseTrailingCommasFlag) and nan's, inf etc (kParseNanAndInfFlag)?
     //WBAssertThrow(!parameters.ParseStream<kParseCommentsFlag>(isw).HasParseError(), "Parsing errors world builder file");
 
-    WBAssertThrowExc(!(parameters.ParseStream<kParseCommentsFlag | kParseNanAndInfFlag>(isw).HasParseError()), std::ifstream json_input_stream_error(filename.c_str()); ,
+    WBAssertThrowExc(!(parameters.ParseStream<kParseCommentsFlag | kParseNanAndInfFlag>(isw).HasParseError()), std::stringstream json_input_stream_error(input_stream.str()); ,
                      "Parsing errors world builder file: Error(offset " << static_cast<unsigned>(parameters.GetErrorOffset())
                      << "): " << GetParseError_En(parameters.GetParseError()) << std::endl << std::endl
                      << " Showing 50 chars before and after: "
@@ -171,7 +170,7 @@ namespace WorldBuilder
                                                                              static_cast<unsigned>(parameters.GetErrorOffset())-5,
                                                                              (static_cast<unsigned>(parameters.GetErrorOffset()) + 10 > json_input_stream_error.seekg(0,std::ios::end).tellg()
                                                                               ?
-                                                                              static_cast<unsigned>(json_input_stream.tellg())-static_cast<unsigned>(parameters.GetErrorOffset())
+                                                                              static_cast<unsigned>(input_stream.tellg())-static_cast<unsigned>(parameters.GetErrorOffset())
                                                                               :
                                                                               10)
                                                                             ));

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -97,7 +97,8 @@ namespace WorldBuilder
 
     WorldBuilder::World::declare_entries(parameters);
 
-    parameters.initialize(filename, has_output_dir, output_dir);
+    std::stringstream input_stream(WorldBuilder::Utilities::read_and_distribute_file_content(filename));
+    parameters.initialize(input_stream, has_output_dir, output_dir);
 
     this->parse_entries(parameters);
 

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -4027,7 +4027,10 @@ TEST_CASE("WorldBuilder Parameters")
   approval_tests.emplace_back("1",std::isinf(world.parameters.coordinate_system->max_model_depth()));
 
   Parameters prm(world);
-  prm.initialize(file);
+  std::ifstream input_file_stream(file);
+  std::stringstream input_stream;
+  input_stream << input_file_stream.rdbuf();
+  prm.initialize(input_stream);
 
   world.parameters.coordinate_system.swap(prm.coordinate_system);
 


### PR DESCRIPTION
Move reading of the file into a stringstream outside the initialization function, directly into the constructor. This is a preparation for being able to create a world from the contents of a file, instead of a file path.