### PR TITLE
Add a maximum topography for external usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Added Perlin noise models for composition and temperature across features, and gwb-dat coverage tests for Cartesian Perlin noise inputs. \[Tilman May; 2026-03-29; [#906](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/906)\]
 
+- Added a `maximum_topography()` API that returns a guaranteed upper bound for all configured topography models. \[Michael Pons; 2026-07-26\]
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Added Perlin noise models for composition and temperature across features, and gwb-dat coverage tests for Cartesian Perlin noise inputs. \[Tilman May; 2026-03-29; [#906](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/906)\]
 
-- Added a `maximum_topography()` API that returns a guaranteed upper bound for all configured topography models. \[Michael Pons; 2026-07-26\]
+- Added `maximum_topography()` and `minimum_topography()` APIs that return guaranteed bounds for all configured topography models. \[Michael Pons; 2026-07-26; [#945](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/945)\]
 
 ### Changed
 

--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -139,6 +139,11 @@ namespace WorldBuilder
          */
         double maximum_topography() const override final;
 
+        /**
+         * Return a lower bound for all topography models in this feature.
+         */
+        double minimum_topography() const override final;
+
       private:
         /**
          * A vector containing all the pointers to the temperature models. This vector is

--- a/include/world_builder/features/continental_plate.h
+++ b/include/world_builder/features/continental_plate.h
@@ -134,6 +134,11 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        /**
+         * Return an upper bound for all topography models in this feature.
+         */
+        double maximum_topography() const override final;
+
       private:
         /**
          * A vector containing all the pointers to the temperature models. This vector is

--- a/include/world_builder/features/continental_plate_models/topography/depth_surface.h
+++ b/include/world_builder/features/continental_plate_models/topography/depth_surface.h
@@ -75,6 +75,7 @@ namespace WorldBuilder
                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
                                   double topography) const override final;
 
+            double maximum_topography() const override final;
 
           private:
             // depth surface topography submodule parameters

--- a/include/world_builder/features/continental_plate_models/topography/depth_surface.h
+++ b/include/world_builder/features/continental_plate_models/topography/depth_surface.h
@@ -77,6 +77,8 @@ namespace WorldBuilder
 
             double maximum_topography() const override final;
 
+            double minimum_topography() const override final;
+
           private:
             // depth surface topography submodule parameters
             double min_depth;

--- a/include/world_builder/features/continental_plate_models/topography/interface.h
+++ b/include/world_builder/features/continental_plate_models/topography/interface.h
@@ -80,6 +80,13 @@ namespace WorldBuilder
             double get_topography(const Point<3> &position,
                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
                                   double topography) const = 0;
+
+            /**
+             * Return a guaranteed upper bound for this topography model.
+             */
+            virtual
+            double maximum_topography() const = 0;
+
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/continental_plate_models/topography/interface.h
+++ b/include/world_builder/features/continental_plate_models/topography/interface.h
@@ -88,6 +88,12 @@ namespace WorldBuilder
             double maximum_topography() const = 0;
 
             /**
+             * Return a guaranteed lower bound for this topography model.
+             */
+            virtual
+            double minimum_topography() const = 0;
+
+            /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.
              */

--- a/include/world_builder/features/continental_plate_models/topography/uniform.h
+++ b/include/world_builder/features/continental_plate_models/topography/uniform.h
@@ -77,6 +77,8 @@ namespace WorldBuilder
 
             double maximum_topography() const override final;
 
+            double minimum_topography() const override final;
+
           private:
             // uniform topography submodule parameters
             double min_depth;

--- a/include/world_builder/features/continental_plate_models/topography/uniform.h
+++ b/include/world_builder/features/continental_plate_models/topography/uniform.h
@@ -75,6 +75,7 @@ namespace WorldBuilder
                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
                                   double topography) const override final;
 
+            double maximum_topography() const override final;
 
           private:
             // uniform topography submodule parameters

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -146,8 +146,16 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        /**
+         * Return negative infinity because this feature does not modify
+         * topography.
+         */
         double maximum_topography() const override final;
 
+        /**
+         * Return positive infinity because this feature does not modify
+         * topography.
+         */
         double minimum_topography() const override final;
 
         /**

--- a/include/world_builder/features/fault.h
+++ b/include/world_builder/features/fault.h
@@ -146,6 +146,10 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        double maximum_topography() const override final;
+
+        double minimum_topography() const override final;
+
         /**
         * Returns a PlaneDistances object that has the distance from and along a fault plane,
         * calculated from the coordinates and the depth of the point.

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -90,10 +90,17 @@ namespace WorldBuilder
 
         /**
          * Return a guaranteed upper bound for the topography produced by this
-         * feature. Features without topography return zero.
+         * feature.
          */
         virtual
-        double maximum_topography() const;
+        double maximum_topography() const = 0;
+
+        /**
+         * Return a guaranteed lower bound for the topography produced by this
+         * feature.
+         */
+        virtual
+        double minimum_topography() const = 0;
 
         /**
          * A function to register a new type. This is part of the automatic

--- a/include/world_builder/features/interface.h
+++ b/include/world_builder/features/interface.h
@@ -89,6 +89,13 @@ namespace WorldBuilder
                         std::vector<double> &output) const = 0;
 
         /**
+         * Return a guaranteed upper bound for the topography produced by this
+         * feature. Features without topography return zero.
+         */
+        virtual
+        double maximum_topography() const;
+
+        /**
          * A function to register a new type. This is part of the automatic
          * registration of the object factory.
          */

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -130,6 +130,10 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        double maximum_topography() const override final;
+
+        double minimum_topography() const override final;
+
       private:
         /**
          * A vector containing all the pointers to the temperature models. This vector is

--- a/include/world_builder/features/mantle_layer.h
+++ b/include/world_builder/features/mantle_layer.h
@@ -130,8 +130,16 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        /**
+         * Return negative infinity because this feature does not modify
+         * topography.
+         */
         double maximum_topography() const override final;
 
+        /**
+         * Return positive infinity because this feature does not modify
+         * topography.
+         */
         double minimum_topography() const override final;
 
       private:

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -139,6 +139,11 @@ namespace WorldBuilder
          */
         double maximum_topography() const override final;
 
+        /**
+         * Return a lower bound for all topography models in this feature.
+         */
+        double minimum_topography() const override final;
+
       private:
         /**
          * A vector containing all the pointers to the temperature models. This vector is

--- a/include/world_builder/features/oceanic_plate.h
+++ b/include/world_builder/features/oceanic_plate.h
@@ -134,6 +134,11 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        /**
+         * Return an upper bound for all topography models in this feature.
+         */
+        double maximum_topography() const override final;
+
       private:
         /**
          * A vector containing all the pointers to the temperature models. This vector is

--- a/include/world_builder/features/oceanic_plate_models/topography/depth_surface.h
+++ b/include/world_builder/features/oceanic_plate_models/topography/depth_surface.h
@@ -75,6 +75,7 @@ namespace WorldBuilder
                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
                                   double topography) const override final;
 
+            double maximum_topography() const override final;
 
           private:
             // depth surface topography submodule parameters

--- a/include/world_builder/features/oceanic_plate_models/topography/depth_surface.h
+++ b/include/world_builder/features/oceanic_plate_models/topography/depth_surface.h
@@ -77,6 +77,8 @@ namespace WorldBuilder
 
             double maximum_topography() const override final;
 
+            double minimum_topography() const override final;
+
           private:
             // depth surface topography submodule parameters
             double min_depth;

--- a/include/world_builder/features/oceanic_plate_models/topography/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/topography/interface.h
@@ -80,6 +80,13 @@ namespace WorldBuilder
             double get_topography(const Point<3> &position,
                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
                                   double topography) const = 0;
+
+            /**
+             * Return a guaranteed upper bound for this topography model.
+             */
+            virtual
+            double maximum_topography() const = 0;
+
             /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.

--- a/include/world_builder/features/oceanic_plate_models/topography/interface.h
+++ b/include/world_builder/features/oceanic_plate_models/topography/interface.h
@@ -88,6 +88,12 @@ namespace WorldBuilder
             double maximum_topography() const = 0;
 
             /**
+             * Return a guaranteed lower bound for this topography model.
+             */
+            virtual
+            double minimum_topography() const = 0;
+
+            /**
              * A function to register a new type. This is part of the automatic
              * registration of the object factory.
              */

--- a/include/world_builder/features/oceanic_plate_models/topography/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/topography/uniform.h
@@ -77,6 +77,8 @@ namespace WorldBuilder
 
             double maximum_topography() const override final;
 
+            double minimum_topography() const override final;
+
           private:
             // uniform topography submodule parameters
             double min_depth;

--- a/include/world_builder/features/oceanic_plate_models/topography/uniform.h
+++ b/include/world_builder/features/oceanic_plate_models/topography/uniform.h
@@ -75,6 +75,7 @@ namespace WorldBuilder
                                   const Objects::NaturalCoordinate &position_in_natural_coordinates,
                                   double topography) const override final;
 
+            double maximum_topography() const override final;
 
           private:
             // uniform topography submodule parameters

--- a/include/world_builder/features/plume.h
+++ b/include/world_builder/features/plume.h
@@ -130,6 +130,10 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        double maximum_topography() const override final;
+
+        double minimum_topography() const override final;
+
       private:
         /**
          * A vector containing all the pointers to the temperature models. This vector is

--- a/include/world_builder/features/plume.h
+++ b/include/world_builder/features/plume.h
@@ -130,8 +130,16 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        /**
+         * Return negative infinity because this feature does not modify
+         * topography.
+         */
         double maximum_topography() const override final;
 
+        /**
+         * Return positive infinity because this feature does not modify
+         * topography.
+         */
         double minimum_topography() const override final;
 
       private:

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -147,8 +147,16 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        /**
+         * Return negative infinity because this feature does not modify
+         * topography.
+         */
         double maximum_topography() const override final;
 
+        /**
+         * Return positive infinity because this feature does not modify
+         * topography.
+         */
         double minimum_topography() const override final;
 
         /**

--- a/include/world_builder/features/subducting_plate.h
+++ b/include/world_builder/features/subducting_plate.h
@@ -147,6 +147,10 @@ namespace WorldBuilder
                    const std::vector<size_t> &entry_in_output,
                    std::vector<double> &output) const override final;
 
+        double maximum_topography() const override final;
+
+        double minimum_topography() const override final;
+
         /**
         * Returns a PlaneDistances object that has the distance from and along a subducting plate plane,
         * calculated from the coordinates and the depth of the point.

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -88,6 +88,13 @@ namespace WorldBuilder
       unsigned int properties_output_size(const std::vector<std::array<unsigned int,3>> &properties) const;
 
       /**
+       * Return a guaranteed upper bound for topography produced by all
+       * configured features. The result is zero when no positive topography
+       * is configured.
+       */
+      double maximum_topography() const;
+
+      /**
        * Returns different values at a single point in one go stored in a vector of doubles.
        *
        * The properties input decides what each entry means, and the output is generated in the

--- a/include/world_builder/world.h
+++ b/include/world_builder/world.h
@@ -95,6 +95,13 @@ namespace WorldBuilder
       double maximum_topography() const;
 
       /**
+       * Return a guaranteed lower bound for topography produced by all
+       * configured features. The result is zero when no negative topography
+       * is configured.
+       */
+      double minimum_topography() const;
+
+      /**
        * Returns different values at a single point in one go stored in a vector of doubles.
        *
        * The properties input decides what each entry means, and the output is generated in the

--- a/source/world_builder/features/continental_plate.cc
+++ b/source/world_builder/features/continental_plate.cc
@@ -388,6 +388,16 @@ namespace WorldBuilder
         }
     }
 
+    double
+    ContinentalPlate::maximum_topography() const
+    {
+      double maximum = 0.0;
+      for (const auto &topography_model : topography_models)
+        maximum = std::max(maximum, topography_model->maximum_topography());
+
+      return maximum;
+    }
+
     WB_REGISTER_FEATURE(ContinentalPlate, continental plate)
 
   } // namespace Features

--- a/source/world_builder/features/continental_plate.cc
+++ b/source/world_builder/features/continental_plate.cc
@@ -392,7 +392,7 @@ namespace WorldBuilder
     double
     ContinentalPlate::maximum_topography() const
     {
-      double maximum = 0.0;
+      double maximum = -std::numeric_limits<double>::infinity();
       for (const auto &topography_model : topography_models)
         maximum = std::max(maximum, topography_model->maximum_topography());
 
@@ -402,7 +402,7 @@ namespace WorldBuilder
     double
     ContinentalPlate::minimum_topography() const
     {
-      double minimum = 0.0;
+      double minimum = std::numeric_limits<double>::infinity();
       for (const auto &topography_model : topography_models)
         minimum = std::min(minimum, topography_model->minimum_topography());
 

--- a/source/world_builder/features/continental_plate.cc
+++ b/source/world_builder/features/continental_plate.cc
@@ -36,6 +36,7 @@
 #include "world_builder/types/value_at_points.h"
 #include "world_builder/world.h"
 
+#include <algorithm>
 #include <array>
 #include <iostream>
 
@@ -396,6 +397,16 @@ namespace WorldBuilder
         maximum = std::max(maximum, topography_model->maximum_topography());
 
       return maximum;
+    }
+
+    double
+    ContinentalPlate::minimum_topography() const
+    {
+      double minimum = 0.0;
+      for (const auto &topography_model : topography_models)
+        minimum = std::min(minimum, topography_model->minimum_topography());
+
+      return minimum;
     }
 
     WB_REGISTER_FEATURE(ContinentalPlate, continental plate)

--- a/source/world_builder/features/continental_plate_models/topography/depth_surface.cc
+++ b/source/world_builder/features/continental_plate_models/topography/depth_surface.cc
@@ -100,9 +100,14 @@ namespace WorldBuilder
           return -topography_surface.local_value(position_in_natural_coordinates.get_surface_point()).interpolated_value;
         }
 
+        double
+        DepthSurface::maximum_topography() const
+        {
+          return -topography_surface.minimum;
+        }
+
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TOPOGRAPHY_MODEL(DepthSurface, depth surface)
       } // namespace Topography
     } // namespace ContinentalPlateModels
   } // namespace Features
 } // namespace WorldBuilder
-

--- a/source/world_builder/features/continental_plate_models/topography/depth_surface.cc
+++ b/source/world_builder/features/continental_plate_models/topography/depth_surface.cc
@@ -106,6 +106,12 @@ namespace WorldBuilder
           return -topography_surface.minimum;
         }
 
+        double
+        DepthSurface::minimum_topography() const
+        {
+          return -topography_surface.maximum;
+        }
+
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TOPOGRAPHY_MODEL(DepthSurface, depth surface)
       } // namespace Topography
     } // namespace ContinentalPlateModels

--- a/source/world_builder/features/continental_plate_models/topography/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/topography/uniform.cc
@@ -99,9 +99,14 @@ namespace WorldBuilder
           return topography;
         }
 
+        double
+        Uniform::maximum_topography() const
+        {
+          return topography;
+        }
+
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TOPOGRAPHY_MODEL(Uniform, uniform)
       } // namespace Topography
     } // namespace ContinentalPlateModels
   } // namespace Features
 } // namespace WorldBuilder
-

--- a/source/world_builder/features/continental_plate_models/topography/uniform.cc
+++ b/source/world_builder/features/continental_plate_models/topography/uniform.cc
@@ -105,6 +105,12 @@ namespace WorldBuilder
           return topography;
         }
 
+        double
+        Uniform::minimum_topography() const
+        {
+          return topography;
+        }
+
         WB_REGISTER_FEATURE_CONTINENTAL_PLATE_TOPOGRAPHY_MODEL(Uniform, uniform)
       } // namespace Topography
     } // namespace ContinentalPlateModels

--- a/source/world_builder/features/fault.cc
+++ b/source/world_builder/features/fault.cc
@@ -910,13 +910,13 @@ namespace WorldBuilder
     double
     Fault::maximum_topography() const
     {
-      return 0.0;
+      return -std::numeric_limits<double>::infinity();
     }
 
     double
     Fault::minimum_topography() const
     {
-      return 0.0;
+      return std::numeric_limits<double>::infinity();
     }
 
     WB_REGISTER_FEATURE(Fault, fault)

--- a/source/world_builder/features/fault.cc
+++ b/source/world_builder/features/fault.cc
@@ -907,6 +907,18 @@ namespace WorldBuilder
     /**
      * Register plugin
      */
+    double
+    Fault::maximum_topography() const
+    {
+      return 0.0;
+    }
+
+    double
+    Fault::minimum_topography() const
+    {
+      return 0.0;
+    }
+
     WB_REGISTER_FEATURE(Fault, fault)
   } // namespace Features
 } // namespace WorldBuilder

--- a/source/world_builder/features/interface.cc
+++ b/source/world_builder/features/interface.cc
@@ -63,12 +63,6 @@ namespace WorldBuilder
     Interface::~Interface ()
       = default;
 
-    double
-    Interface::maximum_topography() const
-    {
-      return 0.0;
-    }
-
     void
     Interface::declare_entries(Parameters &prm, const std::string &parent_name, const std::vector<std::string> &required_entries)
     {

--- a/source/world_builder/features/interface.cc
+++ b/source/world_builder/features/interface.cc
@@ -63,6 +63,12 @@ namespace WorldBuilder
     Interface::~Interface ()
       = default;
 
+    double
+    Interface::maximum_topography() const
+    {
+      return 0.0;
+    }
+
     void
     Interface::declare_entries(Parameters &prm, const std::string &parent_name, const std::vector<std::string> &required_entries)
     {
@@ -206,4 +212,3 @@ namespace WorldBuilder
 
   } // namespace Features
 } // namespace WorldBuilder
-

--- a/source/world_builder/features/mantle_layer.cc
+++ b/source/world_builder/features/mantle_layer.cc
@@ -343,6 +343,18 @@ namespace WorldBuilder
         }
     }
 
+    double
+    MantleLayer::maximum_topography() const
+    {
+      return 0.0;
+    }
+
+    double
+    MantleLayer::minimum_topography() const
+    {
+      return 0.0;
+    }
+
     WB_REGISTER_FEATURE(MantleLayer, mantle layer)
 
   } // namespace Features

--- a/source/world_builder/features/mantle_layer.cc
+++ b/source/world_builder/features/mantle_layer.cc
@@ -346,13 +346,13 @@ namespace WorldBuilder
     double
     MantleLayer::maximum_topography() const
     {
-      return 0.0;
+      return -std::numeric_limits<double>::infinity();
     }
 
     double
     MantleLayer::minimum_topography() const
     {
-      return 0.0;
+      return std::numeric_limits<double>::infinity();
     }
 
     WB_REGISTER_FEATURE(MantleLayer, mantle layer)

--- a/source/world_builder/features/oceanic_plate.cc
+++ b/source/world_builder/features/oceanic_plate.cc
@@ -398,10 +398,19 @@ namespace WorldBuilder
         }
     }
 
+    double
+    OceanicPlate::maximum_topography() const
+    {
+      double maximum = 0.0;
+      for (const auto &topography_model : topography_models)
+        maximum = std::max(maximum, topography_model->maximum_topography());
+
+      return maximum;
+    }
+
     /**
      * Register plugin
      */
     WB_REGISTER_FEATURE(OceanicPlate, oceanic plate)
   } // namespace Features
 } // namespace WorldBuilder
-

--- a/source/world_builder/features/oceanic_plate.cc
+++ b/source/world_builder/features/oceanic_plate.cc
@@ -35,6 +35,7 @@
 #include "world_builder/types/value_at_points.h"
 #include "world_builder/world.h"
 
+#include <algorithm>
 
 namespace WorldBuilder
 {
@@ -406,6 +407,16 @@ namespace WorldBuilder
         maximum = std::max(maximum, topography_model->maximum_topography());
 
       return maximum;
+    }
+
+    double
+    OceanicPlate::minimum_topography() const
+    {
+      double minimum = 0.0;
+      for (const auto &topography_model : topography_models)
+        minimum = std::min(minimum, topography_model->minimum_topography());
+
+      return minimum;
     }
 
     /**

--- a/source/world_builder/features/oceanic_plate.cc
+++ b/source/world_builder/features/oceanic_plate.cc
@@ -402,7 +402,7 @@ namespace WorldBuilder
     double
     OceanicPlate::maximum_topography() const
     {
-      double maximum = 0.0;
+      double maximum = -std::numeric_limits<double>::infinity();
       for (const auto &topography_model : topography_models)
         maximum = std::max(maximum, topography_model->maximum_topography());
 
@@ -412,7 +412,7 @@ namespace WorldBuilder
     double
     OceanicPlate::minimum_topography() const
     {
-      double minimum = 0.0;
+      double minimum = std::numeric_limits<double>::infinity();
       for (const auto &topography_model : topography_models)
         minimum = std::min(minimum, topography_model->minimum_topography());
 

--- a/source/world_builder/features/oceanic_plate_models/topography/depth_surface.cc
+++ b/source/world_builder/features/oceanic_plate_models/topography/depth_surface.cc
@@ -100,9 +100,14 @@ namespace WorldBuilder
           return -topography_surface.local_value(position_in_natural_coordinates.get_surface_point()).interpolated_value;
         }
 
+        double
+        DepthSurface::maximum_topography() const
+        {
+          return -topography_surface.minimum;
+        }
+
         WB_REGISTER_FEATURE_OCEANIC_PLATE_TOPOGRAPHY_MODEL(DepthSurface, depth surface)
       } // namespace Topography
     } // namespace OceanicPlateModels
   } // namespace Features
 } // namespace WorldBuilder
-

--- a/source/world_builder/features/oceanic_plate_models/topography/depth_surface.cc
+++ b/source/world_builder/features/oceanic_plate_models/topography/depth_surface.cc
@@ -106,6 +106,12 @@ namespace WorldBuilder
           return -topography_surface.minimum;
         }
 
+        double
+        DepthSurface::minimum_topography() const
+        {
+          return -topography_surface.maximum;
+        }
+
         WB_REGISTER_FEATURE_OCEANIC_PLATE_TOPOGRAPHY_MODEL(DepthSurface, depth surface)
       } // namespace Topography
     } // namespace OceanicPlateModels

--- a/source/world_builder/features/oceanic_plate_models/topography/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/topography/uniform.cc
@@ -99,9 +99,14 @@ namespace WorldBuilder
           return topography;
         }
 
+        double
+        Uniform::maximum_topography() const
+        {
+          return topography;
+        }
+
         WB_REGISTER_FEATURE_OCEANIC_PLATE_TOPOGRAPHY_MODEL(Uniform, uniform)
       } // namespace Topography
     } // namespace OceanicPlateModels
   } // namespace Features
 } // namespace WorldBuilder
-

--- a/source/world_builder/features/oceanic_plate_models/topography/uniform.cc
+++ b/source/world_builder/features/oceanic_plate_models/topography/uniform.cc
@@ -105,6 +105,12 @@ namespace WorldBuilder
           return topography;
         }
 
+        double
+        Uniform::minimum_topography() const
+        {
+          return topography;
+        }
+
         WB_REGISTER_FEATURE_OCEANIC_PLATE_TOPOGRAPHY_MODEL(Uniform, uniform)
       } // namespace Topography
     } // namespace OceanicPlateModels

--- a/source/world_builder/features/plume.cc
+++ b/source/world_builder/features/plume.cc
@@ -485,13 +485,13 @@ namespace WorldBuilder
     double
     Plume::maximum_topography() const
     {
-      return 0.0;
+      return -std::numeric_limits<double>::infinity();
     }
 
     double
     Plume::minimum_topography() const
     {
-      return 0.0;
+      return std::numeric_limits<double>::infinity();
     }
 
     WB_REGISTER_FEATURE(Plume, plume)

--- a/source/world_builder/features/plume.cc
+++ b/source/world_builder/features/plume.cc
@@ -482,6 +482,18 @@ namespace WorldBuilder
         }
     }
 
+    double
+    Plume::maximum_topography() const
+    {
+      return 0.0;
+    }
+
+    double
+    Plume::minimum_topography() const
+    {
+      return 0.0;
+    }
+
     WB_REGISTER_FEATURE(Plume, plume)
 
   } // namespace Features

--- a/source/world_builder/features/subducting_plate.cc
+++ b/source/world_builder/features/subducting_plate.cc
@@ -943,13 +943,13 @@ namespace WorldBuilder
     double
     SubductingPlate::maximum_topography() const
     {
-      return 0.0;
+      return -std::numeric_limits<double>::infinity();
     }
 
     double
     SubductingPlate::minimum_topography() const
     {
-      return 0.0;
+      return std::numeric_limits<double>::infinity();
     }
 
     WB_REGISTER_FEATURE(SubductingPlate, subducting plate)

--- a/source/world_builder/features/subducting_plate.cc
+++ b/source/world_builder/features/subducting_plate.cc
@@ -940,7 +940,18 @@ namespace WorldBuilder
     /**
      * Register plugin
      */
+    double
+    SubductingPlate::maximum_topography() const
+    {
+      return 0.0;
+    }
+
+    double
+    SubductingPlate::minimum_topography() const
+    {
+      return 0.0;
+    }
+
     WB_REGISTER_FEATURE(SubductingPlate, subducting plate)
   } // namespace Features
 } // namespace WorldBuilder
-

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -38,6 +38,8 @@
 #include <world_builder/coordinate_system.h>
 #include <world_builder/objects/distance_from_surface.h>
 
+#include <algorithm>
+
 #ifdef WB_WITH_MPI
 // we don't need the c++ MPI wrappers
 #define OMPI_SKIP_MPICXX 1
@@ -63,6 +65,16 @@ namespace WorldBuilder
       maximum = std::max(maximum, feature->maximum_topography());
 
     return maximum;
+  }
+
+  double
+  World::minimum_topography() const
+  {
+    double minimum = 0.0;
+    for (const auto &feature : parameters.features)
+      minimum = std::min(minimum, feature->minimum_topography());
+
+    return minimum;
   }
 
   World::World(std::string filename, bool has_output_dir, const std::string &output_dir, unsigned long random_number_seed, const bool limit_debug_consistency_checks_)

--- a/source/world_builder/world.cc
+++ b/source/world_builder/world.cc
@@ -55,6 +55,16 @@ namespace WorldBuilder
 {
   using namespace Utilities;
 
+  double
+  World::maximum_topography() const
+  {
+    double maximum = 0.0;
+    for (const auto &feature : parameters.features)
+      maximum = std::max(maximum, feature->maximum_topography());
+
+    return maximum;
+  }
+
   World::World(std::string filename, bool has_output_dir, const std::string &output_dir, unsigned long random_number_seed, const bool limit_debug_consistency_checks_)
     :
     parameters(*this),
@@ -701,4 +711,3 @@ namespace WorldBuilder
   }
 
 } // namespace WorldBuilder
-

--- a/tests/data/topography_extrema.wb
+++ b/tests/data/topography_extrema.wb
@@ -1,0 +1,20 @@
+{
+  "version": "1.2",
+  "coordinate system": {"model": "cartesian"},
+  "cross section": [[0,0], [100000,0]],
+  "features":
+  [
+    {
+      "model": "continental plate",
+      "name": "positive depth-surface topography",
+      "coordinates": [[-1000,-1000], [50000,-1000], [50000,1000], [-1000,1000]],
+      "topography models": [{"model": "depth surface", "topography": -9000}]
+    },
+    {
+      "model": "oceanic plate",
+      "name": "negative depth-surface topography",
+      "coordinates": [[50000,-1000], [101000,-1000], [101000,1000], [50000,1000]],
+      "topography models": [{"model": "depth surface", "topography": 3000}]
+    }
+  ]
+}

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -1074,23 +1074,25 @@ TEST_CASE("WorldBuilder topography extrema")
   CHECK(world_without_topography.minimum_topography() == Approx(0.0));
 }
 
-TEST_CASE("Features without topography report zero extrema")
+TEST_CASE("Features without topography report reduction identities")
 {
+  const double infinity = std::numeric_limits<double>::infinity();
+
   const WorldBuilder::Features::Fault fault(nullptr);
-  CHECK(fault.maximum_topography() == Approx(0.0));
-  CHECK(fault.minimum_topography() == Approx(0.0));
+  CHECK(fault.maximum_topography() == -infinity);
+  CHECK(fault.minimum_topography() == infinity);
 
   const WorldBuilder::Features::MantleLayer mantle_layer(nullptr);
-  CHECK(mantle_layer.maximum_topography() == Approx(0.0));
-  CHECK(mantle_layer.minimum_topography() == Approx(0.0));
+  CHECK(mantle_layer.maximum_topography() == -infinity);
+  CHECK(mantle_layer.minimum_topography() == infinity);
 
   const WorldBuilder::Features::Plume plume(nullptr);
-  CHECK(plume.maximum_topography() == Approx(0.0));
-  CHECK(plume.minimum_topography() == Approx(0.0));
+  CHECK(plume.maximum_topography() == -infinity);
+  CHECK(plume.minimum_topography() == infinity);
 
   const WorldBuilder::Features::SubductingPlate subducting_plate(nullptr);
-  CHECK(subducting_plate.maximum_topography() == Approx(0.0));
-  CHECK(subducting_plate.minimum_topography() == Approx(0.0));
+  CHECK(subducting_plate.maximum_topography() == -infinity);
+  CHECK(subducting_plate.minimum_topography() == infinity);
 }
 
 TEST_CASE("Worldbuilder grains")

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -1046,6 +1046,21 @@ TEST_CASE("WorldBuilder interface")
   ApprovalTests::Approvals::verifyAll("TITLE", approvals);
 }
 
+TEST_CASE("WorldBuilder maximum topography")
+{
+  const std::string topography_file =
+    WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR +
+    "/tests/gwb-grid/cartesian_2d_topography.wb";
+  const WorldBuilder::World world_with_topography(topography_file);
+  CHECK(world_with_topography.maximum_topography() == Approx(7000.0));
+
+  const std::string no_topography_file =
+    WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR +
+    "/tests/data/continental_plate.wb";
+  const WorldBuilder::World world_without_topography(no_topography_file);
+  CHECK(world_without_topography.maximum_topography() == Approx(0.0));
+}
+
 TEST_CASE("Worldbuilder grains")
 {
   // creat a grains object

--- a/tests/unit_tests/unit_test_world_builder.cc
+++ b/tests/unit_tests/unit_test_world_builder.cc
@@ -30,7 +30,11 @@
 #include "world_builder/coordinate_systems/interface.h"
 #include "world_builder/coordinate_systems/invalid.h"
 #include "world_builder/features/continental_plate.h"
+#include "world_builder/features/fault.h"
 #include "world_builder/features/interface.h"
+#include "world_builder/features/mantle_layer.h"
+#include "world_builder/features/plume.h"
+#include "world_builder/features/subducting_plate.h"
 #include "world_builder/grains.h"
 #include "world_builder/objects/natural_coordinate.h"
 #include "world_builder/objects/segment.h"
@@ -1046,19 +1050,47 @@ TEST_CASE("WorldBuilder interface")
   ApprovalTests::Approvals::verifyAll("TITLE", approvals);
 }
 
-TEST_CASE("WorldBuilder maximum topography")
+TEST_CASE("WorldBuilder topography extrema")
 {
   const std::string topography_file =
     WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR +
     "/tests/gwb-grid/cartesian_2d_topography.wb";
   const WorldBuilder::World world_with_topography(topography_file);
   CHECK(world_with_topography.maximum_topography() == Approx(7000.0));
+  CHECK(world_with_topography.minimum_topography() == Approx(-1000.0));
+
+  const std::string depth_surface_file =
+    WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR +
+    "/tests/data/topography_extrema.wb";
+  const WorldBuilder::World world_with_depth_surface_topography(depth_surface_file);
+  CHECK(world_with_depth_surface_topography.maximum_topography() == Approx(9000.0));
+  CHECK(world_with_depth_surface_topography.minimum_topography() == Approx(-3000.0));
 
   const std::string no_topography_file =
     WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR +
     "/tests/data/continental_plate.wb";
   const WorldBuilder::World world_without_topography(no_topography_file);
   CHECK(world_without_topography.maximum_topography() == Approx(0.0));
+  CHECK(world_without_topography.minimum_topography() == Approx(0.0));
+}
+
+TEST_CASE("Features without topography report zero extrema")
+{
+  const WorldBuilder::Features::Fault fault(nullptr);
+  CHECK(fault.maximum_topography() == Approx(0.0));
+  CHECK(fault.minimum_topography() == Approx(0.0));
+
+  const WorldBuilder::Features::MantleLayer mantle_layer(nullptr);
+  CHECK(mantle_layer.maximum_topography() == Approx(0.0));
+  CHECK(mantle_layer.minimum_topography() == Approx(0.0));
+
+  const WorldBuilder::Features::Plume plume(nullptr);
+  CHECK(plume.maximum_topography() == Approx(0.0));
+  CHECK(plume.minimum_topography() == Approx(0.0));
+
+  const WorldBuilder::Features::SubductingPlate subducting_plate(nullptr);
+  CHECK(subducting_plate.maximum_topography() == Approx(0.0));
+  CHECK(subducting_plate.minimum_topography() == Approx(0.0));
 }
 
 TEST_CASE("Worldbuilder grains")


### PR DESCRIPTION
Hi everyone,

this PR adds `World::maximum_topography()`. It returns an upper bound for the
topography configured in World Builder. This allows applications such as
ASPECT to determine the required geometry size before creating the mesh.

I added tests for a model with uniform topography and for a model without
topography. The complete unit test suite passes.

Cheers,  
Michael
