### PR TITLE
Optimize allocations (get them out of loops) with the help of heaptrack.

### DIFF
--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -68,7 +68,7 @@ namespace WorldBuilder
 
         T &get_object_from_pool()
         {
-          std::lock_guard<std::mutex> lock(mutex);
+          //std::lock_guard<std::mutex> lock(mutex);
           for (auto &pair : object_list)
             if (pair.second == false)
               {
@@ -82,7 +82,7 @@ namespace WorldBuilder
 
         void return_object_to_pool (T &t)
         {
-          std::lock_guard<std::mutex> lock(mutex);
+          //std::lock_guard<std::mutex> lock(mutex);
           for (auto &pair : object_list)
             if (&pair.first == &t)
               {
@@ -94,9 +94,10 @@ namespace WorldBuilder
 
       private:
         std::mutex mutex;
-        std::list<std::pair<T,bool>> object_list;
+        static thread_local std::list<std::pair<T,bool>> object_list;
     };
 
+    template<typename T> thread_local std::list<std::pair<T,bool>> ScratchSpace<T>::object_list = {};
 
     /**
      * provide a short way to test if two doubles are equal.

--- a/include/world_builder/utilities.h
+++ b/include/world_builder/utilities.h
@@ -26,6 +26,8 @@
 #include "world_builder/objects/natural_coordinate.h"
 #include "world_builder/objects/bezier_curve.h"
 #include <iostream>
+#include <list>
+#include <mutex>
 
 
 namespace WorldBuilder
@@ -37,6 +39,64 @@ namespace WorldBuilder
   } // namespace CoordinateSystems
   namespace Utilities
   {
+    template <typename T>
+    class ScratchSpace
+    {
+      public:
+        class ScopedScratchObject
+        {
+          public:
+            ScopedScratchObject (ScratchSpace<T> &space_)
+              : space (space_),
+                t (space.get_object_from_pool())
+            {}
+
+            ~ScopedScratchObject()
+            {
+              space.return_object_to_pool(t);
+            }
+
+            operator T &()
+            {
+              return t;
+            }
+
+          private:
+            ScratchSpace &space;
+            T &t;
+        };
+
+        T &get_object_from_pool()
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          for (auto &pair : object_list)
+            if (pair.second == false)
+              {
+                pair.second = true;
+                return pair.first;
+              }
+
+          object_list.emplace_back (T(), true);
+          return object_list.back().first;
+        }
+
+        void return_object_to_pool (T &t)
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          for (auto &pair : object_list)
+            if (&pair.first == &t)
+              {
+                pair.second = false;
+                return;
+              }
+          // TODO: assert that we never get here
+        }
+
+      private:
+        std::mutex mutex;
+        std::list<std::pair<T,bool>> object_list;
+    };
+
 
     /**
      * provide a short way to test if two doubles are equal.

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -128,6 +128,9 @@ namespace WorldBuilder
                                      const double depth,
                                      const std::vector<std::array<unsigned int,3>> &properties) const;
 
+      void properties(const std::array<double, 2> &point,
+                      const double depth,
+                      const std::vector<std::array<unsigned int,3>> &properties,std::vector<double> &output) const;
       /**
        * Returns different values at a single point in one go stored in a vector of doubles.
        *
@@ -169,6 +172,10 @@ namespace WorldBuilder
                                      const double depth,
                                      const std::vector<std::array<unsigned int,3>> &properties) const;
 
+      void properties(const std::array<double, 3> &point,
+                      const double depth,
+                      const std::vector<std::array<unsigned int,3>> &properties,
+                      std::vector<double> &output) const;
       /**
        * Returns the temperature based on a 2d Cartesian point, the depth in the
        * model at that point and the gravity norm at that point.

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -1915,6 +1915,7 @@ int main(int argc, char **argv)
           pool.parallel_for(0, n_p, [&] (size_t i)
           {
             thread_local static  std::vector<double> output(world->properties_output_size(properties));
+            output.clear();
 
             const std::array<double,2> coords = {{grid_x[i], grid_z[i]}};
             world->properties(coords, grid_depth_wrt_surface[i],properties,output);
@@ -1940,6 +1941,7 @@ int main(int argc, char **argv)
           pool.parallel_for(0, n_p, [&] (size_t i)
           {
             thread_local static  std::vector<double> output(world->properties_output_size(properties));
+            output.clear();
             const std::array<double,3> coords = {{grid_x[i], grid_y[i], grid_z[i]}};
             world->properties(coords, grid_depth_wrt_surface[i],properties,output);
             data_set[2][i] = output[0];

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -27,6 +27,7 @@
 
 #include "world_builder/assert.h"
 #include "world_builder/coordinate_system.h"
+#include "world_builder/coordinate_systems/cartesian.h"
 #include "world_builder/nan.h"
 #include "world_builder/objects/natural_coordinate.h"
 #include "world_builder/point.h"
@@ -633,6 +634,7 @@ int main(int argc, char **argv)
       /**
        * Begin making the grid
        */
+      std::vector<std::array<unsigned int,3>> topo_input = {{{6,0,0}}};
       std::cout << "[4/6] Building the grid...                        \r";
       std::cout.flush();
       WBAssertThrow(dim == 2 || dim == 3, "Dimension should be 2d or 3d.");
@@ -678,7 +680,7 @@ int main(int argc, char **argv)
                       grid_z[counter] = z_min + static_cast<double>(j) * dz;
                       grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(j) * dz;
 
-                      const double topography = world->properties(std::array<double,2>({{grid_x[counter],grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                      const double topography = world->properties(std::array<double,2>({{grid_x[counter],grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                       const double domain_height = z_max - z_min + topography;
                       const double cell_height = domain_height / static_cast<double>(n_cell_z);
                       grid_z[counter] = z_min + static_cast<double>(j) * cell_height;
@@ -703,7 +705,7 @@ int main(int argc, char **argv)
                               grid_z[counter] = z_min + static_cast<double>(k) * dz;
                               grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
 
-                              const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                              const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                               const double domain_height = z_max - z_min + topography;
                               const double cell_height = domain_height / static_cast<double>(n_cell_z);
                               grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -730,7 +732,7 @@ int main(int argc, char **argv)
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
 
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -745,7 +747,7 @@ int main(int argc, char **argv)
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
 
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -760,7 +762,7 @@ int main(int argc, char **argv)
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
 
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -775,7 +777,7 @@ int main(int argc, char **argv)
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
 
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -790,7 +792,7 @@ int main(int argc, char **argv)
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
 
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -805,7 +807,7 @@ int main(int argc, char **argv)
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
 
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -820,7 +822,7 @@ int main(int argc, char **argv)
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
 
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -835,7 +837,7 @@ int main(int argc, char **argv)
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
 
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -948,7 +950,7 @@ int main(int argc, char **argv)
                   const double grid_z_rad = FT::sin(theta) * (z_min + grid_z_cart);
                   const double grid_depth_wrt_surface_local = z_max - std::sqrt(grid_x_rad * grid_x_rad + grid_z_rad * grid_z_rad);
 
-                  const double topography = world->properties(std::array<double,2>({{grid_x_rad,grid_z_rad}}), grid_depth_wrt_surface_local, {{{6,0,0}}})[0];
+                  const double topography = world->properties(std::array<double,2>({{grid_x_rad,grid_z_rad}}), grid_depth_wrt_surface_local, topo_input)[0];
 
                   const double outer_circumference_local = 2.0 * Consts::PI * (z_max+topography);
                   const double cell_height_local = (z_max - z_min + topography) / static_cast<double>(n_cell_z);
@@ -1045,7 +1047,7 @@ int main(int argc, char **argv)
 
                       const double x = radius * cos_long;
                       const double z = radius * sin_long;
-                      const double topography = world->properties(std::array<double,2>({{x,z}}), 0, {{{6,0,0}}})[0];
+                      const double topography = world->properties(std::array<double,2>({{x,z}}), 0, topo_input)[0];
 
                       domain_height [counter]= outer_radius + topography - inner_radius;
                       cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1083,7 +1085,7 @@ int main(int argc, char **argv)
                               const double y = radius * cos_lat * sin_long;
                               const double z = radius * sin_lat;
 
-                              const double topography = world->properties({{x,y,z}}, 0, {{{6,0,0}}})[0];
+                              const double topography = world->properties({{x,y,z}}, 0, topo_input)[0];
 
                               domain_height[counter] = outer_radius + topography - inner_radius;
                               cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1117,7 +1119,7 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1138,7 +1140,7 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1159,7 +1161,7 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1180,7 +1182,7 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1201,7 +1203,7 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1222,7 +1224,7 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1243,7 +1245,7 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1264,7 +1266,7 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1714,7 +1716,7 @@ int main(int argc, char **argv)
                   grid_z[j] = temp_shell_grid_z[counter];
                   grid_depth_wrt_surface[j] = outer_radius - std::sqrt(grid_x[j] * grid_x[j] + grid_y[j] * grid_y[j] + grid_z[j] * grid_z[j]);
                   grid_depth_wrt_surface[j] = (std::fabs(grid_depth_wrt_surface[j]) < 1e-8 ? 0 : grid_depth_wrt_surface[j]);
-                  const double topography = world->properties({{grid_x[j],grid_y[j],grid_z[j]}}, grid_depth_wrt_surface[counter], {{{6,0,0}}})[0];
+                  const double topography = world->properties({{grid_x[j],grid_y[j],grid_z[j]}}, grid_depth_wrt_surface[counter], topo_input)[0];
 
                   grid_x[j] = temp_shell_grid_x[counter]+topography*(double(i)/double(n_cell_z));
                   grid_y[j] = temp_shell_grid_y[counter]+topography*(double(i)/double(n_cell_z));

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -623,7 +623,9 @@ int main(int argc, char **argv)
       std::vector<double> grid_depth_wrt_surface(0);
       std::vector<double> grid_depth_wrt_reference(0);
 
-      std::vector<std::vector<size_t> > grid_connectivity(0);
+      const size_t pow_2_dim = dim == 2 ? 4 : 8;
+      std::vector<vtu11::VtkIndexType> connectivity(n_cell*pow_2_dim);
+      //std::vector<std::vector<size_t> > grid_connectivity(0);
 
 
       const bool compress_size = true;
@@ -865,7 +867,7 @@ int main(int argc, char **argv)
             }
 
           // compute connectivity. Local to global mapping.
-          grid_connectivity.resize(n_cell,std::vector<size_t>((dim-1)*4));
+          //grid_connectivity.resize(n_cell,std::vector<size_t>((dim-1)*4));
 
           counter = 0;
           if (dim == 2)
@@ -874,10 +876,10 @@ int main(int argc, char **argv)
                 {
                   for (size_t i = 1; i <= n_cell_x; ++i)
                     {
-                      grid_connectivity[counter][0] = i + (j - 1) * (n_cell_x + 1) - 1;
-                      grid_connectivity[counter][1] = i + 1 + (j - 1) * (n_cell_x + 1) - 1;
-                      grid_connectivity[counter][2] = i + 1  + j * (n_cell_x + 1) - 1;
-                      grid_connectivity[counter][3] = i + j * (n_cell_x + 1) - 1;
+                      connectivity[counter*pow_2_dim]   = static_cast<vtu11::VtkIndexType>(i + (j - 1) * (n_cell_x + 1) - 1);
+                      connectivity[counter*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(i + 1 + (j - 1) * (n_cell_x + 1) - 1);
+                      connectivity[counter*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(i + 1  + j * (n_cell_x + 1) - 1);
+                      connectivity[counter*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(i + j * (n_cell_x + 1) - 1);
                       counter++;
                     }
                 }
@@ -892,14 +894,14 @@ int main(int argc, char **argv)
                         {
                           for (size_t k = 1; k <= n_cell_z; ++k)
                             {
-                              grid_connectivity[counter][0] = (n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j - 1) + k - 1;
-                              grid_connectivity[counter][1] = (n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j - 1) + k - 1;
-                              grid_connectivity[counter][2] = (n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j    ) + k - 1;
-                              grid_connectivity[counter][3] = (n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j    ) + k - 1;
-                              grid_connectivity[counter][4] = (n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j - 1) + k;
-                              grid_connectivity[counter][5] = (n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j - 1) + k;
-                              grid_connectivity[counter][6] = (n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j    ) + k;
-                              grid_connectivity[counter][7] = (n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j    ) + k;
+                              connectivity[counter*pow_2_dim+0] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j - 1) + k - 1);
+                              connectivity[counter*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j - 1) + k - 1);
+                              connectivity[counter*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j    ) + k - 1);
+                              connectivity[counter*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j    ) + k - 1);
+                              connectivity[counter*pow_2_dim+4] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j - 1) + k);
+                              connectivity[counter*pow_2_dim+5] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j - 1) + k);
+                              connectivity[counter*pow_2_dim+6] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j    ) + k);
+                              connectivity[counter*pow_2_dim+7] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j    ) + k);
                               counter++;
                             }
                         }
@@ -909,14 +911,14 @@ int main(int argc, char **argv)
                 {
                   for (size_t i = 0; i < n_cell; ++i)
                     {
-                      grid_connectivity[i][0] = counter;
-                      grid_connectivity[i][1] = counter + 1;
-                      grid_connectivity[i][2] = counter + 2;
-                      grid_connectivity[i][3] = counter + 3;
-                      grid_connectivity[i][4] = counter + 4;
-                      grid_connectivity[i][5] = counter + 5;
-                      grid_connectivity[i][6] = counter + 6;
-                      grid_connectivity[i][7] = counter + 7;
+                      connectivity[counter*pow_2_dim+0] = static_cast<vtu11::VtkIndexType>(counter);
+                      connectivity[counter*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(counter + 1);
+                      connectivity[counter*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(counter + 2);
+                      connectivity[counter*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(counter + 3);
+                      connectivity[counter*pow_2_dim+4] = static_cast<vtu11::VtkIndexType>(counter + 4);
+                      connectivity[counter*pow_2_dim+5] = static_cast<vtu11::VtkIndexType>(counter + 5);
+                      connectivity[counter*pow_2_dim+6] = static_cast<vtu11::VtkIndexType>(counter + 6);
+                      connectivity[counter*pow_2_dim+7] = static_cast<vtu11::VtkIndexType>(counter + 7);
                       counter = counter + 8;
                     }
                 }
@@ -982,7 +984,7 @@ int main(int argc, char **argv)
                 }
             }
 
-          grid_connectivity.resize(n_cell,std::vector<size_t>(4));
+          //grid_connectivity.resize(n_cell,std::vector<size_t>(4));
           counter = 0;
           for (size_t j = 1; j <= n_cell_z; ++j)
             {
@@ -998,10 +1000,10 @@ int main(int argc, char **argv)
                       cell_connectivity[1] = cell_connectivity[1] - n_cell_circumference;
                       cell_connectivity[2] = cell_connectivity[2] - n_cell_circumference;
                     }
-                  grid_connectivity[counter][0] = cell_connectivity[1] - 1;
-                  grid_connectivity[counter][1] = cell_connectivity[0] - 1;
-                  grid_connectivity[counter][2] = cell_connectivity[3] - 1;
-                  grid_connectivity[counter][3] = cell_connectivity[2] - 1;
+                  connectivity[counter*pow_2_dim+0] = static_cast<vtu11::VtkIndexType>(cell_connectivity[1] - 1);
+                  connectivity[counter*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(cell_connectivity[0] - 1);
+                  connectivity[counter*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(cell_connectivity[3] - 1);
+                  connectivity[counter*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(cell_connectivity[2] - 1);
                   counter++;
                 }
             }
@@ -1345,7 +1347,7 @@ int main(int argc, char **argv)
           std::cout.flush();
           // compute connectivity. Local to global mapping.
           const std::vector<size_t> tmp_vector((dim-1)*4);
-          grid_connectivity.resize(n_cell,tmp_vector);
+          //grid_connectivity.resize(n_cell,tmp_vector);
 
           counter = 0;
           if (dim == 2)
@@ -1354,10 +1356,10 @@ int main(int argc, char **argv)
                 {
                   for (size_t j = 1; j <= n_cell_z; ++j)
                     {
-                      grid_connectivity[counter][0] = (n_cell_z + 1) * (i - 1) + j - 1;
-                      grid_connectivity[counter][1] = (n_cell_z + 1) * (i - 1) + j;
-                      grid_connectivity[counter][2] = (n_cell_z + 1) * (i    ) + j;
-                      grid_connectivity[counter][3] = (n_cell_z + 1) * (i    ) + j - 1;
+                      connectivity[counter*pow_2_dim+0] = static_cast<vtu11::VtkIndexType>((n_cell_z + 1) * (i - 1) + j - 1);
+                      connectivity[counter*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>((n_cell_z + 1) * (i - 1) + j);
+                      connectivity[counter*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>((n_cell_z + 1) * (i    ) + j);
+                      connectivity[counter*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>((n_cell_z + 1) * (i    ) + j - 1);
 
                       counter = counter+1;
                       std::cout << "[4/6] Building the grid: stage 3 of 3 [" << (static_cast<double>(i)/static_cast<double>(n_cell))*100.0 << "%]                       \r";
@@ -1375,14 +1377,14 @@ int main(int argc, char **argv)
                         {
                           for (size_t k = 1; k <= n_cell_z; ++k)
                             {
-                              grid_connectivity[counter][0] = (n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j - 1) + k - 1;
-                              grid_connectivity[counter][1] = (n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j - 1) + k - 1;
-                              grid_connectivity[counter][2] = (n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j    ) + k - 1;
-                              grid_connectivity[counter][3] = (n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j    ) + k - 1;
-                              grid_connectivity[counter][4] = (n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j - 1) + k;
-                              grid_connectivity[counter][5] = (n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j - 1) + k;
-                              grid_connectivity[counter][6] = (n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j    ) + k;
-                              grid_connectivity[counter][7] = (n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j    ) + k;
+                              connectivity[counter*pow_2_dim+0] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j - 1) + k - 1);
+                              connectivity[counter*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j - 1) + k - 1);
+                              connectivity[counter*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j    ) + k - 1);
+                              connectivity[counter*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j    ) + k - 1);
+                              connectivity[counter*pow_2_dim+4] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j - 1) + k);
+                              connectivity[counter*pow_2_dim+5] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j - 1) + k);
+                              connectivity[counter*pow_2_dim+6] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i    ) + (n_cell_z + 1) * (j    ) + k);
+                              connectivity[counter*pow_2_dim+7] = static_cast<vtu11::VtkIndexType>((n_cell_y + 1) * (n_cell_z + 1) * (i - 1) + (n_cell_z + 1) * (j    ) + k);
                               counter++;
                             }
                         }
@@ -1392,14 +1394,14 @@ int main(int argc, char **argv)
                 {
                   for (size_t i = 0; i < n_cell; ++i)
                     {
-                      grid_connectivity[i][0] = counter;
-                      grid_connectivity[i][1] = counter + 1;
-                      grid_connectivity[i][2] = counter + 2;
-                      grid_connectivity[i][3] = counter + 3;
-                      grid_connectivity[i][4] = counter + 4;
-                      grid_connectivity[i][5] = counter + 5;
-                      grid_connectivity[i][6] = counter + 6;
-                      grid_connectivity[i][7] = counter + 7;
+                      connectivity[i*pow_2_dim+0] = static_cast<vtu11::VtkIndexType>(counter);
+                      connectivity[i*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(counter + 1);
+                      connectivity[i*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(counter + 2);
+                      connectivity[i*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(counter + 3);
+                      connectivity[i*pow_2_dim+4] = static_cast<vtu11::VtkIndexType>(counter + 4);
+                      connectivity[i*pow_2_dim+5] = static_cast<vtu11::VtkIndexType>(counter + 5);
+                      connectivity[i*pow_2_dim+6] = static_cast<vtu11::VtkIndexType>(counter + 6);
+                      connectivity[i*pow_2_dim+7] = static_cast<vtu11::VtkIndexType>(counter + 7);
                       counter = counter + 8;
                       std::cout << "[4/6] Building the grid: stage 3 of 3 [" << (static_cast<double>(i)/static_cast<double>(n_cell))*100.0 << "%]                       \r";
                       std::cout.flush();
@@ -1713,7 +1715,7 @@ int main(int argc, char **argv)
           grid_z.resize(n_p);
           grid_depth_wrt_surface.resize(n_p);
           grid_depth_wrt_reference.resize(n_p);
-          grid_connectivity.resize(n_cell,std::vector<size_t>(n_v));
+          //grid_connectivity.resize(n_cell,std::vector<size_t>(n_v));
 
 
           for (size_t i = 0; i < n_cell_z + 1; ++i)
@@ -1772,7 +1774,7 @@ int main(int argc, char **argv)
                 {
                   for (size_t k = 0; k < shell_n_v; ++k)
                     {
-                      grid_connectivity[j][k] = shell_grid_connectivity[counter][k] + i * shell_n_p;
+                      connectivity[j*pow_2_dim+k] = static_cast<vtu11::VtkIndexType>(shell_grid_connectivity[counter][k] + i * shell_n_p);
                     }
                   counter++;
                 }
@@ -1784,7 +1786,7 @@ int main(int argc, char **argv)
                   for (size_t k = shell_n_v ; k < 2 * shell_n_v; ++k)
                     {
                       WBAssert(k-shell_n_v < shell_grid_connectivity[counter].size(), "k - shell_n_v is larger then shell_grid_connectivity[counter]: k= " << k << ", shell_grid_connectivity[counter].size() = " << shell_grid_connectivity[counter].size());
-                      grid_connectivity[j][k] = shell_grid_connectivity[counter][k-shell_n_v] + (i+1) * shell_n_p;
+                      connectivity[j*pow_2_dim+k] = static_cast<vtu11::VtkIndexType>(shell_grid_connectivity[counter][k-shell_n_v] + (i+1) * shell_n_p);
                     }
                   counter++;
                 }
@@ -1829,29 +1831,29 @@ int main(int argc, char **argv)
         }
       std::cout << "[5/6] Preparing to write the paraview file: stage 2 of 6, converting the connectivity                              \r";
       std::cout.flush();
-      const size_t pow_2_dim = dim == 2 ? 4 : 8;
-      std::vector<vtu11::VtkIndexType> connectivity(n_cell*pow_2_dim);
-      if (dim == 2)
-        for (size_t i = 0; i < n_cell; ++i)
-          {
-            connectivity[i*pow_2_dim] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][0]);
-            connectivity[i*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][1]);
-            connectivity[i*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][2]);
-            connectivity[i*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][3]);
-          }
-      else
-        for (size_t i = 0; i < n_cell; ++i)
-          {
+      //const size_t pow_2_dim = dim == 2 ? 4 : 8;
+      //std::vector<vtu11::VtkIndexType> connectivity(n_cell*pow_2_dim);
+      //if (dim == 2)
+      //  for (size_t i = 0; i < n_cell; ++i)
+      //    {
+      //      connectivity[i*pow_2_dim] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][0]);
+      //      connectivity[i*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][1]);
+      //      connectivity[i*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][2]);
+      //      connectivity[i*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][3]);
+      //    }
+      //else
+      //  for (size_t i = 0; i < n_cell; ++i)
+      //    {
 
-            connectivity[i*pow_2_dim] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][0]);
-            connectivity[i*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][1]);
-            connectivity[i*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][2]);
-            connectivity[i*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][3]);
-            connectivity[i*pow_2_dim+4] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][4]);
-            connectivity[i*pow_2_dim+5] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][5]);
-            connectivity[i*pow_2_dim+6] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][6]);
-            connectivity[i*pow_2_dim+7] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][7]);
-          }
+      //      connectivity[i*pow_2_dim] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][0]);
+      //      connectivity[i*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][1]);
+      //      connectivity[i*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][2]);
+      //      connectivity[i*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][3]);
+      //      connectivity[i*pow_2_dim+4] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][4]);
+      //      connectivity[i*pow_2_dim+5] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][5]);
+      //      connectivity[i*pow_2_dim+6] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][6]);
+      //      connectivity[i*pow_2_dim+7] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][7]);
+      //    }
       std::cout << "[5/6] Preparing to write the paraview file: stage 3 of 6, creating the offsets                              \r";
       std::cout.flush();
       std::vector<vtu11::VtkIndexType> offsets(n_cell);

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -683,7 +683,7 @@ int main(int argc, char **argv)
 
                       world->properties(std::array<double,2>({{grid_x[counter],grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                       const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                      std::fill(topo_output.begin(), topo_output.end(), 0);
                       const double domain_height = z_max - z_min + topography;
                       const double cell_height = domain_height / static_cast<double>(n_cell_z);
                       grid_z[counter] = z_min + static_cast<double>(j) * cell_height;
@@ -709,7 +709,7 @@ int main(int argc, char **argv)
                               grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                               world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input, topo_output);
                               const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                              std::fill(topo_output.begin(), topo_output.end(), 0);
                               const double domain_height = z_max - z_min + topography;
                               const double cell_height = domain_height / static_cast<double>(n_cell_z);
                               grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -737,7 +737,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -753,7 +753,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -769,7 +769,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography =topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -785,7 +785,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -801,7 +801,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -817,7 +817,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -833,7 +833,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -849,7 +849,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -963,7 +963,7 @@ int main(int argc, char **argv)
                   const double grid_depth_wrt_surface_local = z_max - std::sqrt(grid_x_rad * grid_x_rad + grid_z_rad * grid_z_rad);
                   world->properties(std::array<double,2>({{grid_x_rad,grid_z_rad}}), grid_depth_wrt_surface_local, topo_input,topo_output);
                   const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                  std::fill(topo_output.begin(), topo_output.end(), 0);
 
                   const double outer_circumference_local = 2.0 * Consts::PI * (z_max+topography);
                   const double cell_height_local = (z_max - z_min + topography) / static_cast<double>(n_cell_z);
@@ -1062,7 +1062,7 @@ int main(int argc, char **argv)
                       const double z = radius * sin_long;
                       world->properties(std::array<double,2>({{x,z}}), 0, topo_input,topo_output);
                       const double topography =topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                      std::fill(topo_output.begin(), topo_output.end(), 0);
 
                       domain_height [counter]= outer_radius + topography - inner_radius;
                       cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1101,7 +1101,7 @@ int main(int argc, char **argv)
                               const double z = radius * sin_lat;
                               world->properties({{x,y,z}}, 0, topo_input,topo_output);
                               const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                              std::fill(topo_output.begin(), topo_output.end(), 0);
 
                               domain_height[counter] = outer_radius + topography - inner_radius;
                               cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1137,7 +1137,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1160,7 +1160,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography =topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1183,7 +1183,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1206,7 +1206,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography =topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1229,7 +1229,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1250,7 +1250,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1271,7 +1273,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1292,7 +1296,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1914,10 +1920,10 @@ int main(int argc, char **argv)
         {
           pool.parallel_for(0, n_p, [&] (size_t i)
           {
-                            //std::cout << "E: properties.size() = " << properties.size() << ", world->properties_output_size(properties) " << world->properties_output_size(properties) << std::endl;
+            //std::cout << "E: properties.size() = " << properties.size() << ", world->properties_output_size(properties) " << world->properties_output_size(properties) << std::endl;
             thread_local static  std::vector<double> output(world->properties_output_size(properties));
             std::fill(topo_output.begin(), topo_output.end(), 0);
-                            //std::cout << "F: output.size() = " << output.size() << std::endl;
+            //std::cout << "F: output.size() = " << output.size() << std::endl;
 
             const std::array<double,2> coords = {{grid_x[i], grid_z[i]}};
             world->properties(coords, grid_depth_wrt_surface[i],properties,output);

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -681,9 +681,9 @@ int main(int argc, char **argv)
                       grid_z[counter] = z_min + static_cast<double>(j) * dz;
                       grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(j) * dz;
 
+                      std::fill(topo_output.begin(), topo_output.end(), 0);
                       world->properties(std::array<double,2>({{grid_x[counter],grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                       const double topography = topo_output[0];
-                      std::fill(topo_output.begin(), topo_output.end(), 0);
                       const double domain_height = z_max - z_min + topography;
                       const double cell_height = domain_height / static_cast<double>(n_cell_z);
                       grid_z[counter] = z_min + static_cast<double>(j) * cell_height;
@@ -707,9 +707,9 @@ int main(int argc, char **argv)
                               grid_y[counter] = y_min + static_cast<double>(j) * dy;
                               grid_z[counter] = z_min + static_cast<double>(k) * dz;
                               grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
+                              std::fill(topo_output.begin(), topo_output.end(), 0);
                               world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input, topo_output);
                               const double topography = topo_output[0];
-                              std::fill(topo_output.begin(), topo_output.end(), 0);
                               const double domain_height = z_max - z_min + topography;
                               const double cell_height = domain_height / static_cast<double>(n_cell_z);
                               grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -735,9 +735,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + static_cast<double>(j) * dy;
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -751,9 +751,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + static_cast<double>(j) * dy;
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -767,9 +767,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + (static_cast<double>(j) + 1.0) * dy;
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography =topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -783,9 +783,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + (static_cast<double>(j) + 1.0) * dy;
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -799,9 +799,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + static_cast<double>(j) * dy;
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -815,9 +815,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + static_cast<double>(j) * dy;
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -831,9 +831,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + (static_cast<double>(j) + 1.0) * dy;
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -847,9 +847,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + (static_cast<double>(j) + 1.0) * dy;
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -961,9 +961,9 @@ int main(int argc, char **argv)
                   const double grid_x_rad = FT::cos(theta) * (z_min + grid_z_cart);
                   const double grid_z_rad = FT::sin(theta) * (z_min + grid_z_cart);
                   const double grid_depth_wrt_surface_local = z_max - std::sqrt(grid_x_rad * grid_x_rad + grid_z_rad * grid_z_rad);
+                  std::fill(topo_output.begin(), topo_output.end(), 0);
                   world->properties(std::array<double,2>({{grid_x_rad,grid_z_rad}}), grid_depth_wrt_surface_local, topo_input,topo_output);
                   const double topography = topo_output[0];
-                  std::fill(topo_output.begin(), topo_output.end(), 0);
 
                   const double outer_circumference_local = 2.0 * Consts::PI * (z_max+topography);
                   const double cell_height_local = (z_max - z_min + topography) / static_cast<double>(n_cell_z);
@@ -1060,9 +1060,9 @@ int main(int argc, char **argv)
 
                       const double x = radius * cos_long;
                       const double z = radius * sin_long;
+                      std::fill(topo_output.begin(), topo_output.end(), 0);
                       world->properties(std::array<double,2>({{x,z}}), 0, topo_input,topo_output);
                       const double topography =topo_output[0];
-                      std::fill(topo_output.begin(), topo_output.end(), 0);
 
                       domain_height [counter]= outer_radius + topography - inner_radius;
                       cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1099,9 +1099,9 @@ int main(int argc, char **argv)
                               const double x = radius * cos_lat * cos_long;
                               const double y = radius * cos_lat * sin_long;
                               const double z = radius * sin_lat;
+                              std::fill(topo_output.begin(), topo_output.end(), 0);
                               world->properties({{x,y,z}}, 0, topo_input,topo_output);
                               const double topography = topo_output[0];
-                              std::fill(topo_output.begin(), topo_output.end(), 0);
 
                               domain_height[counter] = outer_radius + topography - inner_radius;
                               cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1135,9 +1135,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1158,9 +1158,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography =topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1181,9 +1181,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1204,9 +1204,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography =topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1227,9 +1227,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1250,9 +1250,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1273,9 +1273,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1296,9 +1296,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
+                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1749,8 +1749,10 @@ int main(int argc, char **argv)
                   grid_z[j] = temp_shell_grid_z[counter];
                   grid_depth_wrt_surface[j] = outer_radius - std::sqrt(grid_x[j] * grid_x[j] + grid_y[j] * grid_y[j] + grid_z[j] * grid_z[j]);
                   grid_depth_wrt_surface[j] = (std::fabs(grid_depth_wrt_surface[j]) < 1e-8 ? 0 : grid_depth_wrt_surface[j]);
+                  std::fill(topo_output.begin(), topo_output.end(), 0);
                   world->properties({{grid_x[j],grid_y[j],grid_z[j]}}, grid_depth_wrt_surface[counter], topo_input, topo_output);
                   const double topography = topo_output[0];
+
 
                   grid_x[j] = temp_shell_grid_x[counter]+topography*(double(i)/double(n_cell_z));
                   grid_y[j] = temp_shell_grid_y[counter]+topography*(double(i)/double(n_cell_z));
@@ -1921,10 +1923,8 @@ int main(int argc, char **argv)
         {
           pool.parallel_for(0, n_p, [&] (size_t i)
           {
-            //std::cout << "E: properties.size() = " << properties.size() << ", world->properties_output_size(properties) " << world->properties_output_size(properties) << std::endl;
             thread_local static  std::vector<double> output(world->properties_output_size(properties));
             std::fill(output.begin(), output.end(), 0);
-            //std::cout << "F: output.size() = " << output.size() << std::endl;
 
             const std::array<double,2> coords = {{grid_x[i], grid_z[i]}};
             world->properties(coords, grid_depth_wrt_surface[i],properties,output);

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -683,7 +683,7 @@ int main(int argc, char **argv)
 
                       world->properties(std::array<double,2>({{grid_x[counter],grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                       const double topography = topo_output[0];
-                      topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                       const double domain_height = z_max - z_min + topography;
                       const double cell_height = domain_height / static_cast<double>(n_cell_z);
                       grid_z[counter] = z_min + static_cast<double>(j) * cell_height;
@@ -709,7 +709,7 @@ int main(int argc, char **argv)
                               grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                               world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input, topo_output);
                               const double topography = topo_output[0];
-                              topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                               const double domain_height = z_max - z_min + topography;
                               const double cell_height = domain_height / static_cast<double>(n_cell_z);
                               grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -737,7 +737,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -753,7 +753,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -769,7 +769,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography =topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -785,7 +785,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -801,7 +801,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -817,7 +817,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -833,7 +833,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -849,7 +849,7 @@ int main(int argc, char **argv)
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
                                 world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -963,7 +963,7 @@ int main(int argc, char **argv)
                   const double grid_depth_wrt_surface_local = z_max - std::sqrt(grid_x_rad * grid_x_rad + grid_z_rad * grid_z_rad);
                   world->properties(std::array<double,2>({{grid_x_rad,grid_z_rad}}), grid_depth_wrt_surface_local, topo_input,topo_output);
                   const double topography = topo_output[0];
-                  topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
 
                   const double outer_circumference_local = 2.0 * Consts::PI * (z_max+topography);
                   const double cell_height_local = (z_max - z_min + topography) / static_cast<double>(n_cell_z);
@@ -1062,7 +1062,7 @@ int main(int argc, char **argv)
                       const double z = radius * sin_long;
                       world->properties(std::array<double,2>({{x,z}}), 0, topo_input,topo_output);
                       const double topography =topo_output[0];
-                      topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
 
                       domain_height [counter]= outer_radius + topography - inner_radius;
                       cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1101,7 +1101,7 @@ int main(int argc, char **argv)
                               const double z = radius * sin_lat;
                               world->properties({{x,y,z}}, 0, topo_input,topo_output);
                               const double topography = topo_output[0];
-                              topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
 
                               domain_height[counter] = outer_radius + topography - inner_radius;
                               cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1137,7 +1137,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1160,7 +1160,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography =topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1183,7 +1183,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1206,7 +1206,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography =topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1229,7 +1229,7 @@ int main(int argc, char **argv)
                                 const double z = radius * FT::sin(latitutde);
                                 world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
                                 const double topography = topo_output[0];
-                                topo_output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1914,8 +1914,10 @@ int main(int argc, char **argv)
         {
           pool.parallel_for(0, n_p, [&] (size_t i)
           {
+                            //std::cout << "E: properties.size() = " << properties.size() << ", world->properties_output_size(properties) " << world->properties_output_size(properties) << std::endl;
             thread_local static  std::vector<double> output(world->properties_output_size(properties));
-            output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
+                            //std::cout << "F: output.size() = " << output.size() << std::endl;
 
             const std::array<double,2> coords = {{grid_x[i], grid_z[i]}};
             world->properties(coords, grid_depth_wrt_surface[i],properties,output);
@@ -1933,7 +1935,6 @@ int main(int argc, char **argv)
               {
                 data_set[6+c+output_densities][i] = output[6+c+output_densities];
               }
-            output.clear();
           });
         }
       else
@@ -1941,7 +1942,7 @@ int main(int argc, char **argv)
           pool.parallel_for(0, n_p, [&] (size_t i)
           {
             thread_local static  std::vector<double> output(world->properties_output_size(properties));
-            output.clear();
+            std::fill(topo_output.begin(), topo_output.end(), 0);
             const std::array<double,3> coords = {{grid_x[i], grid_y[i], grid_z[i]}};
             world->properties(coords, grid_depth_wrt_surface[i],properties,output);
             data_set[2][i] = output[0];
@@ -1958,7 +1959,6 @@ int main(int argc, char **argv)
               {
                 data_set[6+c+output_densities][i] = output[6+c+output_densities];
               }
-            output.clear();
           });
         }
       std::cout << "[6/6] Writing the paraview file                                                                                \r";

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -1749,7 +1749,8 @@ int main(int argc, char **argv)
                   grid_z[j] = temp_shell_grid_z[counter];
                   grid_depth_wrt_surface[j] = outer_radius - std::sqrt(grid_x[j] * grid_x[j] + grid_y[j] * grid_y[j] + grid_z[j] * grid_z[j]);
                   grid_depth_wrt_surface[j] = (std::fabs(grid_depth_wrt_surface[j]) < 1e-8 ? 0 : grid_depth_wrt_surface[j]);
-                  const double topography = world->properties({{grid_x[j],grid_y[j],grid_z[j]}}, grid_depth_wrt_surface[counter], topo_input)[0];
+                  world->properties({{grid_x[j],grid_y[j],grid_z[j]}}, grid_depth_wrt_surface[counter], topo_input, topo_output);
+                  const double topography = topo_output[0];
 
                   grid_x[j] = temp_shell_grid_x[counter]+topography*(double(i)/double(n_cell_z));
                   grid_y[j] = temp_shell_grid_y[counter]+topography*(double(i)/double(n_cell_z));
@@ -1922,7 +1923,7 @@ int main(int argc, char **argv)
           {
             //std::cout << "E: properties.size() = " << properties.size() << ", world->properties_output_size(properties) " << world->properties_output_size(properties) << std::endl;
             thread_local static  std::vector<double> output(world->properties_output_size(properties));
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+            std::fill(output.begin(), output.end(), 0);
             //std::cout << "F: output.size() = " << output.size() << std::endl;
 
             const std::array<double,2> coords = {{grid_x[i], grid_z[i]}};
@@ -1948,7 +1949,7 @@ int main(int argc, char **argv)
           pool.parallel_for(0, n_p, [&] (size_t i)
           {
             thread_local static  std::vector<double> output(world->properties_output_size(properties));
-            std::fill(topo_output.begin(), topo_output.end(), 0);
+            std::fill(output.begin(), output.end(), 0);
             const std::array<double,3> coords = {{grid_x[i], grid_y[i], grid_z[i]}};
             world->properties(coords, grid_depth_wrt_surface[i],properties,output);
             data_set[2][i] = output[0];
@@ -1989,7 +1990,6 @@ int main(int argc, char **argv)
 
             vtu11::Vtu11UnstructuredMesh filtered_mesh {filtered_points, filtered_connectivity, filtered_offsets, filtered_types};
             std::vector<vtu11::DataSetData> filtered_data_set;
-            //std::cout << "flag 6: filtered_mesh.points.size() = " << filtered_mesh.points_.size() <<std::endl;
             filter_vtu_mesh(static_cast<int>(dim), include_tag, mesh, data_set, filtered_mesh, filtered_data_set);
             vtu11::writeVtu( file_without_extension + ".filtered.vtu", filtered_mesh, dataSetInfo, filtered_data_set, vtu_output_format );
           }

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -634,7 +634,7 @@ int main(int argc, char **argv)
       /**
        * Begin making the grid
        */
-      std::vector<std::array<unsigned int,3>> topo_input = {{{6,0,0}}};
+      const std::vector<std::array<unsigned int,3>> topo_input = {{{6,0,0}}};
       std::cout << "[4/6] Building the grid...                        \r";
       std::cout.flush();
       WBAssertThrow(dim == 2 || dim == 3, "Dimension should be 2d or 3d.");

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -624,7 +624,7 @@ int main(int argc, char **argv)
       std::vector<double> grid_depth_wrt_reference(0);
 
       const size_t pow_2_dim = dim == 2 ? 4 : 8;
-      std::vector<vtu11::VtkIndexType> connectivity(n_cell*pow_2_dim);
+      std::vector<vtu11::VtkIndexType> connectivity(0);//n_cell*pow_2_dim);
       //std::vector<std::vector<size_t> > grid_connectivity(0);
 
 
@@ -868,6 +868,8 @@ int main(int argc, char **argv)
 
           // compute connectivity. Local to global mapping.
           //grid_connectivity.resize(n_cell,std::vector<size_t>((dim-1)*4));
+           connectivity.resize(n_cell*pow_2_dim);
+
 
           counter = 0;
           if (dim == 2)
@@ -985,6 +987,8 @@ int main(int argc, char **argv)
             }
 
           //grid_connectivity.resize(n_cell,std::vector<size_t>(4));
+                 connectivity.resize(n_cell*pow_2_dim);
+
           counter = 0;
           for (size_t j = 1; j <= n_cell_z; ++j)
             {
@@ -1348,6 +1352,7 @@ int main(int argc, char **argv)
           // compute connectivity. Local to global mapping.
           const std::vector<size_t> tmp_vector((dim-1)*4);
           //grid_connectivity.resize(n_cell,tmp_vector);
+                 connectivity.resize(n_cell*pow_2_dim);
 
           counter = 0;
           if (dim == 2)
@@ -1716,6 +1721,7 @@ int main(int argc, char **argv)
           grid_depth_wrt_surface.resize(n_p);
           grid_depth_wrt_reference.resize(n_p);
           //grid_connectivity.resize(n_cell,std::vector<size_t>(n_v));
+                 connectivity.resize(n_cell*pow_2_dim);
 
 
           for (size_t i = 0; i < n_cell_z + 1; ++i)

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -1706,7 +1706,7 @@ int main(int argc, char **argv)
           std::vector<double> temp_shell_grid_y(shell_n_p);
           std::vector<double> temp_shell_grid_z(shell_n_p);
 
-          const size_t n_v = shell_n_v * 2;
+          //const size_t n_v = shell_n_v * 2;
           n_p = (n_cell_z + 1) * shell_n_p;
           n_cell = (n_cell_z) * shell_n_cell;
 

--- a/source/gwb-grid/main.cc
+++ b/source/gwb-grid/main.cc
@@ -635,6 +635,7 @@ int main(int argc, char **argv)
        * Begin making the grid
        */
       const std::vector<std::array<unsigned int,3>> topo_input = {{{6,0,0}}};
+      std::vector<double> topo_output(world->properties_output_size(topo_input));
       std::cout << "[4/6] Building the grid...                        \r";
       std::cout.flush();
       WBAssertThrow(dim == 2 || dim == 3, "Dimension should be 2d or 3d.");
@@ -680,7 +681,9 @@ int main(int argc, char **argv)
                       grid_z[counter] = z_min + static_cast<double>(j) * dz;
                       grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(j) * dz;
 
-                      const double topography = world->properties(std::array<double,2>({{grid_x[counter],grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                      world->properties(std::array<double,2>({{grid_x[counter],grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
+                      const double topography = topo_output[0];
+                      topo_output.clear();
                       const double domain_height = z_max - z_min + topography;
                       const double cell_height = domain_height / static_cast<double>(n_cell_z);
                       grid_z[counter] = z_min + static_cast<double>(j) * cell_height;
@@ -704,8 +707,9 @@ int main(int argc, char **argv)
                               grid_y[counter] = y_min + static_cast<double>(j) * dy;
                               grid_z[counter] = z_min + static_cast<double>(k) * dz;
                               grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
-
-                              const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                              world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input, topo_output);
+                              const double topography = topo_output[0];
+                              topo_output.clear();
                               const double domain_height = z_max - z_min + topography;
                               const double cell_height = domain_height / static_cast<double>(n_cell_z);
                               grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -731,8 +735,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + static_cast<double>(j) * dy;
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
-
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -746,8 +751,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + static_cast<double>(j) * dy;
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
-
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -761,8 +767,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + (static_cast<double>(j) + 1.0) * dy;
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
-
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography =topo_output[0];
+                                topo_output.clear();
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -776,8 +783,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + (static_cast<double>(j) + 1.0) * dy;
                                 grid_z[counter] = z_min + static_cast<double>(k) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - static_cast<double>(k) * dz;
-
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + static_cast<double>(k) * cell_height;
@@ -791,8 +799,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + static_cast<double>(j) * dy;
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
-
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -806,8 +815,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + static_cast<double>(j) * dy;
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
-
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -821,8 +831,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + (static_cast<double>(j) + 1.0) * dy;
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
-
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -836,8 +847,9 @@ int main(int argc, char **argv)
                                 grid_y[counter] = y_min + (static_cast<double>(j) + 1.0) * dy;
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * dz;
                                 grid_depth_wrt_surface[counter] = (surface - z_min) - (static_cast<double>(k) + 1.0) * dz;
-
-                                const double topography = world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties(std::array<double,3>({{grid_x[counter],grid_y[counter], grid_z[counter]}}), grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 const double domain_height = z_max - z_min + topography;
                                 const double cell_height = domain_height / static_cast<double>(n_cell_z);
                                 grid_z[counter] = z_min + (static_cast<double>(k) + 1.0) * cell_height;
@@ -949,8 +961,9 @@ int main(int argc, char **argv)
                   const double grid_x_rad = FT::cos(theta) * (z_min + grid_z_cart);
                   const double grid_z_rad = FT::sin(theta) * (z_min + grid_z_cart);
                   const double grid_depth_wrt_surface_local = z_max - std::sqrt(grid_x_rad * grid_x_rad + grid_z_rad * grid_z_rad);
-
-                  const double topography = world->properties(std::array<double,2>({{grid_x_rad,grid_z_rad}}), grid_depth_wrt_surface_local, topo_input)[0];
+                  world->properties(std::array<double,2>({{grid_x_rad,grid_z_rad}}), grid_depth_wrt_surface_local, topo_input,topo_output);
+                  const double topography = topo_output[0];
+                  topo_output.clear();
 
                   const double outer_circumference_local = 2.0 * Consts::PI * (z_max+topography);
                   const double cell_height_local = (z_max - z_min + topography) / static_cast<double>(n_cell_z);
@@ -1047,7 +1060,9 @@ int main(int argc, char **argv)
 
                       const double x = radius * cos_long;
                       const double z = radius * sin_long;
-                      const double topography = world->properties(std::array<double,2>({{x,z}}), 0, topo_input)[0];
+                      world->properties(std::array<double,2>({{x,z}}), 0, topo_input,topo_output);
+                      const double topography =topo_output[0];
+                      topo_output.clear();
 
                       domain_height [counter]= outer_radius + topography - inner_radius;
                       cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1084,8 +1099,9 @@ int main(int argc, char **argv)
                               const double x = radius * cos_lat * cos_long;
                               const double y = radius * cos_lat * sin_long;
                               const double z = radius * sin_lat;
-
-                              const double topography = world->properties({{x,y,z}}, 0, topo_input)[0];
+                              world->properties({{x,y,z}}, 0, topo_input,topo_output);
+                              const double topography = topo_output[0];
+                              topo_output.clear();
 
                               domain_height[counter] = outer_radius + topography - inner_radius;
                               cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
@@ -1119,7 +1135,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1140,7 +1158,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography =topo_output[0];
+                                topo_output.clear();
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1161,7 +1181,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1182,7 +1204,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography =topo_output[0];
+                                topo_output.clear();
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1203,7 +1227,9 @@ int main(int argc, char **argv)
                                 const double x = radius * FT::cos(latitutde) * FT::cos(longitude);
                                 const double y = radius * FT::cos(latitutde) * FT::sin(longitude);
                                 const double z = radius * FT::sin(latitutde);
-                                const double topography = world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input)[0];
+                                world->properties({{x,y,z}}, grid_depth_wrt_surface[counter], topo_input,topo_output);
+                                const double topography = topo_output[0];
+                                topo_output.clear();
                                 domain_height[counter] = outer_radius + topography - inner_radius;
                                 cell_height[counter] = domain_height[counter] / static_cast<double>(n_cell_z);
                                 grid_z[counter] = inner_radius + (static_cast<double>(k) - 1.0) * cell_height[counter];
@@ -1312,7 +1338,8 @@ int main(int argc, char **argv)
           std::cout << "[4/6] Building the grid: stage 3 of 3                        \r";
           std::cout.flush();
           // compute connectivity. Local to global mapping.
-          grid_connectivity.resize(n_cell,std::vector<size_t>((dim-1)*4));
+          const std::vector<size_t> tmp_vector((dim-1)*4);
+          grid_connectivity.resize(n_cell,tmp_vector);
 
           counter = 0;
           if (dim == 2)
@@ -1887,8 +1914,10 @@ int main(int argc, char **argv)
         {
           pool.parallel_for(0, n_p, [&] (size_t i)
           {
+            thread_local static  std::vector<double> output(world->properties_output_size(properties));
+
             const std::array<double,2> coords = {{grid_x[i], grid_z[i]}};
-            std::vector<double> output = world->properties(coords, grid_depth_wrt_surface[i],properties);
+            world->properties(coords, grid_depth_wrt_surface[i],properties,output);
             data_set[2][i] = output[0];
             data_set[3][i] = output[1];
             data_set[4][3*i] = output[2];
@@ -1903,14 +1932,16 @@ int main(int argc, char **argv)
               {
                 data_set[6+c+output_densities][i] = output[6+c+output_densities];
               }
+            output.clear();
           });
         }
       else
         {
           pool.parallel_for(0, n_p, [&] (size_t i)
           {
+            thread_local static  std::vector<double> output(world->properties_output_size(properties));
             const std::array<double,3> coords = {{grid_x[i], grid_y[i], grid_z[i]}};
-            std::vector<double> output = world->properties(coords, grid_depth_wrt_surface[i],properties);
+            world->properties(coords, grid_depth_wrt_surface[i],properties,output);
             data_set[2][i] = output[0];
             data_set[3][i] = output[1];
             data_set[4][3*i] = output[2];
@@ -1925,6 +1956,7 @@ int main(int argc, char **argv)
               {
                 data_set[6+c+output_densities][i] = output[6+c+output_densities];
               }
+            output.clear();
           });
         }
       std::cout << "[6/6] Writing the paraview file                                                                                \r";

--- a/source/world_builder/features/continental_plate.cc
+++ b/source/world_builder/features/continental_plate.cc
@@ -258,8 +258,8 @@ namespace WorldBuilder
                             {
                               for (const auto &temperature_model: temperature_models)
                                 {
-                    //std::cout << "C: i_property = " << i_property << ", entry_in_output.size() = " << entry_in_output.size() << ", output.size() = " << output.size() << std::endl;
-                    //std::cout << "D: entry_in_output[i_property] = " << entry_in_output[i_property] << std::endl;
+                                  //std::cout << "C: i_property = " << i_property << ", entry_in_output.size() = " << entry_in_output.size() << ", output.size() = " << output.size() << std::endl;
+                                  //std::cout << "D: entry_in_output[i_property] = " << entry_in_output[i_property] << std::endl;
                                   output[entry_in_output[i_property]] = temperature_model->get_temperature(position_in_cartesian_coordinates,
                                                                                                            position_in_natural_coordinates,
                                                                                                            depth,

--- a/source/world_builder/features/continental_plate.cc
+++ b/source/world_builder/features/continental_plate.cc
@@ -258,6 +258,8 @@ namespace WorldBuilder
                             {
                               for (const auto &temperature_model: temperature_models)
                                 {
+                    //std::cout << "C: i_property = " << i_property << ", entry_in_output.size() = " << entry_in_output.size() << ", output.size() = " << output.size() << std::endl;
+                    //std::cout << "D: entry_in_output[i_property] = " << entry_in_output[i_property] << std::endl;
                                   output[entry_in_output[i_property]] = temperature_model->get_temperature(position_in_cartesian_coordinates,
                                                                                                            position_in_natural_coordinates,
                                                                                                            depth,

--- a/source/world_builder/features/continental_plate.cc
+++ b/source/world_builder/features/continental_plate.cc
@@ -258,8 +258,6 @@ namespace WorldBuilder
                             {
                               for (const auto &temperature_model: temperature_models)
                                 {
-                                  //std::cout << "C: i_property = " << i_property << ", entry_in_output.size() = " << entry_in_output.size() << ", output.size() = " << output.size() << std::endl;
-                                  //std::cout << "D: entry_in_output[i_property] = " << entry_in_output[i_property] << std::endl;
                                   output[entry_in_output[i_property]] = temperature_model->get_temperature(position_in_cartesian_coordinates,
                                                                                                            position_in_natural_coordinates,
                                                                                                            depth,

--- a/source/world_builder/utilities.cc
+++ b/source/world_builder/utilities.cc
@@ -25,8 +25,6 @@
 #include <iostream>
 #include <limits>
 #include <sstream>
-#include <list>
-#include <mutex>
 
 #ifdef WB_WITH_MPI
 // we don't need the c++ MPI wrappers
@@ -36,7 +34,6 @@
 #endif
 
 #include "world_builder/nan.h"
-#include "world_builder/utilities.h"
 #include <world_builder/coordinate_system.h>
 
 
@@ -45,63 +42,6 @@ namespace WorldBuilder
   namespace Utilities
   {
 
-    template <typename T>
-    class ScratchSpace
-    {
-      public:
-        class ScopedScratchObject
-        {
-          public:
-            ScopedScratchObject (ScratchSpace<T> &space_)
-              : space (space_),
-                t (space.get_object_from_pool())
-            {}
-
-            ~ScopedScratchObject()
-            {
-              space.return_object_to_pool(t);
-            }
-
-            operator T &()
-            {
-              return t;
-            }
-
-          private:
-            ScratchSpace &space;
-            T &t;
-        };
-
-        T &get_object_from_pool()
-        {
-          std::lock_guard<std::mutex> lock(mutex);
-          for (auto &pair : object_list)
-            if (pair.second == false)
-              {
-                pair.second = true;
-                return pair.first;
-              }
-
-          object_list.emplace_back (T(), true);
-          return object_list.back().first;
-        }
-
-        void return_object_to_pool (T &t)
-        {
-          std::lock_guard<std::mutex> lock(mutex);
-          for (auto &pair : object_list)
-            if (&pair.first == &t)
-              {
-                pair.second = false;
-                return;
-              }
-          // TODO: assert that we never get here
-        }
-
-      private:
-        std::mutex mutex;
-        std::list<std::pair<T,bool>> object_list;
-    };
 
     bool
     polygon_contains_point(const std::vector<Point<2> > &point_list,

--- a/source/world_builder/utilities.cc
+++ b/source/world_builder/utilities.cc
@@ -34,6 +34,7 @@
 #endif
 
 #include "world_builder/nan.h"
+#include "world_builder/utilities.h"
 #include <world_builder/coordinate_system.h>
 
 

--- a/source/world_builder/utilities.cc
+++ b/source/world_builder/utilities.cc
@@ -25,6 +25,8 @@
 #include <iostream>
 #include <limits>
 #include <sstream>
+#include <list>
+#include <mutex>
 
 #ifdef WB_WITH_MPI
 // we don't need the c++ MPI wrappers
@@ -42,6 +44,65 @@ namespace WorldBuilder
 {
   namespace Utilities
   {
+
+    template <typename T>
+    class ScratchSpace
+    {
+      public:
+        class ScopedScratchObject
+        {
+          public:
+            ScopedScratchObject (ScratchSpace<T> &space_)
+              : space (space_),
+                t (space.get_object_from_pool())
+            {}
+
+            ~ScopedScratchObject()
+            {
+              space.return_object_to_pool(t);
+            }
+
+            operator T &()
+            {
+              return t;
+            }
+
+          private:
+            ScratchSpace &space;
+            T &t;
+        };
+
+        T &get_object_from_pool()
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          for (auto &pair : object_list)
+            if (pair.second == false)
+              {
+                pair.second = true;
+                return pair.first;
+              }
+
+          object_list.emplace_back (T(), true);
+          return object_list.back().first;
+        }
+
+        void return_object_to_pool (T &t)
+        {
+          std::lock_guard<std::mutex> lock(mutex);
+          for (auto &pair : object_list)
+            if (&pair.first == &t)
+              {
+                pair.second = false;
+                return;
+              }
+          // TODO: assert that we never get here
+        }
+
+      private:
+        std::mutex mutex;
+        std::list<std::pair<T,bool>> object_list;
+    };
+
     bool
     polygon_contains_point(const std::vector<Point<2> > &point_list,
                            const Point<2> &point)

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -507,7 +507,7 @@ namespace WorldBuilder
                     const double depth,
                     const std::vector<std::array<unsigned int,3>> &properties) const
   {
-
+    //std::cout << "G: properties.size() = " << properties.size() << ", World::properties_output_size(properties) = "<< World::properties_output_size(properties) << std::endl;
     std::vector<double> output(World::properties_output_size(properties));
     this->properties(point_,depth,properties,output);
     return output;
@@ -535,10 +535,11 @@ namespace WorldBuilder
     const Objects::NaturalCoordinate natural_coordinate = Objects::NaturalCoordinate(point,*(this->parameters.coordinate_system));
 
     // create output vector
-    thread_local static std::vector<size_t> entry_in_output;
-    entry_in_output.reserve(properties.size());
-    thread_local static std::vector<std::array<unsigned int,3>> properties_local;
-    properties_local.reserve(properties.size());
+    //thread_local static std::vector<size_t> entry_in_output(properties.size(),0);
+    //thread_local static std::vector<std::array<unsigned int,3>> properties_local(properties.size(),{{0,0,0}});
+    std::vector<size_t> entry_in_output(properties.size(),0);
+    std::vector<std::array<unsigned int,3>> properties_local(properties.size(),{{0,0,0}});
+  //std::cout << "H: properties.size() << " << properties.size() << ", entry_in_output.size() = " << entry_in_output.size() << std::endl;
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);
     size_t output_location_index = 0;
     for (unsigned int i_property = 0; i_property < properties.size(); ++i_property)
@@ -548,70 +549,70 @@ namespace WorldBuilder
             case 1: // Temperature
               if (std::fabs(depth) < 2.0 * std::numeric_limits<double>::epsilon() && force_surface_temperature)
                 {
-                  entry_in_output.emplace_back(output_location_index);
-                  output[output.size()]=this->surface_temperature;
+                  entry_in_output[i_property] = output_location_index;
+                  output[output_location_index]=this->surface_temperature;
                   output_location_index++;
                   if (properties.size() == 1)
                     return;
                 }
               else
                 {
-                  entry_in_output.emplace_back(output_location_index);
+                  entry_in_output[i_property] = output_location_index;
                   output[output_location_index] = potential_mantle_temperature * std::exp(((thermal_expansion_coefficient * gravity_norm) / specific_heat) * depth);
                   output_location_index++;
                 }
-              properties_local.emplace_back(properties[i_property]);
+              properties_local[i_property] = properties[i_property];
               break;
             case 2: // composition
-              entry_in_output.emplace_back(output_location_index);
+              entry_in_output[i_property] = output_location_index;
               output[output_location_index] = 0.;
               output_location_index++;
-              properties_local.emplace_back(properties[i_property]);
+              properties_local[i_property] = properties[i_property];
               break;
             case 3: // grains (10 entries per grain)
             {
-              entry_in_output.emplace_back(output_location_index);
+              entry_in_output[i_property] =output_location_index;
               output_location_index+=properties[i_property][2]*10;
               //const std::vector<double> tmp_vector(properties[i_property][2]*10,0.);
               //output.insert(output.end(), tmp_vector.begin(), tmp_vector.end());
-              properties_local.emplace_back(properties[i_property]);
+              properties_local[i_property] =properties[i_property];
               break;
             }
             case 4: // tag
             {
-              entry_in_output.emplace_back(output_location_index);
+              entry_in_output[i_property] = output_location_index;
               output[output_location_index] = -1;
               output_location_index++;
-              properties_local.emplace_back(properties[i_property]);
+              properties_local[i_property] = properties[i_property];
               break;
             }
             case 5: // velocity
             {
-              entry_in_output.emplace_back(output_location_index);
+              entry_in_output[i_property] = output_location_index;
               //output.emplace_back(0);
               //output.emplace_back(0);
               //output.emplace_back(0);
               output_location_index+=3;
-              properties_local.emplace_back(properties[i_property]);
+              properties_local[i_property] = properties[i_property];
               break;
             }
             case 6: // topography
             {
-              entry_in_output.emplace_back(output_location_index);
+              entry_in_output[i_property] = output_location_index;
               //output.emplace_back(0);
               output_location_index++;
-              properties_local.emplace_back(properties[i_property]);
+              properties_local[i_property] = properties[i_property];
               break;
             }
             case 7: // density
             {
-              entry_in_output.emplace_back(output_location_index);
+              entry_in_output[i_property] = output_location_index;
 
               // TODO: If a mantle adiabatic temperature is used then the background
               // density should account for it.
               output[output_location_index] =background_density;
               output_location_index++;
-              properties_local.emplace_back(properties[i_property]);
+              properties_local[i_property] = properties[i_property];
               break;
             }
             default:
@@ -621,6 +622,7 @@ namespace WorldBuilder
                             "Provided property number was: " << properties[i_property][0]);
           }
       }
+  //std::cout << "entry_in_output.size() = " << entry_in_output.size() << ", output.size() = " << output.size() << std::endl;
     for (auto &&it : parameters.features)
       {
         it->properties(point, natural_coordinate, depth, properties_local, gravity_norm, entry_in_output, output);

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -514,9 +514,9 @@ namespace WorldBuilder
     const Objects::NaturalCoordinate natural_coordinate = Objects::NaturalCoordinate(point,*(this->parameters.coordinate_system));
 
     // create output vector
-    std::vector<double> output;
-    std::vector<size_t> entry_in_output;
-    std::vector<std::array<unsigned int,3>> properties_local;
+    std::vector<double> output(World::properties_output_size(properties));
+    std::vector<size_t> entry_in_output(properties.size());
+    std::vector<std::array<unsigned int,3>> properties_local(properties.size());
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);
     for (unsigned int i_property = 0; i_property < properties.size(); ++i_property)
       {

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -537,16 +537,17 @@ namespace WorldBuilder
 
     // create output vector
     static WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>> entry_in_output_space;
-    typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::template ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
     std::vector<size_t> &entry_in_output = entry_in_output_scratch;
     entry_in_output.resize(properties.size(), 0);
-    std::fill(entry_in_output.begin(),entry_in_output.end(),0);
+    std::fill(entry_in_output.begin(), entry_in_output.end(), 0);
 
     static WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>> properties_local_space;
-    typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::ScopedScratchObject properties_local_scratch(properties_local_space);
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::template ScopedScratchObject properties_local_scratch(properties_local_space);
     std::vector<std::array<unsigned int, 3>> &properties_local = properties_local_scratch;
     properties_local.resize(properties.size(), {{0,0,0}});
-    std::fill(properties_local.begin(),properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));
+    std::fill(properties_local.begin(), properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));
+
 
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);
     size_t output_location_index = 0;

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -536,22 +536,22 @@ namespace WorldBuilder
     const Objects::NaturalCoordinate natural_coordinate = Objects::NaturalCoordinate(point,*(this->parameters.coordinate_system));
 
     // create output vector
-    std::vector<size_t> entry_in_output(properties.size(),0);
-    std::vector<std::array<unsigned int,3>> properties_local(properties.size(), {{0,0,0}});
+    //std::vector<size_t> entry_in_output(properties.size(),0);
+    //std::vector<std::array<unsigned int,3>> properties_local(properties.size(), {{0,0,0}});
 
     //std::cout << "entry_in_output" << std::endl;
-    //static WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>> entry_in_output_space;
-    //typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
-    //std::vector<size_t> &entry_in_output = entry_in_output_scratch;
-    //entry_in_output.resize(properties.size(), 0);
-    //std::fill(entry_in_output.begin(), entry_in_output.end(), 0);
+    static WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>> entry_in_output_space;
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
+    std::vector<size_t> &entry_in_output = entry_in_output_scratch;
+    entry_in_output.resize(properties.size(), 0);
+    std::fill(entry_in_output.begin(), entry_in_output.end(), 0);
 
     //std::cout << "properties_local" << std::endl;
-    //static WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>> properties_local_space;
-    //typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::ScopedScratchObject properties_local_scratch(properties_local_space);
-    //std::vector<std::array<unsigned int, 3>> &properties_local = properties_local_scratch;
-    //properties_local.resize(properties.size(), {{0,0,0}});
-    //std::fill(properties_local.begin(), properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));
+    static WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>> properties_local_space;
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::ScopedScratchObject properties_local_scratch(properties_local_space);
+    std::vector<std::array<unsigned int, 3>> &properties_local = properties_local_scratch;
+    properties_local.resize(properties.size(), {{0,0,0}});
+    std::fill(properties_local.begin(), properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));
 
 
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -537,13 +537,13 @@ namespace WorldBuilder
 
     // create output vector
     static WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>> entry_in_output_space;
-    ScratchSpace<std::vector<size_t>>::ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::template ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
     std::vector<size_t> &entry_in_output = entry_in_output_scratch;
     entry_in_output.resize(properties.size(), 0);
     std::fill(entry_in_output.begin(),entry_in_output.end(),0);
 
     static WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>> properties_local_space;
-    ScratchSpace<std::vector<std::array<unsigned int,3>>>::ScopedScratchObject properties_local_scratch(properties_local_space);
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::template ScopedScratchObject properties_local_scratch(properties_local_space);
     std::vector<std::array<unsigned int, 3>> &properties_local = properties_local_scratch;
     properties_local.resize(properties.size(), {{0,0,0}});
     std::fill(properties_local.begin(),properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -507,7 +507,6 @@ namespace WorldBuilder
                     const double depth,
                     const std::vector<std::array<unsigned int,3>> &properties) const
   {
-    //std::cout << "G: properties.size() = " << properties.size() << ", World::properties_output_size(properties) = "<< World::properties_output_size(properties) << std::endl;
     std::vector<double> output(World::properties_output_size(properties));
     this->properties(point_,depth,properties,output);
     return output;
@@ -539,7 +538,6 @@ namespace WorldBuilder
     //thread_local static std::vector<std::array<unsigned int,3>> properties_local(properties.size(),{{0,0,0}});
     std::vector<size_t> entry_in_output(properties.size(),0);
     std::vector<std::array<unsigned int,3>> properties_local(properties.size(), {{0,0,0}});
-    //std::cout << "H: properties.size() << " << properties.size() << ", entry_in_output.size() = " << entry_in_output.size() << std::endl;
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);
     size_t output_location_index = 0;
     for (unsigned int i_property = 0; i_property < properties.size(); ++i_property)

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -538,8 +538,8 @@ namespace WorldBuilder
     //thread_local static std::vector<size_t> entry_in_output(properties.size(),0);
     //thread_local static std::vector<std::array<unsigned int,3>> properties_local(properties.size(),{{0,0,0}});
     std::vector<size_t> entry_in_output(properties.size(),0);
-    std::vector<std::array<unsigned int,3>> properties_local(properties.size(),{{0,0,0}});
-  //std::cout << "H: properties.size() << " << properties.size() << ", entry_in_output.size() = " << entry_in_output.size() << std::endl;
+    std::vector<std::array<unsigned int,3>> properties_local(properties.size(), {{0,0,0}});
+    //std::cout << "H: properties.size() << " << properties.size() << ", entry_in_output.size() = " << entry_in_output.size() << std::endl;
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);
     size_t output_location_index = 0;
     for (unsigned int i_property = 0; i_property < properties.size(); ++i_property)
@@ -622,7 +622,7 @@ namespace WorldBuilder
                             "Provided property number was: " << properties[i_property][0]);
           }
       }
-  //std::cout << "entry_in_output.size() = " << entry_in_output.size() << ", output.size() = " << output.size() << std::endl;
+    //std::cout << "entry_in_output.size() = " << entry_in_output.size() << ", output.size() = " << output.size() << std::endl;
     for (auto &&it : parameters.features)
       {
         it->properties(point, natural_coordinate, depth, properties_local, gravity_norm, entry_in_output, output);

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -537,13 +537,13 @@ namespace WorldBuilder
 
     // create output vector
     static WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>> entry_in_output_space;
-    typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::template ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
     std::vector<size_t> &entry_in_output = entry_in_output_scratch;
     entry_in_output.resize(properties.size(), 0);
     std::fill(entry_in_output.begin(), entry_in_output.end(), 0);
 
     static WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>> properties_local_space;
-    typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::template ScopedScratchObject properties_local_scratch(properties_local_space);
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::ScopedScratchObject properties_local_scratch(properties_local_space);
     std::vector<std::array<unsigned int, 3>> &properties_local = properties_local_scratch;
     properties_local.resize(properties.size(), {{0,0,0}});
     std::fill(properties_local.begin(), properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -18,6 +18,7 @@
 */
 
 #include "world_builder/world.h"
+#include "world_builder/utilities.h"
 
 
 #include "world_builder/config.h"
@@ -34,6 +35,7 @@
 #include "world_builder/types/point.h"
 #include "world_builder/types/int.h"
 
+#include <array>
 #include <iostream>
 #include <world_builder/coordinate_system.h>
 #include <world_builder/objects/distance_from_surface.h>
@@ -534,10 +536,18 @@ namespace WorldBuilder
     const Objects::NaturalCoordinate natural_coordinate = Objects::NaturalCoordinate(point,*(this->parameters.coordinate_system));
 
     // create output vector
-    //thread_local static std::vector<size_t> entry_in_output(properties.size(),0);
-    //thread_local static std::vector<std::array<unsigned int,3>> properties_local(properties.size(),{{0,0,0}});
-    std::vector<size_t> entry_in_output(properties.size(),0);
-    std::vector<std::array<unsigned int,3>> properties_local(properties.size(), {{0,0,0}});
+    static WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>> entry_in_output_space;
+    ScratchSpace<std::vector<size_t>>::ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
+    std::vector<size_t> &entry_in_output = entry_in_output_scratch;
+    entry_in_output.resize(properties.size(), 0);
+    std::fill(entry_in_output.begin(),entry_in_output.end(),0);
+
+    static WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>> properties_local_space;
+    ScratchSpace<std::vector<std::array<unsigned int,3>>>::ScopedScratchObject properties_local_scratch(properties_local_space);
+    std::vector<std::array<unsigned int, 3>> &properties_local = properties_local_scratch;
+    properties_local.resize(properties.size(), {{0,0,0}});
+    std::fill(properties_local.begin(),properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));
+
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);
     size_t output_location_index = 0;
     for (unsigned int i_property = 0; i_property < properties.size(); ++i_property)

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -536,17 +536,22 @@ namespace WorldBuilder
     const Objects::NaturalCoordinate natural_coordinate = Objects::NaturalCoordinate(point,*(this->parameters.coordinate_system));
 
     // create output vector
-    static WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>> entry_in_output_space;
-    typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
-    std::vector<size_t> &entry_in_output = entry_in_output_scratch;
-    entry_in_output.resize(properties.size(), 0);
-    std::fill(entry_in_output.begin(), entry_in_output.end(), 0);
+    std::vector<size_t> entry_in_output(properties.size(),0);
+    std::vector<std::array<unsigned int,3>> properties_local(properties.size(), {{0,0,0}});
 
-    static WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>> properties_local_space;
-    typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::ScopedScratchObject properties_local_scratch(properties_local_space);
-    std::vector<std::array<unsigned int, 3>> &properties_local = properties_local_scratch;
-    properties_local.resize(properties.size(), {{0,0,0}});
-    std::fill(properties_local.begin(), properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));
+    //std::cout << "entry_in_output" << std::endl;
+    //static WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>> entry_in_output_space;
+    //typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
+    //std::vector<size_t> &entry_in_output = entry_in_output_scratch;
+    //entry_in_output.resize(properties.size(), 0);
+    //std::fill(entry_in_output.begin(), entry_in_output.end(), 0);
+
+    //std::cout << "properties_local" << std::endl;
+    //static WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>> properties_local_space;
+    //typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::ScopedScratchObject properties_local_scratch(properties_local_space);
+    //std::vector<std::array<unsigned int, 3>> &properties_local = properties_local_scratch;
+    //properties_local.resize(properties.size(), {{0,0,0}});
+    //std::fill(properties_local.begin(), properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));
 
 
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -537,13 +537,13 @@ namespace WorldBuilder
 
     // create output vector
     static WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>> entry_in_output_space;
-    typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::template ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<size_t>>::ScopedScratchObject entry_in_output_scratch(entry_in_output_space);
     std::vector<size_t> &entry_in_output = entry_in_output_scratch;
     entry_in_output.resize(properties.size(), 0);
     std::fill(entry_in_output.begin(),entry_in_output.end(),0);
 
     static WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>> properties_local_space;
-    typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::template ScopedScratchObject properties_local_scratch(properties_local_space);
+    typename WorldBuilder::Utilities::ScratchSpace<std::vector<std::array<unsigned int,3>>>::ScopedScratchObject properties_local_scratch(properties_local_space);
     std::vector<std::array<unsigned int, 3>> &properties_local = properties_local_scratch;
     properties_local.resize(properties.size(), {{0,0,0}});
     std::fill(properties_local.begin(),properties_local.end(), std::array<unsigned int,3>({{0u,0u,0u}}));

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -514,9 +514,12 @@ namespace WorldBuilder
     const Objects::NaturalCoordinate natural_coordinate = Objects::NaturalCoordinate(point,*(this->parameters.coordinate_system));
 
     // create output vector
-    std::vector<double> output(World::properties_output_size(properties));
-    std::vector<size_t> entry_in_output(properties.size());
-    std::vector<std::array<unsigned int,3>> properties_local(properties.size());
+    std::vector<double> output;
+    output.reserve(World::properties_output_size(properties));
+    std::vector<size_t> entry_in_output;
+    entry_in_output.reserve(properties.size());
+    std::vector<std::array<unsigned int,3>> properties_local;
+    properties_local.reserve(properties.size());
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);
     for (unsigned int i_property = 0; i_property < properties.size(); ++i_property)
       {

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -396,12 +396,21 @@ namespace WorldBuilder
     return n_output_entries;
   }
 
-
-
   std::vector<double>
-  World::properties(const std::array<double, 2> &point,
+  World::properties(const std::array<double, 2> &point_,
                     const double depth,
                     const std::vector<std::array<unsigned int,3>> &properties) const
+  {
+
+    std::vector<double> output(World::properties_output_size(properties));
+    this->properties(point_,depth,properties,output);
+    return output;
+  }
+
+  void
+  World::properties(const std::array<double, 2> &point,
+                    const double depth,
+                    const std::vector<std::array<unsigned int,3>> &properties,std::vector<double> &output) const
   {
     // turn it into a 3d coordinate and call the 3d temperature function
     WBAssertThrow(dim == 2, "This function can only be called when the cross section "
@@ -434,7 +443,8 @@ namespace WorldBuilder
 
     const std::array<double, 3> point_3d_cartesian = this->parameters.coordinate_system->natural_to_cartesian_coordinates(coord_3d.get_array());
 
-    std::vector<double> results = this->properties(point_3d_cartesian, depth, properties);
+    this->properties(point_3d_cartesian, depth, properties,output);
+    std::vector<double> &results = output;
     unsigned int counter = 0;
     for (auto property : properties)
       {
@@ -490,14 +500,25 @@ namespace WorldBuilder
           }
 
       }
-    return results;
   }
-
 
   std::vector<double>
   World::properties(const std::array<double, 3> &point_,
                     const double depth,
                     const std::vector<std::array<unsigned int,3>> &properties) const
+  {
+
+    std::vector<double> output(World::properties_output_size(properties));
+    this->properties(point_,depth,properties,output);
+    return output;
+  }
+
+
+  void
+  World::properties(const std::array<double, 3> &point_,
+                    const double depth,
+                    const std::vector<std::array<unsigned int,3>> &properties,
+                    std::vector<double> &output) const
   {
     // We receive the cartesian points from the user.
     const Point<3> point(point_,cartesian);
@@ -514,13 +535,12 @@ namespace WorldBuilder
     const Objects::NaturalCoordinate natural_coordinate = Objects::NaturalCoordinate(point,*(this->parameters.coordinate_system));
 
     // create output vector
-    std::vector<double> output;
-    output.reserve(World::properties_output_size(properties));
-    std::vector<size_t> entry_in_output;
+    thread_local static std::vector<size_t> entry_in_output;
     entry_in_output.reserve(properties.size());
-    std::vector<std::array<unsigned int,3>> properties_local;
+    thread_local static std::vector<std::array<unsigned int,3>> properties_local;
     properties_local.reserve(properties.size());
     const double gravity_norm = this->parameters.gravity_model->gravity_norm(point);
+    size_t output_location_index = 0;
     for (unsigned int i_property = 0; i_property < properties.size(); ++i_property)
       {
         switch (properties[i_property][0])
@@ -528,61 +548,69 @@ namespace WorldBuilder
             case 1: // Temperature
               if (std::fabs(depth) < 2.0 * std::numeric_limits<double>::epsilon() && force_surface_temperature)
                 {
-                  entry_in_output.emplace_back(output.size());
-                  output.emplace_back(this->surface_temperature);
+                  entry_in_output.emplace_back(output_location_index);
+                  output[output.size()]=this->surface_temperature;
+                  output_location_index++;
                   if (properties.size() == 1)
-                    return output;
+                    return;
                 }
               else
                 {
-                  entry_in_output.emplace_back(output.size());
-                  output.emplace_back(potential_mantle_temperature * std::exp(((thermal_expansion_coefficient * gravity_norm) / specific_heat) * depth));
+                  entry_in_output.emplace_back(output_location_index);
+                  output[output_location_index] = potential_mantle_temperature * std::exp(((thermal_expansion_coefficient * gravity_norm) / specific_heat) * depth);
+                  output_location_index++;
                 }
               properties_local.emplace_back(properties[i_property]);
               break;
             case 2: // composition
-              entry_in_output.emplace_back(output.size());
-              output.emplace_back(0.);
+              entry_in_output.emplace_back(output_location_index);
+              output[output_location_index] = 0.;
+              output_location_index++;
               properties_local.emplace_back(properties[i_property]);
               break;
             case 3: // grains (10 entries per grain)
             {
-              entry_in_output.emplace_back(output.size());
-              const std::vector<double> tmp_vector(properties[i_property][2]*10,0.);
-              output.insert(output.end(), tmp_vector.begin(), tmp_vector.end());
+              entry_in_output.emplace_back(output_location_index);
+              output_location_index+=properties[i_property][2]*10;
+              //const std::vector<double> tmp_vector(properties[i_property][2]*10,0.);
+              //output.insert(output.end(), tmp_vector.begin(), tmp_vector.end());
               properties_local.emplace_back(properties[i_property]);
               break;
             }
             case 4: // tag
             {
-              entry_in_output.emplace_back(output.size());
-              output.emplace_back(-1);
+              entry_in_output.emplace_back(output_location_index);
+              output[output_location_index] = -1;
+              output_location_index++;
               properties_local.emplace_back(properties[i_property]);
               break;
             }
             case 5: // velocity
             {
-              entry_in_output.emplace_back(output.size());
-              output.emplace_back(0);
-              output.emplace_back(0);
-              output.emplace_back(0);
+              entry_in_output.emplace_back(output_location_index);
+              //output.emplace_back(0);
+              //output.emplace_back(0);
+              //output.emplace_back(0);
+              output_location_index+=3;
               properties_local.emplace_back(properties[i_property]);
               break;
             }
             case 6: // topography
             {
-              entry_in_output.emplace_back(output.size());
-              output.emplace_back(0);
+              entry_in_output.emplace_back(output_location_index);
+              //output.emplace_back(0);
+              output_location_index++;
               properties_local.emplace_back(properties[i_property]);
               break;
             }
             case 7: // density
             {
-              entry_in_output.emplace_back(output.size());
+              entry_in_output.emplace_back(output_location_index);
 
               // TODO: If a mantle adiabatic temperature is used then the background
               // density should account for it.
-              output.emplace_back(background_density);
+              output[output_location_index] =background_density;
+              output_location_index++;
               properties_local.emplace_back(properties[i_property]);
               break;
             }
@@ -598,7 +626,6 @@ namespace WorldBuilder
         it->properties(point, natural_coordinate, depth, properties_local, gravity_norm, entry_in_output, output);
       }
 
-    return output;
   }
 
   double


### PR DESCRIPTION
Based on advice from @bangerth, I played around with heaptrack. I started with the largest allocations entry being 1619842 allocations, and I got it down to ~~43936 (in Rapidjson)~~ update: 795947 allocations. 